### PR TITLE
fix(doc-gate): 排除名单统一至 _doc_gate_common + .claude/logs 降噪 (#23)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
     {
       "name": "doc-gate",
       "description": "Document editing governance — doc-maintenance skill + hard gate + recall advisory",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "author": {
         "name": "WooDragon"
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ plugins/
       skill-marker.sh            # 标记脚本（Skill 调用时写 marker）
       recall-gate.sh             # 软门禁（BM25 召回 + 孤儿检测 + 出链验证，deny-once-per-file）
     tools/
+      _doc_gate_common.py        # 共享模块：排除名单 + 链接图谱原语单一来源（recall-gate/docs-graph 共用）
       recall-gate.py             # BM25 + 链接图谱合并引擎（单趟扫描，零依赖）
       docs-graph.py              # 链接图谱独立 CLI（7 子命令：check/backlinks/links/orphans/hubs/related/export）
     skills/

--- a/plugins/doc-gate/.claude-plugin/plugin.json
+++ b/plugins/doc-gate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "doc-gate",
   "description": "Document editing governance — doc-maintenance skill + hard gate + recall advisory",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "author": { "name": "woodragon" },
   "skills": ["./skills/doc-maintenance"]
 }

--- a/plugins/doc-gate/scripts/recall-gate.sh
+++ b/plugins/doc-gate/scripts/recall-gate.sh
@@ -58,7 +58,7 @@ _main() {
 
   # Phase 6: Path exclusions
   case "/$FILE_PATH" in
-    */.claude/*|*/.claude-plugin/*|*/.agents/directives/*|*/node_modules/*|*/.git/*) return ;;
+    */.claude/*|*/.claude-plugin/*|*/.agents/directives/*|*/node_modules/*|*/.git/*|*/logs/*) return ;;
   esac
   case "$FILE_PATH" in
     /tmp/*|/var/tmp/*|/var/folders/*|/private/tmp/*) return ;;

--- a/plugins/doc-gate/tools/_doc_gate_common.py
+++ b/plugins/doc-gate/tools/_doc_gate_common.py
@@ -1,0 +1,100 @@
+"""_doc_gate_common.py — doc-gate 排除名单 + 链接图谱原语的单一来源。
+
+recall-gate.py 与 docs-graph.py 共享此模块，杜绝排除逻辑三处漂移。
+任何新增排除目录 / 链接处理改动只改这里，import 重力井保证消费者引用同一对象。
+
+零依赖：仅标准库 re / os / urllib.parse / pathlib。
+两个消费者以绝对路径被调用，Python 将脚本所在目录置于 sys.path[0]，
+故同目录 import 不依赖 cwd，hook 热路径可靠。
+"""
+
+import re
+import os
+import urllib.parse
+from pathlib import Path
+
+
+# 扫描时排除的目录（路径部件匹配，非子串）。
+# .claude / logs 为 #23 降噪新增：工具产物、会话日志不应进文档引用图。
+EXCLUDED_DIRS = {'.git', '.agents', 'node_modules', '.venv', 'research',
+                 'docs-graph-tests', '.claude', 'logs'}
+
+# orphans 白名单（文件名匹配）：索引 / 入口文件天然无入链，不报孤儿。
+ORPHAN_WHITELIST = {'CLAUDE.md', 'README.md', 'MEMORY.md'}
+
+# 标准内联链接 [text](path)，排除图片 ![]()。
+LINK_PATTERN = re.compile(r'(?<!\!)\[([^\]]*)\]\(([^)]+)\)')
+
+# code fence 起止标记。
+CODE_FENCE = re.compile(r'^```')
+
+
+def detect_root(start_path: str, override_root: str = None) -> str:
+    """从 start_path 向上找最外层 CLAUDE.md 作锚点；回退首个 .git；再回退 cwd。"""
+    if override_root:
+        p = Path(override_root)
+        if p.is_dir():
+            return str(p.resolve())
+
+    home = Path.home()
+    current = Path(start_path).resolve()
+    if current.is_file():
+        current = current.parent
+
+    outermost_claude = None
+    first_git = None
+    depth = 0
+    while current != home and current != current.parent and depth < 64:
+        if (current / 'CLAUDE.md').exists():
+            outermost_claude = current
+        if (current / '.git').exists() and first_git is None:
+            first_git = current
+        current = current.parent
+        depth += 1
+
+    if outermost_claude:
+        return str(outermost_claude)
+    if first_git:
+        return str(first_git)
+    return os.getcwd()
+
+
+def should_skip_link(target: str) -> bool:
+    """外部链接 / 纯锚点 / 绝对路径 → 跳过（不纳入图）。"""
+    return target.startswith(('http://', 'https://', 'mailto:', '#', 'file://', '/'))
+
+
+def resolve_link(source_file: Path, target: str, root: Path):
+    """解析相对链接为 root 内绝对路径；越界 / 空 / 解析失败 → None。"""
+    target = target.split('#')[0]
+    if not target:
+        return None
+    target = urllib.parse.unquote(target)
+    try:
+        resolved = (source_file.parent / target).resolve()
+    except (ValueError, OSError):
+        return None
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError:
+        return None
+    return resolved
+
+
+def extract_links_from_content(content: str) -> list:
+    """从内容字符串提取链接（跳过 code fence 内）。返回 [(lineno, text, target), ...]。
+
+    纯字符串处理，不读文件——读取由调用方各自负责（recall errors='ignore'、
+    docs-graph errors='replace'，坏字节行为差异刻意留在各自调用点）。
+    """
+    results = []
+    in_code_block = False
+    for lineno, line in enumerate(content.splitlines(), start=1):
+        if CODE_FENCE.match(line.strip()):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+        for text, target in LINK_PATTERN.findall(line):
+            results.append((lineno, text, target))
+    return results

--- a/plugins/doc-gate/tools/docs-graph.py
+++ b/plugins/doc-gate/tools/docs-graph.py
@@ -15,59 +15,16 @@ docs-graph.py — 文档链接图谱查询工具
 版本：1.0.0
 """
 
-import re
 import sys
-import os
 import json
 import argparse
-import urllib.parse
 from pathlib import Path
 from collections import defaultdict, deque
 
-
-# 默认排除的目录（路径部件匹配）
-EXCLUDED_DIRS = {'.git', '.agents', 'node_modules', '.venv', 'research', 'docs-graph-tests'}
-
-# orphans 白名单（文件名匹配）
-ORPHAN_WHITELIST = {'CLAUDE.md', 'README.md', 'MEMORY.md'}
-
-# orphans 白名单目录（路径部件包含时排除）
-ORPHAN_WHITELIST_DIRS = {'archive'}
-
-# 链接提取正则（排除图片 ![]()）
-LINK_PATTERN = re.compile(r'(?<!\!)\[([^\]]*)\]\(([^)]+)\)')
-
-# code block 开始/结束标记
-CODE_FENCE = re.compile(r'^```')
-
-
-def detect_root(start_path: str, override_root: str = None) -> str:
-    if override_root:
-        p = Path(override_root)
-        if p.is_dir():
-            return str(p.resolve())
-
-    home = Path.home()
-    current = Path(start_path).resolve()
-    if current.is_file():
-        current = current.parent
-
-    outermost_claude = None
-    first_git = None
-    depth = 0
-    while current != home and current != current.parent and depth < 64:
-        if (current / 'CLAUDE.md').exists():
-            outermost_claude = current
-        if (current / '.git').exists() and first_git is None:
-            first_git = current
-        current = current.parent
-        depth += 1
-
-    if outermost_claude:
-        return str(outermost_claude)
-    if first_git:
-        return str(first_git)
-    return os.getcwd()
+from _doc_gate_common import (
+    EXCLUDED_DIRS, ORPHAN_WHITELIST,
+    detect_root, should_skip_link, resolve_link, extract_links_from_content,
+)
 
 
 def is_excluded(path: Path, root: Path) -> bool:
@@ -80,70 +37,17 @@ def is_excluded(path: Path, root: Path) -> bool:
 
 
 def extract_links(filepath: Path):
+    """从文件读取内容并提取链接（薄包装：读文件 + 委托 extract_links_from_content）。
+
+    errors='replace' 与 recall-gate 的 'ignore' 不同——坏字节行为差异刻意留在
+    各自调用点，不下沉到 common。
+    返回 [(line_no, link_text, link_target), ...]，line_no 从 1 开始。
     """
-    从文件中提取所有链接，跳过 code block 内的链接。
-    返回列表：[(line_no, link_text, link_target), ...]
-    line_no 从 1 开始。
-    """
-    results = []
-    in_code_block = False
     try:
         content = filepath.read_text(encoding='utf-8', errors='replace')
     except OSError:
-        return results
-
-    for lineno, line in enumerate(content.splitlines(), start=1):
-        # 检测 code fence 切换
-        if CODE_FENCE.match(line.strip()):
-            in_code_block = not in_code_block
-            continue
-
-        if in_code_block:
-            continue
-
-        for text, target in LINK_PATTERN.findall(line):
-            results.append((lineno, text, target))
-
-    return results
-
-
-def should_skip_link(target: str) -> bool:
-    """判断链接是否应跳过（外部链接、纯锚点、绝对路径）"""
-    if target.startswith(('http://', 'https://', 'mailto:', '#', 'file://', '/')):
-        return True
-    return False
-
-
-def resolve_link(source_file: Path, target: str, root: Path):
-    """
-    解析链接目标为绝对路径。
-    1. 剥离锚点
-    2. URL 解码
-    3. 相对路径解析
-    4. 验证在 root 内
-    返回 Path 或 None（越界/空）
-    """
-    # 剥离锚点
-    target = target.split('#')[0]
-    if not target:
-        return None
-
-    # URL 解码
-    target = urllib.parse.unquote(target)
-
-    # 解析路径
-    try:
-        resolved = (source_file.parent / target).resolve()
-    except (ValueError, OSError):
-        return None
-
-    # 验证在 root 内（防止软链越界）
-    try:
-        resolved.relative_to(root.resolve())
-    except ValueError:
-        return None
-
-    return resolved
+        return []
+    return extract_links_from_content(content)
 
 
 def scan_all_files(root: Path):
@@ -265,10 +169,7 @@ def cmd_orphans(args, root: Path):
         # 白名单文件名
         if f.name in ORPHAN_WHITELIST:
             continue
-        # 白名单目录
         rel = f.relative_to(root)
-        if any(part in ORPHAN_WHITELIST_DIRS for part in rel.parts):
-            continue
         # 零入链
         if not backward.get(f):
             orphans.append(str(rel))

--- a/plugins/doc-gate/tools/recall-gate.py
+++ b/plugins/doc-gate/tools/recall-gate.py
@@ -6,18 +6,16 @@ import sys
 import math
 import json
 import argparse
-import urllib.parse
 from pathlib import Path
 from collections import Counter
 
-
-EXCLUDED_DIRS = {'.git', '.agents', 'node_modules', '.venv', 'research', 'docs-graph-tests'}
-ORPHAN_WHITELIST = {'CLAUDE.md', 'README.md', 'MEMORY.md'}
+from _doc_gate_common import (
+    EXCLUDED_DIRS, ORPHAN_WHITELIST, CODE_FENCE,
+    detect_root, should_skip_link, resolve_link, extract_links_from_content,
+)
 
 _EN_TOKEN_RE = re.compile(r'[a-zA-Z][a-zA-Z0-9_.-]{1,}')
 _ZH_RUN_RE = re.compile(r'[一-鿿]+')
-_CODE_FENCE_RE = re.compile(r'^```')
-_LINK_PATTERN = re.compile(r'(?<!\!)\[([^\]]*)\]\(([^)]+)\)')
 
 
 # ---------------------------------------------------------------------------
@@ -46,7 +44,7 @@ def _strip_fences(content: str) -> str:
     lines = []
     in_fence = False
     for line in content.splitlines():
-        if _CODE_FENCE_RE.match(line):
+        if CODE_FENCE.match(line):
             in_fence = not in_fence
             continue
         if not in_fence:
@@ -60,45 +58,6 @@ def _extract_title(content: str) -> str:
         if stripped.startswith('# '):
             return stripped[2:].strip()
     return ''
-
-
-# ---------------------------------------------------------------------------
-# Link graph functions (ported from docs-graph.py)
-# ---------------------------------------------------------------------------
-
-def extract_links_from_content(content: str) -> list:
-    """Extract links from content string. Returns [(lineno, text, target), ...]"""
-    results = []
-    in_code_block = False
-    for lineno, line in enumerate(content.splitlines(), start=1):
-        if _CODE_FENCE_RE.match(line.strip()):
-            in_code_block = not in_code_block
-            continue
-        if in_code_block:
-            continue
-        for text, target in _LINK_PATTERN.findall(line):
-            results.append((lineno, text, target))
-    return results
-
-
-def should_skip_link(target: str) -> bool:
-    return target.startswith(('http://', 'https://', 'mailto:', '#', 'file://', '/'))
-
-
-def resolve_link(source_file: Path, target: str, root: Path):
-    target = target.split('#')[0]
-    if not target:
-        return None
-    target = urllib.parse.unquote(target)
-    try:
-        resolved = (source_file.parent / target).resolve()
-    except (ValueError, OSError):
-        return None
-    try:
-        resolved.relative_to(root.resolve())
-    except ValueError:
-        return None
-    return resolved
 
 
 # ---------------------------------------------------------------------------
@@ -208,39 +167,6 @@ def build_indexes(corpus: list) -> tuple:
     total_title_len = sum(len(doc['title_tokens']) for doc in corpus)
     avg_title_dl = total_title_len / len(corpus) if corpus else 1.0
     return content_idf, title_idf, avg_dl, avg_title_dl
-
-
-# ---------------------------------------------------------------------------
-# Root detection
-# ---------------------------------------------------------------------------
-
-def detect_root(start_path: str, override_root: str = None) -> str:
-    if override_root:
-        p = Path(override_root)
-        if p.is_dir():
-            return str(p.resolve())
-
-    home = Path.home()
-    current = Path(start_path).resolve()
-    if current.is_file():
-        current = current.parent
-
-    outermost_claude = None
-    first_git = None
-    depth = 0
-    while current != home and current != current.parent and depth < 64:
-        if (current / 'CLAUDE.md').exists():
-            outermost_claude = current
-        if (current / '.git').exists() and first_git is None:
-            first_git = current
-        current = current.parent
-        depth += 1
-
-    if outermost_claude:
-        return str(outermost_claude)
-    if first_git:
-        return str(first_git)
-    return os.getcwd()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

Issue #23：doc-gate 扫 monorepo orphans 时混入 `.claude/`、`logs/` 工具产物噪音。根因更深——「哪些路径不纳入」分散三处硬编码（recall-gate.sh / recall-gate.py / docs-graph.py），已漂移。

## 改动

- **抽取共享模块 `_doc_gate_common.py`**：排除名单 + 链接图谱原语单一来源，`recall-gate.py`/`docs-graph.py` 改 `import`，import 重力井根除三处漂移
- **#23 降噪**：`EXCLUDED_DIRS` 新增 `.claude`、`logs`；`recall-gate.sh` Phase 6 补 `*/logs/*`（写时门禁与语料库扫描是两套独立机制，须同时覆盖，否则编辑 `logs/sync/x.md` 自身会被反报孤儿）
- **删 archive 死规则 `ORPHAN_WHITELIST_DIRS`**（v1.1.0 从 Infra 迁入、本项目零目录零覆盖）
- `docs-graph` `extract_links` 降薄包装，`errors='replace'` 逐字保留
- 顺删抽取后 unused import（recall: `urllib.parse`；docs-graph: `re`/`os`/`urllib.parse`）
- 版本 `1.2.2 → 1.3.0`（plugin.json + marketplace.json 双写）

净 −172 行，去重收敛。

## 测试（全绿，commit 前硬门禁）

| 套件 | 结果 |
|------|------|
| test_doc_gate_common.py | 17/17（含 `is` 去重硬证据 + import 冒烟） |
| test_recall_gate.py | 67/67（抽取后零回归） |
| recall-gate.bats | 40/40（含 #23 红→绿：logs silent allow + 精度对照） |
| test-docs-graph.sh | 28/28（L8 断裂修复后复活 + 4 个 #23 scenario） |

人工验收：orphans 输出无 `.claude/`/`logs/` 噪音，真孤儿（`data/sync/real-orphan.md`、`my-logs-notes.md` 子串非目录）保留——部件匹配精确。

## 附带

顺修 #22 遗留的 2 个 detect_root 测试债（测试名/期望停在旧 innermost 语义，未随 #22 的 innermost→outermost 反转同步；git stash 铁证为 pre-existing）。

Closes #23