### PR TITLE
feat(code-search): 新增代码搜索方法论 skill (#27)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,6 +37,17 @@
       "source": "./plugins/doc-gate",
       "category": "development",
       "homepage": "https://github.com/WooDragon/cc-plugins"
+    },
+    {
+      "name": "code-search",
+      "description": "Code search & symbol navigation — pick the right tool (ast-grep/ripgrep/grep/find/glob) by search intent",
+      "version": "1.0.0",
+      "author": {
+        "name": "WooDragon"
+      },
+      "source": "./plugins/code-search",
+      "category": "development",
+      "homepage": "https://github.com/WooDragon/cc-plugins"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ WooDragon 的 Claude Code 插件 + 技能包 marketplace。
 | Plugin | plan-review | 对抗性审阅（Gemini/Claude） |
 | Plugin | ppt-press（3 skills） | PPT 全生命周期 |
 | Plugin | doc-gate（1 skill + 3 hooks + 2 tools） | 文档编辑门禁 + 词法召回 |
+| Plugin | code-search（1 skill） | 代码搜索与符号导航方法论（纯 skill，零 hook） |
 
 ## 版本变更铁律
 
@@ -64,6 +65,11 @@ plugins/
         SKILL.md
       ppt-manage/                # 检索管理
         SKILL.md
+  code-search/                   # 代码搜索方法论插件（纯 skill，零 hook）
+    .claude-plugin/plugin.json   # 插件元数据（纯 skill）
+    skills/
+      code-search/SKILL.md       # 工具决策树 + 按意图策略 + 组合技巧 + 上下文经济
+    README.md                    # 面向安装者说明
 ```
 
 ## 环境变量
@@ -137,6 +143,18 @@ recall-gate 内含 double-deny guard：skill-gate 启用且 marker 不存在时�
 | `ppt-create` | 内容生产：需求澄清 → 大纲 → Astro 页面 → 自检 | ~85KB（含 5 references + 1 asset） |
 | `ppt-deploy` | 构建验证 → 批量 Playwright 测试 → Amplify 部署 | ~4KB |
 | `ppt-manage` | deck 列表检索 / 搜索 / URL 复制 | ~2KB |
+
+### 代码搜索技能
+
+`code-search` skill 注入代码搜索方法论，让 Claude 按搜索意图选对工具，不漏触发、不滥用全库 grep：
+
+| 维度 | 内容 |
+|------|------|
+| 工具决策树 | 结构搜索 → ast-grep；文本 → Grep；文件定位 → Glob；读取 → Read |
+| 按意图策略 | 找定义 / 找引用 / 调用链 / 结构概览 / 文本模式各有首选工具 |
+| 上下文经济 | 大检索派子 agent 隔离，只回收结论 |
+
+触发靠 description 语义匹配（中英关键词 + 口语化说法全覆盖），不用 hook——搜代码无可判定的 tool-level 信号，且高频动作门禁会破坏工作流。
 
 ### Plugin vs Skill
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npx skills add WooDragon/cc-plugins -g
 | [plan-review](./plugins/plan-review/) | Adversarial plan review via cross-model consultation (Gemini/Claude) |
 | [doc-gate](./plugins/doc-gate/) | Document editing governance — skill gate + lexical recall advisory + link graph tools |
 | [ppt-press](./plugins/ppt-press/) | PPT toolkit — editorial magazine × e-ink web presentation skills |
+| [code-search](./plugins/code-search/) | Code search & symbol navigation — pick the right tool by search intent |
 
 ## Skills
 
@@ -32,3 +33,4 @@ npx skills add WooDragon/cc-plugins -g
 | [ppt-deploy](./plugins/ppt-press/skills/ppt-deploy/) | ppt-press | Build, test, and deploy PPT decks to AWS Amplify |
 | [ppt-manage](./plugins/ppt-press/skills/ppt-manage/) | ppt-press | List, search, and retrieve PPT deck URLs |
 | [doc-maintenance](./plugins/doc-gate/skills/doc-maintenance/) | doc-gate | Document maintenance workflow with pre/post-flight checks |
+| [code-search](./plugins/code-search/skills/code-search/) | code-search | Pick the right search tool (ast-grep/grep/glob) by intent |

--- a/plugins/code-search/.claude-plugin/plugin.json
+++ b/plugins/code-search/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "code-search",
+  "description": "Code search & symbol navigation — pick the right tool (ast-grep/ripgrep/grep/find/glob) by search intent",
+  "version": "1.0.0",
+  "author": { "name": "WooDragon" },
+  "skills": ["./skills/code-search"]
+}

--- a/plugins/code-search/README.md
+++ b/plugins/code-search/README.md
@@ -1,0 +1,31 @@
+# code-search
+
+Code search & symbol navigation skill for Claude Code — teaches Claude to pick the right tool by search intent instead of reflexively running `grep -r`.
+
+A **pure skill plugin** (no hooks, no scripts). It injects a code-search methodology so any "find this in the codebase" task routes to the right tool with the right strategy.
+
+## Installation
+
+```bash
+# From marketplace
+claude plugin add code-search@WooDragon-cc-plugins
+```
+
+## What it does
+
+| Dimension | Guidance |
+|-----------|----------|
+| **Tool decision tree** | structure → ast-grep · text → Grep · file lookup → Glob · read → Read |
+| **Strategy by intent** | definition / references / call chain / structure overview / text pattern each have a preferred tool |
+| **Combine moves** | narrow-then-widen, locate-then-read, converge layer by layer |
+| **Context economy** | offload large / exploratory searches to an isolated sub-agent, return conclusions only |
+
+## Triggering
+
+Activation is purely semantic — the skill's `description` enumerates code-search scenarios and triggers across Chinese/English keywords and colloquial phrasings ("where is X defined", "who calls X", "全局搜 TODO", "find references"…). No hook, no manual invocation: any code-search / symbol-navigation task surfaces it.
+
+**Why no hook?** There's no decidable signal for "this tool call is a code search" — searches run through Grep, Glob, Bash (`grep`/`rg`/`ast-grep`/`find`), and Read interchangeably, and a PreToolUse matcher only sees the tool name, not intent. Gating a high-frequency action would also wreck the workflow. Semantic matching hands the judgment to the model that already reads the description every turn.
+
+## Skill: code-search
+
+The plugin bundles one skill (`skills/code-search/SKILL.md`) covering the tool decision tree, intent-based strategy, combination techniques, context economy, and anti-patterns.

--- a/plugins/code-search/skills/code-search/SKILL.md
+++ b/plugins/code-search/skills/code-search/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: code-search
+description: |
+  代码搜索与符号导航——在代码库里找定义、找引用、追调用链、看结构、跑正则。当需要：
+  - 查找函数/类/方法/变量/常量/类型/接口的定义（"X 在哪定义"、"找 X 的定义"、"where is X defined"、"jump to definition"、"跳转到定义"）
+  - 追踪符号的所有引用/调用点（"谁调用了 X"、"X 在哪被用到"、"find references/usages"、"call sites"、"哪些文件用了 X"）
+  - 分析调用链、依赖、import 关系（"X 的调用链"、"谁 import 了 Y"、"dependency/call graph"、"依赖分析"）
+  - 跨文件搜文本/正则/字符串字面量（grep、ripgrep、正则匹配、"全局搜 X"、"search for pattern"、"搜一下哪里有"）
+  - 按文件名/路径定位文件、看目录树/项目结构（"有哪些 X 文件"、"文件树"、"项目结构"、"find files"、"glob"）
+  - 定位 TODO/FIXME/标记注释或特定代码模式（"所有 TODO"、"找所有 catch 块"、ast 结构模式匹配）
+  - 在动手改代码、读代码、理解陌生代码库之前先定位相关代码
+  时调用此 Skill，按工具决策树选对 ast-grep / ripgrep / grep / find / Glob / Read，避免盲目全库 grep、避免把大检索结果塞满主上下文。
+  Triggers: 代码搜索, 搜代码, 查找代码, 找函数, 找定义, 找用法, 找引用, 符号导航, 代码导航, 调用链, 依赖分析, 全局搜索, grep, ripgrep, rg, ast-grep, sg, find files, search code, find function, find references, where defined, who calls, call graph, codebase search, locate code, navigate code.
+---
+
+# 代码搜索
+
+在代码库里定位代码：找定义、找引用、追调用链、看结构、跑正则。核心一句话——**按搜索意图选对工具，别一上来就 `grep -r`**。
+
+## 决策原则
+
+搜索前先问：**我找的是「语法结构」还是「文本」？**
+
+- **结构**（函数/类/方法/类型/import 的定义与调用）→ `ast-grep`（命令 `ast-grep`，部分环境别名 `sg`），按 AST 匹配，不受格式、换行、注释干扰。
+- **文本**（字符串字面量、注释、配置值、日志、跨语言关键词）→ **Grep 工具**（Claude Code 原生，ripgrep 内核），正则匹配。
+- ast-grep 表达不了的结构 → 回退 Grep / 正则。
+
+## §1 工具决策树
+
+| 搜索目标 | 首选 | 要点 / 示例 |
+|---------|------|------------|
+| 函数/类/方法/类型/接口**定义** | `ast-grep` | `ast-grep -p 'function $NAME($$$)'`、`-p 'class $NAME'`、`-p 'def $NAME'`；`-l <lang>` 指定语言 |
+| 符号**引用/调用点** | Grep 工具 / `ast-grep` | 快速铺开用 Grep 搜符号名；噪音大时换 `ast-grep -p '$NAME($$$)'` 精确匹配调用形态 |
+| 文本 / 正则 / 字面量 | **Grep 工具** | 原生 Grep（rg 内核）优先于裸 `rg`/`grep`；用 `-A/-B/-C` 看上下文、`type` 过滤语言、`glob` 限路径 |
+| 文件名 / 路径定位 | **Glob 工具** | `**/*.ts`、`**/test_*.py`；多条件或按时间/大小回退 `find` |
+| import / 依赖关系 | `ast-grep` | 匹配 import/require/use 语句结构，比正则稳 |
+| 目录树 / 结构概览 | Glob / `find` | 先摸结构建坐标系，再精搜 |
+| 已知文件读内容 | **Read** | 禁止 `cat`/`head`/`tail` |
+
+## §2 按意图选策略
+
+- **找定义**：ast-grep 结构匹配（`function/class/def/type/interface $NAME`）。比 grep 准——不会把调用点、同名字符串、注释误当定义。
+- **找引用/调用点**：Grep 符号名快速铺开；若噪音大（同名变量、注释命中），换 ast-grep 调用模式 `$NAME($$$)` 收敛。
+- **调用链 / 依赖**：组合——先 ast-grep 定位定义，再找所有调用点，按需逐层展开。别指望一条命令出全图。
+- **结构概览**：Glob 看文件分布、`find` 看目录树，建立坐标系后再精搜。
+- **文本模式**：纯文本 / 正则 / 配置值 / 日志，直接 Grep 工具，用 `type` 和路径缩范围。
+
+## §3 组合技巧
+
+- **先窄后宽**：先 Glob 把文件集缩到目标范围（按目录 / 扩展名），再在范围内 Grep，别全库扫。
+- **先定位后读**：先 ast-grep / Grep 拿到 `file:line`，再 Read 精读——不要 Read 一堆文件靠肉眼找。
+- **逐层收敛**：命中太多就加 `type`、限路径、换结构匹配收紧，而不是翻页看完。
+
+## §4 上下文经济
+
+搜索结果会占用上下文，按规模分流：
+
+- **精确、单次即得**（已知符号名、明确路径）→ 直接搜。
+- **结果不可预测 / 需多轮检索 / 大范围探索**（陌生代码库摸索、"找出所有用到 X 的地方再分析"）→ 若运行环境支持子任务隔离（如 Claude Code 的 Task / subagent），派子 agent 执行，**只回收结论**，别把成百上千行匹配灌进主上下文。检索取数是低推理活，适合卸载到更轻量的执行单元。
+
+## §5 反模式
+
+- ❌ 一上来 `grep -r pattern .` 不缩范围 → 噪音淹没信号；先 Glob 缩范围或用 ast-grep 结构搜。
+- ❌ 用 `cat` / `head` / `tail` 读文件 → 用 Read。
+- ❌ 能用 ast-grep 结构搜（找函数定义）却用脆弱正则硬凑 → 换行、参数、注释一变就漏。
+- ❌ 大范围检索直接在主上下文跑 → 污染上下文；派 Task 隔离。
+- ❌ `cd` 切目录 → 用工具的路径参数代替。


### PR DESCRIPTION
## 摘要
独立纯 skill 插件 `code-search` v1.0.0（零 hook、零脚本，单文件 SKILL.md）。

## 设计决策
触发靠 description 语义匹配，不用 hook——搜代码无可判定的 tool-level 信号（PreToolUse matcher 只认 tool_name，Bash 里的 grep/rg/sg/find 看不见），且高频动作门禁会破坏工作流。判断交给每轮读 description 的模型。这是「消除边界情况而非加 if」的好品味落地。

## 内容
- 工具决策树（结构→ast-grep / 文本→Grep / 文件→Glob / 读→Read）
- 按意图选策略 + 组合技巧 + 上下文经济（大检索派子 agent 隔离）
- description 中英关键词 + 口语化说法全覆盖，最大化触发面、不漏触发

## 登记
marketplace.json / 项目 CLAUDE.md / 顶层 README 全同步；版本 1.0.0 双写一致。

Closes #27