### PR TITLE
feat(plan-review): Finding Quality Gate 系统化降噪 (#30)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "plan-review",
       "description": "Adversarial plan review via cross-model consultation (Gemini/Claude)",
-      "version": "1.0.41",
+      "version": "1.0.42",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/plan-review/.claude-plugin/plugin.json
+++ b/plugins/plan-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-review",
   "description": "Adversarial plan review via cross-model consultation (Gemini/Claude)",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "author": {
     "name": "woodragon"
   }

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -477,10 +477,43 @@ Keep your response under 3000 characters.
 9. **Dispatch Manifest** — 若 plan 涉及 Agent/Task 调度，必须包含 `## Dispatch Manifest` 表格，列出每个 step 的 agent_type、model、depends_on、parallel_with。主上下文执行的 step 用 `-` 占位。任一 Agent step 缺 model 视为 [Critical]（REJECT）；缺 manifest 表格本身视为 [Major]（CONCERNS，受 MAX_ROUNDS 安全阀约束）。
 
 ## Review Discipline
-- If the plan already provides justification for a design choice, **DO NOT** raise it as an issue unless the justification itself is flawed. Acknowledge the rationale and move on.
 - Focus on gaps the plan author **missed**, not on restating what they already considered.
-- Every issue must cite specific evidence from the plan or project context. Generic warnings without grounding (e.g., "consider edge cases" without naming which) are noise — **OMIT** them.
-- Tool names, agent type identifiers, and API parameter names in the plan are opaque references to the author'"'"'s runtime — **NEVER** flag them as errors, hallucinations, or incorrect naming. This is out of scope.
+- Every issue MUST cite specific evidence from the plan or project context.
+
+## Finding Quality Gate (pre-report self-check)
+A false positive here is **amplified**: each spurious finding burns one scarce
+negotiation round (MAX_ROUNDS) that a genuine issue then never gets. Suppress
+aggressively. Gate EVERY finding through these four checks before reporting it.
+
+1. **Confidence threshold** — Self-assess whether the finding is a grounded defect or a guess.
+   - Low confidence + Minor/Major → **DROP** it silently. Generic warnings without a
+     named case (e.g. "consider edge cases" / "add error handling" with no specific
+     path) are ungrounded — omit them.
+   - Low confidence + suspected **Critical** (security, data loss, irreversible
+     corruption) → **DO NOT drop** — false-negative cost is catastrophic. Keep it,
+     prefix the description with `[UNVERIFIED]`, and treat it as Major (→ CONCERNS,
+     NOT REJECT): the suspicion surfaces to the human without hard-blocking on a guess.
+   - High confidence → report normally.
+
+2. **False-positive registry — never raise these:**
+   - Naming / style / formatting preferences (never a finding on their own).
+   - Magic constants the plan or context documents as a fixed contract.
+   - Repetition that is deliberate emphasis or required by the output format.
+   - A design choice the plan already justified — unless the justification is itself
+     flawed; then attack the justification, not the choice.
+   - Tool names, agent-type identifiers, API parameter names (out of scope — see Scope Boundary).
+
+3. **Severity calibration (anti-drift)** — Match severity to demonstrable impact:
+   - A style / naming / "could be cleaner" preference is **never** Major or Critical.
+   - Critical requires a concrete, named blocker (a specific vuln, a specific data-loss
+     path, wrong-result logic) — not a general worry.
+
+4. **Verdict↔severity pre-flight** — Before writing the verdict tag, confirm it matches
+   your highest-severity SURVIVING finding (post-gate), so the verdict never contradicts
+   the body (no "ghost reports"):
+   - any confirmed [Critical] → REJECT
+   - highest is [Major], or any [UNVERIFIED] suspicion → CONCERNS
+   - only [Minor] or none → APPROVE
 
 ## Severity Definitions
 - **[Critical]** — Blocker: security vulnerabilities, data loss, logic errors producing wrong results, breaking changes to existing behavior, fundamental approach flaws
@@ -489,16 +522,19 @@ Keep your response under 3000 characters.
 
 ## Verdict Rules
 - **APPROVE**: No issues, or only Minor items remaining
-- **CONCERNS**: Major items present but no Critical
-- **REJECT**: Critical items present
+- **CONCERNS**: Major items present (including any `[UNVERIFIED]` suspicion) but no confirmed Critical
+- **REJECT**: confirmed Critical items present
 
 Verdict is the structured severity signal — the automation routes on verdict tags only,
-no body scanning. Strictly follow verdict-severity correspondence.
+no body scanning. Strictly follow verdict-severity correspondence (see Finding Quality
+Gate check 4 — the verdict must match your highest surviving finding).
 
 ## Output Format
 - FIRST line must be a verdict tag: <verdict>APPROVE</verdict> or <verdict>CONCERNS</verdict> or <verdict>REJECT</verdict>
 - List issues, each prefixed with severity tag: `[Critical]`, `[Major]`, or `[Minor]`
 - Each issue format: `[Severity] description → impact → suggested fix`
+- A low-confidence but high-severity suspicion (Quality Gate check 1) is emitted as
+  `[Major] [UNVERIFIED] description → ...` — surfaced for the human, never as REJECT
 - If a severity level has no issues, omit it entirely
 - End with brief strengths of the plan (if any)
 

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -2082,3 +2082,49 @@ Good."
   grep -q "Deletion completeness" "${HOOK_SCRIPT:?Missing hook script}"
   grep -q "3000 characters" "${HOOK_SCRIPT:?Missing hook script}"
 }
+
+# ---------------------------------------------------------------------------
+# Finding Quality Gate (issue #30) — prompt-layer denoising directives.
+# These are static prompt-content assertions: the gate operates inside the
+# review engine (LLM self-check), so it cannot be exercised at runtime here.
+# We assert the four gap-closing directives are present in SYSTEM_INSTRUCTIONS.
+# ---------------------------------------------------------------------------
+@test "system-instructions: Finding Quality Gate section present" {
+  grep -q "Finding Quality Gate" "${HOOK_SCRIPT:?Missing hook script}"
+}
+
+@test "quality-gate: gap1 confidence threshold + drop-low-confidence directive" {
+  grep -q "Confidence threshold" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "DROP" "${HOOK_SCRIPT:?Missing hook script}"
+}
+
+@test "quality-gate: gap1 gradient exit — low-confidence Critical kept as UNVERIFIED, not dropped" {
+  grep -q "UNVERIFIED" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "DO NOT drop" "${HOOK_SCRIPT:?Missing hook script}"
+  # gradient exit must downgrade to CONCERNS, never hard-block as REJECT on a guess
+  grep -q "NOT REJECT" "${HOOK_SCRIPT:?Missing hook script}"
+}
+
+@test "quality-gate: gap2 false-positive registry present" {
+  grep -q "False-positive registry" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "never raise these" "${HOOK_SCRIPT:?Missing hook script}"
+}
+
+@test "quality-gate: gap3 verdict-severity pre-flight self-check (prompt-layer, not body-scan)" {
+  grep -q "Verdict↔severity pre-flight" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "ghost reports" "${HOOK_SCRIPT:?Missing hook script}"
+  # Routing must remain verdict-only: the hook must NOT grep the body for severity tags
+  ! grep -qE "grep[^|]*'\[Critical\]'" "${HOOK_SCRIPT:?Missing hook script}"
+}
+
+@test "quality-gate: gap4 severity calibration anti-drift" {
+  grep -q "Severity calibration" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "never\*\* Major or Critical" "${HOOK_SCRIPT:?Missing hook script}"
+}
+
+@test "quality-gate: UNVERIFIED routes to CONCERNS in verdict rules + output format" {
+  # CONCERNS bucket explicitly includes UNVERIFIED suspicions
+  grep -q "UNVERIFIED.*suspicion.*but no confirmed Critical\|including any .UNVERIFIED" "${HOOK_SCRIPT:?Missing hook script}"
+  # output format documents the [Major] [UNVERIFIED] emission shape
+  grep -q '\[Major\] \[UNVERIFIED\]' "${HOOK_SCRIPT:?Missing hook script}"
+}


### PR DESCRIPTION
## Summary

把散落在 `SYSTEM_INSTRUCTIONS` 三处的降噪直觉收敛成独立 `## Finding Quality Gate` 章节,覆盖 #30 的四个 gap。纯 Prompt 层,零运行时成本。

- **置信度阈值** — 低置信 Minor/Major 静默 DROP
- **低置信×高危梯度出口** — 标 `[UNVERIFIED]` 降级 Major(→CONCERNS 非 REJECT),高危疑虑浮现给人但不靠猜测硬阻断
- **假阳性注册表** — 命名/风格偏好、文档化常量、刻意重复、已 justify 设计、tool/agent 标识符一律不报
- **severity 反例校准 + verdict↔severity 发射前自检** — 消除 ghost report

## 关键取舍

否决 issue 原提案的 **hook body-scan 纠正 verdict**:违反 `routes on verdict tags only, no body scanning` 铁律,且 FP 注册表上线后 prompt 含字面量 `[Critical]`,body-scan 误判率不降反升。`REVIEW_CONFIDENCE_MIN` 与外部 FP-registry 文件均不做(hook 层无可测信号 / YAGNI)。

`[UNVERIFIED]` 是 `[Major]` 后的描述前缀而非新 severity tag,verdict 路由仍 100% 只认 verdict tag。

## Test

新增 7 个 BDD scenario(逐 gap + 守卫"hook 不扫 body"),全套 **143 测试通过**(129+14),零回归。经 plan-review 3 轮对抗性审阅 APPROVE。

版本双写 1.0.41 → 1.0.42。

Closes #30