### PR TITLE
feat(plan-review): degenerate manifest 拦截 + prompt 结构优化

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "plan-review",
       "description": "Adversarial plan review via cross-model consultation (Gemini/Claude)",
-      "version": "1.0.42",
+      "version": "1.0.43",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/plan-review/.claude-plugin/plugin.json
+++ b/plugins/plan-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-review",
   "description": "Adversarial plan review via cross-model consultation (Gemini/Claude)",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "author": {
     "name": "woodragon"
   }

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -196,6 +196,20 @@ resolve_plan_from_transcript() {
 needs_manifest() { printf '%s' "$1" | grep -qiE '(Task\(|subagent_type|agent_type|Plan agent|Explore agent|worker agent|dev agent)'; }
 has_manifest()   { printf '%s' "$1" | grep -qi '^## Dispatch Manifest'; }
 
+# Returns 0 if at least one manifest data row has a non-dash agent_type.
+manifest_has_real_agent() {
+  printf '%s\n' "$1" | awk '
+    /^## Dispatch Manifest/ {in_m=1; next}
+    in_m && /^## / {in_m=0}
+    in_m && /^ *$/ {in_m=0}
+    in_m && /^\|/ && !/^\|---/ && !/^\| *step/ {
+      gsub(/^\| *| *\| *$/, ""); n = split($0, f, / *\| */)
+      if (n >= 2) { at=f[2]; gsub(/^ +| +$|"/, "", at); if (at != "-" && at != "") found=1 }
+    }
+    END { exit (found ? 0 : 1) }
+  '
+}
+
 # --- Manifest JSON serializer (called only from APPROVE branch; failures are silent) ---
 # Parses the ## Dispatch Manifest markdown table and outputs a dispatch JSON blob.
 # JSON injection defense: strips stray double-quotes LLM may write in manifest rows.
@@ -204,6 +218,7 @@ parse_manifest_to_json() {
   printf '%s\n' "$plan" | awk -v hash="$hash" -v now="$(date +%s)" '
     /^## Dispatch Manifest/ {in_manifest=1; next}
     in_manifest && /^## / {in_manifest=0}
+    in_manifest && /^ *$/ {in_manifest=0}
     in_manifest && /^\|/ && !/^\|---/ && !/^\| *step/ {
       gsub(/^\| *| *\| *$/, ""); n = split($0, f, / *\| */)
       if (n >= 3) {
@@ -405,6 +420,25 @@ EOF
   exit 0
 fi
 
+# --- Pre-flight degenerate manifest check (all agent_type == "-") ---
+# Fires when manifest is present but declares zero real agent steps.
+if needs_manifest "$PLAN" && has_manifest "$PLAN" && ! manifest_has_real_agent "$PLAN"; then
+  TOTAL_ROUNDS=$((TOTAL_ROUNDS + 1))
+  ATTEMPT=$((ATTEMPT + 1))
+  echo "${ATTEMPT}:${TOTAL_ROUNDS}" > "$COUNTER_FILE"
+  log_decision "decision=deny reason=degenerate-manifest"
+  DEGEN_MSG="## Red Team Pre-flight — DEGENERATE DISPATCH MANIFEST
+
+Plan 含 Agent/Task 调度关键词，但 Manifest 所有行 agent_type 均为 \`-\`（全主上下文）。
+若任务确实简单（单一关注点、无接口变更），请移除 dispatch 关键词或改写为直接执行描述。
+若任务复杂，请在 manifest 中声明真实 agent 步骤。"
+  DEGEN_DENY_JSON=$(printf '%s' "$DEGEN_MSG" | jq -Rs .)
+  cat <<EOF
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":${DEGEN_DENY_JSON}}}
+EOF
+  exit 0
+fi
+
 # --- 2. Collect project context ---
 CWD=$(echo "$INPUT" | jq -r '.cwd // "."')
 
@@ -472,48 +506,33 @@ Keep your response under 3000 characters.
      local/internal symbols, or provably dead code with no external consumers (grep
      evidence in the plan).
 6. **Architecture fit** — Consistent with project patterns?
-7. **Execution topology** — Does each step explicitly annotate its execution location (main context vs Task) and scheduling topology (sequential / parallel / dependency order)? Steps that spawn agents or run multi-phase operations without these annotations are [Major] issues.
+7. **Dispatch Discipline** — Task complexity determines execution strategy:
+   - **Simple task** (single-concern, no interface/dependency changes): main context
+     self-executes; manifest all-dash is valid; manifest table itself is optional.
+   - **Complex task** (multi-concern, interface changes, cross-module coordination):
+     main context MUST act as dispatcher — at least one step delegates to a typed
+     agent with explicit model. All-dash manifest on a complex plan is [Critical]
+     (main session hoarding work it should delegate).
+   - Manifest format: Agent steps require both agent_type + model (full name, no
+     abbreviation). Main-context steps use `-`. Missing manifest when dispatch
+     keywords are present = [Major]. Agent step missing model = [Critical].
 8. **Reuse over reinvention** — Does the plan propose building something that already exists in the project dependencies, framework, or standard library? Custom implementations require explicit justification (e.g., "framework X lacks feature Y" with concrete evidence). Without strong justification, prefer existing solutions. This is a [Major] issue.
-9. **Dispatch Manifest** — 若 plan 涉及 Agent/Task 调度，必须包含 `## Dispatch Manifest` 表格，列出每个 step 的 agent_type、model、depends_on、parallel_with。主上下文执行的 step 用 `-` 占位。任一 Agent step 缺 model 视为 [Critical]（REJECT）；缺 manifest 表格本身视为 [Major]（CONCERNS，受 MAX_ROUNDS 安全阀约束）。
 
 ## Review Discipline
 - Focus on gaps the plan author **missed**, not on restating what they already considered.
 - Every issue MUST cite specific evidence from the plan or project context.
 
 ## Finding Quality Gate (pre-report self-check)
-A false positive here is **amplified**: each spurious finding burns one scarce
-negotiation round (MAX_ROUNDS) that a genuine issue then never gets. Suppress
-aggressively. Gate EVERY finding through these four checks before reporting it.
+False positives burn scarce negotiation rounds. Gate EVERY finding:
 
-1. **Confidence threshold** — Self-assess whether the finding is a grounded defect or a guess.
-   - Low confidence + Minor/Major → **DROP** it silently. Generic warnings without a
-     named case (e.g. "consider edge cases" / "add error handling" with no specific
-     path) are ungrounded — omit them.
-   - Low confidence + suspected **Critical** (security, data loss, irreversible
-     corruption) → **DO NOT drop** — false-negative cost is catastrophic. Keep it,
-     prefix the description with `[UNVERIFIED]`, and treat it as Major (→ CONCERNS,
-     NOT REJECT): the suspicion surfaces to the human without hard-blocking on a guess.
-   - High confidence → report normally.
-
-2. **False-positive registry — never raise these:**
-   - Naming / style / formatting preferences (never a finding on their own).
-   - Magic constants the plan or context documents as a fixed contract.
-   - Repetition that is deliberate emphasis or required by the output format.
-   - A design choice the plan already justified — unless the justification is itself
-     flawed; then attack the justification, not the choice.
-   - Tool names, agent-type identifiers, API parameter names (out of scope — see Scope Boundary).
-
-3. **Severity calibration (anti-drift)** — Match severity to demonstrable impact:
-   - A style / naming / "could be cleaner" preference is **never** Major or Critical.
-   - Critical requires a concrete, named blocker (a specific vuln, a specific data-loss
-     path, wrong-result logic) — not a general worry.
-
-4. **Verdict↔severity pre-flight** — Before writing the verdict tag, confirm it matches
-   your highest-severity SURVIVING finding (post-gate), so the verdict never contradicts
-   the body (no "ghost reports"):
-   - any confirmed [Critical] → REJECT
-   - highest is [Major], or any [UNVERIFIED] suspicion → CONCERNS
-   - only [Minor] or none → APPROVE
+1. **Confidence** — Low confidence + Minor/Major → DROP silently. Low confidence +
+   suspected Critical → keep as `[UNVERIFIED]`, downgrade to Major (→ CONCERNS, not REJECT).
+2. **False-positive registry** — Never raise: naming/style preferences, justified design
+   choices (attack the justification instead), tool/agent-type/parameter names (Scope Boundary).
+3. **Severity calibration** — Style is never Major/Critical. Critical requires a concrete,
+   named blocker (specific vuln, data-loss path, wrong-result logic).
+4. **Verdict↔severity** — Confirm verdict matches highest surviving finding:
+   confirmed Critical → REJECT; Major or UNVERIFIED → CONCERNS; Minor-only → APPROVE.
 
 ## Severity Definitions
 - **[Critical]** — Blocker: security vulnerabilities, data loss, logic errors producing wrong results, breaking changes to existing behavior, fundamental approach flaws

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -202,7 +202,7 @@ manifest_has_real_agent() {
     /^## Dispatch Manifest/ {in_m=1; next}
     in_m && /^## / {in_m=0}
     in_m && /^ *$/ {in_m=0}
-    in_m && /^\|/ && !/^\|---/ && !/^\| *step/ {
+    in_m && /^\|/ && !/^\|---/ && !/^\| *[Ss][Tt][Ee][Pp]/ {
       gsub(/^\| *| *\| *$/, ""); n = split($0, f, / *\| */)
       if (n >= 2) { at=f[2]; gsub(/^ +| +$|"/, "", at); if (at != "-" && at != "") found=1 }
     }
@@ -219,7 +219,7 @@ parse_manifest_to_json() {
     /^## Dispatch Manifest/ {in_manifest=1; next}
     in_manifest && /^## / {in_manifest=0}
     in_manifest && /^ *$/ {in_manifest=0}
-    in_manifest && /^\|/ && !/^\|---/ && !/^\| *step/ {
+    in_manifest && /^\|/ && !/^\|---/ && !/^\| *[Ss][Tt][Ee][Pp]/ {
       gsub(/^\| *| *\| *$/, ""); n = split($0, f, / *\| */)
       if (n >= 3) {
         id=f[1]; at=f[2]; md=f[3]
@@ -508,7 +508,8 @@ Keep your response under 3000 characters.
 6. **Architecture fit** — Consistent with project patterns?
 7. **Dispatch Discipline** — Task complexity determines execution strategy:
    - **Simple task** (single-concern, no interface/dependency changes): main context
-     self-executes; manifest all-dash is valid; manifest table itself is optional.
+     self-executes; no manifest table required. If dispatch keywords appear in the
+     plan text, either remove them or declare at least one real agent step.
    - **Complex task** (multi-concern, interface changes, cross-module coordination):
      main context MUST act as dispatcher — at least one step delegates to a typed
      agent with explicit model. All-dash manifest on a complex plan is [Critical]

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -2047,6 +2047,106 @@ Good."
   [ ! -f "$stale_file" ]
 }
 
+# 110. plan 含 dispatch 关键词 + manifest 全 "-" → degenerate deny + counter increment
+@test "manifest: all-dash manifest → pre-flight degenerate deny + counter increment" {
+  local plan_all_dash="## Plan
+Step 1: Use Task( for analysis.
+
+## Dispatch Manifest
+| step | agent_type | model | depends_on | parallel_with |
+|------|-----------|-------|------------|---------------|
+| 1    | -         | -     | -          | -             |
+| 2    | -         | -     | 1          | -             |"
+  INPUT=$(build_input "plan=$plan_all_dash")
+  run_hook
+
+  assert_deny_json
+  local reason
+  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+  [[ "$reason" == *"DEGENERATE DISPATCH MANIFEST"* ]]
+  local attempt; attempt=$(get_counter_value)
+  [ "$attempt" -eq 1 ]
+}
+
+# 111. mixed manifest (dash + real agent) → passes pre-flight (non-regression)
+@test "manifest: mixed manifest with real agent_type → passes pre-flight to engine" {
+  create_mock_engine "gemini" "<verdict>APPROVE</verdict>
+All good."
+  local plan_mixed="## Plan
+Step 1: Prepare context. Step 2: Use Task( for heavy lifting.
+
+## Dispatch Manifest
+| step | agent_type | model | depends_on | parallel_with |
+|------|-----------|-------|------------|---------------|
+| 1    | -         | -     | -          | -             |
+| 2    | worker    | sonnet| 1          | -             |"
+  INPUT=$(build_input "plan=$plan_mixed")
+  run_hook
+
+  assert_ack_approve_json
+}
+
+# 112. all-dash repeated → valve escalates (same pattern as test 108)
+@test "manifest: repeated degenerate denies up to MAX_ROUNDS → valve escalates" {
+  export REVIEW_MAX_ROUNDS=2
+  local plan_all_dash="## Plan
+Use Task( for work.
+
+## Dispatch Manifest
+| step | agent_type | model | depends_on | parallel_with |
+|------|-----------|-------|------------|---------------|
+| 1    | -         | -     | -          | -             |"
+  INPUT=$(build_input "plan=$plan_all_dash")
+
+  # Round 1: ATTEMPT=0 < MAX=2 → degenerate deny, ATTEMPT→1
+  run_hook
+  assert_deny_json
+
+  # Round 2: ATTEMPT=1 < MAX=2 → degenerate deny, ATTEMPT→2
+  run_hook
+  assert_deny_json
+
+  # Round 3: ATTEMPT=2 >= MAX=2 → valve fires BEFORE degenerate check → allow
+  run_hook
+  assert_approve_json
+}
+
+# 113. empty manifest (header + separator only, 0 data rows) → degenerate deny
+@test "manifest: empty manifest section (no data rows) → degenerate deny" {
+  local plan_empty_manifest="## Plan
+Step 1: Use Task( for isolation.
+
+## Dispatch Manifest
+| step | agent_type | model | depends_on | parallel_with |
+|------|-----------|-------|------------|---------------|
+
+## Next Section"
+  INPUT=$(build_input "plan=$plan_empty_manifest")
+  run_hook
+
+  assert_deny_json
+  local reason
+  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+  [[ "$reason" == *"DEGENERATE DISPATCH MANIFEST"* ]]
+}
+
+# 114. agent_type="worker" + model="-" → NOT blocked (only agent_type checked)
+@test "manifest: real agent_type with dash model → passes pre-flight" {
+  create_mock_engine "gemini" "<verdict>APPROVE</verdict>
+OK."
+  local plan_agent_no_model="## Plan
+Use Task( for analysis.
+
+## Dispatch Manifest
+| step | agent_type | model | depends_on | parallel_with |
+|------|-----------|-------|------------|---------------|
+| 1    | worker    | -     | -          | -             |"
+  INPUT=$(build_input "plan=$plan_agent_no_model")
+  run_hook
+
+  assert_ack_approve_json
+}
+
 # 100. Capacity-fast-break → degrade file already written; REST entry does not overwrite
 #      (double-write is harmless: timestamps differ by <1s, both numeric, TTL still valid)
 @test "degrade: capacity-fast-break + REST success → degrade file refreshed (double-write harmless)" {
@@ -2094,32 +2194,29 @@ Good."
 }
 
 @test "quality-gate: gap1 confidence threshold + drop-low-confidence directive" {
-  grep -q "Confidence threshold" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "Confidence" "${HOOK_SCRIPT:?Missing hook script}"
   grep -q "DROP" "${HOOK_SCRIPT:?Missing hook script}"
 }
 
 @test "quality-gate: gap1 gradient exit — low-confidence Critical kept as UNVERIFIED, not dropped" {
   grep -q "UNVERIFIED" "${HOOK_SCRIPT:?Missing hook script}"
-  grep -q "DO NOT drop" "${HOOK_SCRIPT:?Missing hook script}"
-  # gradient exit must downgrade to CONCERNS, never hard-block as REJECT on a guess
-  grep -q "NOT REJECT" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "not REJECT" "${HOOK_SCRIPT:?Missing hook script}"
 }
 
 @test "quality-gate: gap2 false-positive registry present" {
   grep -q "False-positive registry" "${HOOK_SCRIPT:?Missing hook script}"
-  grep -q "never raise these" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -qi "never raise" "${HOOK_SCRIPT:?Missing hook script}"
 }
 
 @test "quality-gate: gap3 verdict-severity pre-flight self-check (prompt-layer, not body-scan)" {
-  grep -q "Verdict↔severity pre-flight" "${HOOK_SCRIPT:?Missing hook script}"
-  grep -q "ghost reports" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "Verdict↔severity" "${HOOK_SCRIPT:?Missing hook script}"
   # Routing must remain verdict-only: the hook must NOT grep the body for severity tags
   ! grep -qE "grep[^|]*'\[Critical\]'" "${HOOK_SCRIPT:?Missing hook script}"
 }
 
 @test "quality-gate: gap4 severity calibration anti-drift" {
   grep -q "Severity calibration" "${HOOK_SCRIPT:?Missing hook script}"
-  grep -q "never\*\* Major or Critical" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "never Major" "${HOOK_SCRIPT:?Missing hook script}"
 }
 
 @test "quality-gate: UNVERIFIED routes to CONCERNS in verdict rules + output format" {


### PR DESCRIPTION
## Summary
- 合并 Criterion 7 (Execution topology) + 9 (Dispatch Manifest) → 新 Criterion 7 "Dispatch Discipline"，内嵌简单/复杂任务复杂度定义
- 压缩 Finding Quality Gate（~35行→~10行），保留核心 4 条规则
- 新增 `manifest_has_real_agent()` shell helper + degenerate manifest pre-flight deny
- 5 个新 BDD 测试（110-114），总测试 134 pass

## Test plan
- [x] `bats tests/plan-review.bats` — 134/134 全绿
- [x] test 105 (mixed manifest) 无回归
- [x] 新 test 121-125 覆盖: all-dash deny, mixed pass, valve escalate, empty manifest, agent_type-only check
- [x] quality-gate regression tests 更新匹配压缩后 prompt