### PR TITLE
feat(plan-review): Dispatch Economy 审查 + heredoc 重构

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "plan-review",
       "description": "Adversarial plan review via cross-model consultation (Gemini/Claude)",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/plan-review/.claude-plugin/plugin.json
+++ b/plugins/plan-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-review",
   "description": "Adversarial plan review via cross-model consultation (Gemini/Claude)",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "author": {
     "name": "woodragon"
   }

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -492,7 +492,14 @@ fi
 # --- 4. Compose prompt ---
 # Static instructions: single canonical source for both engines.
 # Claude → --system-prompt (independent KV cache); Gemini → prompt file prefix.
-SYSTEM_INSTRUCTIONS='# Red Team Plan Review
+# Quoted heredoc ('EOF') → body is pure literal: $, backtick, parens, and
+# apostrophe are all safe, no escaping needed. We use `read -r -d ''` rather
+# than `$(cat <<'EOF')`: bash 3.2 (macOS /bin/bash) mis-parses unbalanced
+# parens like "Task(" inside a command-substituted heredoc, erroring with
+# "unexpected EOF looking for matching )". The read form has no command
+# substitution and is immune. `|| true` absorbs read's exit 1 at EOF (set -e).
+IFS= read -r -d '' SYSTEM_INSTRUCTIONS << 'EOF' || true
+# Red Team Plan Review
 
 You are a senior software architect performing an ADVERSARIAL review of the
 following implementation plan. Your job is to find flaws before implementation
@@ -532,14 +539,41 @@ Keep your response under 3000 characters.
      local/internal symbols, or provably dead code with no external consumers (grep
      evidence in the plan).
 6. **Architecture fit** — Consistent with project patterns?
-7. **Dispatch Discipline** — Task complexity determines execution strategy:
-   - **Simple task** (single-concern, no interface/dependency changes): main context
-     self-executes; no manifest table required. If dispatch keywords appear in the
-     plan text, either remove them or declare at least one real agent step.
-   - **Complex task** (multi-concern, interface changes, cross-module coordination):
-     main context MUST act as dispatcher — at least one step delegates to a typed
-     agent with explicit model. All-dash manifest on a complex plan is [Critical]
-     (main session hoarding work it should delegate).
+7. **Dispatch Economy** — Work nature determines who executes, to protect the
+   main context's lifespan and minimize token cost. Classify each step by its
+   NATURE (not by a fuzzy complexity estimate), then check the assigned tier:
+   - **Decision work** (architecture, root-cause debugging, requirements
+     breakdown, plan authoring, review judgment) → tier `opus` → runs in main
+     context (manifest model/agent_type = `-`).
+   - **Implementation work** (writing code, editing files, producing content)
+     → tier `sonnet` → MUST be delegated to a typed agent.
+   - **Retrieval work** (read-only exploration, search, data extraction with
+     zero reasoning) → tier `haiku` → MUST be delegated to a typed agent.
+   The default is to delegate: only decision steps legitimately stay in main
+   context. The single whole-plan exemption is **Tier 0** — ALL of: single
+   file, no new dependency, no API-contract / DB-schema change, no cross-file
+   coordination, not an ops task. A Tier-0 plan needs no manifest at all. Do
+   NOT count lines of code to judge Tier 0 — the moment a plan touches multiple
+   files, adds a dependency, or changes an interface, it is not Tier 0 and its
+   implementation steps must be delegated, regardless of how few lines they are.
+   Even a Tier-0 plan, if its text contains dispatch keywords (Task(,
+   subagent_type, worker agent, etc.), must still obey the underlying syntax
+   gate: either remove the keywords or supply a full manifest — otherwise a
+   static check will hard-block it (avoid the split-brain where the reviewer
+   approves but the script rejects).
+   - **Severity calibration** (do not weaken the existing rule):
+     - **Full hoarding** — a non-Tier-0 plan whose manifest leaves ALL
+       implementation/retrieval steps on `-` (main session swallowing every
+       offloadable task) → [Critical] → REJECT. This preserves the existing
+       contract: an all-dash manifest on a complex plan is a Critical blocker.
+     - **Partial hoarding** — individual implementation steps kept in main,
+       a sonnet-grade task kept in main, OR main context (opus) hoarding
+       retrieval/extraction work → [Major] → CONCERNS. Opus hoarding retrieval
+       (haiku-grade, zero-reasoning, high-token work) pollutes the main window
+       worse than hoarding code-writing, so it must force CONCERNS, never Minor.
+     - **Pure mis-tiering / fragmentation** — a sonnet-grade task already inside
+       an agent, or implementation steps sharing one file set split across
+       multiple agents that each reload the same context → [Minor].
    - Manifest format: Agent steps require both agent_type + model (full name, no
      abbreviation). Main-context steps use `-`. Missing manifest when dispatch
      keywords are present = [Major]. Agent step missing model = [Critical].
@@ -588,7 +622,8 @@ IMPORTANT: The verdict MUST be wrapped in <verdict></verdict> XML tags on the
 very first line. This is machine-parsed. Do NOT place verdict keywords anywhere
 else in your response without the tags.
 
-Use Chinese for the review output.'
+Use Chinese for the review output.
+EOF
 
 ENGINE_OUT=""
 ENGINE_STATUS=""

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -2232,3 +2232,45 @@ Use Task( for analysis.
   # output format documents the [Major] [UNVERIFIED] emission shape
   grep -q '\[Major\] \[UNVERIFIED\]' "${HOOK_SCRIPT:?Missing hook script}"
 }
+
+# =============================================================================
+# Dispatch Economy — Criterion 7 regression (v1.0.44 → v1.0.45)
+# Asserts: (1) bash syntax still valid after heredoc refactor,
+#          (2) new Criterion 7 token set is present in SYSTEM_INSTRUCTIONS,
+#          (3) manifest detection path still passes through to engine (non-regression).
+# =============================================================================
+
+# 115. bash syntax check — quoted heredoc must have matching delimiters
+@test "dispatch-economy: bash -n reports no syntax errors after heredoc refactor" {
+  run bash -n "${HOOK_SCRIPT:?Missing hook script}"
+  [ "$status" -eq 0 ]
+}
+
+# 116. Criterion 7 token presence — new prompt content has not been reverted
+@test "dispatch-economy: Criterion 7 tokens present in SYSTEM_INSTRUCTIONS" {
+  grep -q "Dispatch Economy"      "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "Full hoarding"         "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "Partial hoarding"      "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "Retrieval work"        "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "split-brain"           "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "Decision work"         "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "Implementation work"   "${HOOK_SCRIPT:?Missing hook script}"
+}
+
+# 117. manifest detection survives prompt refactor — Task( + manifest reaches engine
+# Non-regression: same scenario as test 102, re-asserted post-heredoc-refactor.
+@test "dispatch-economy: Task( + Dispatch Manifest still proceeds to engine review after refactor" {
+  create_mock_engine "gemini" "<verdict>APPROVE</verdict>
+Dispatch Economy verified."
+  local plan_with_manifest="## Plan
+Step 1: Use Task( for isolation.
+
+## Dispatch Manifest
+| step | agent_type | model | depends_on | parallel_with |
+|------|-----------|-------|------------|---------------|
+| 1    | worker    | sonnet| -          | -             |"
+  INPUT=$(build_input "plan=$plan_with_manifest")
+  run_hook
+
+  assert_ack_approve_json
+}


### PR DESCRIPTION
## 概述

plan-review 的 Criterion 7 从模糊的「Dispatch Discipline（simple/complex 二分）」重写为「Dispatch Economy」——按工作性质三档分类审查 plan 调度成本，逼 LLM 卸载落地/检索工作给 agent，主上下文只做决策，省 token、延长主上下文寿命。

根本问题：旧审阅从不查 model 选得对不对（只校验字段填没填），且默认路径（留主上下文）零阻力 → 偏置内建。

## 核心改动

- **三档分类**：决策→opus→主上下文 / 落地→sonnet→派 agent / 检索→haiku→派 agent
- **默认翻转**：派发是正常情况，留主上下文是需满足 Tier-0 的特殊情况（消除"估复杂度"的偏置）
- **三向严重性校准**（不破坏现有铁律）：完全囤积→Critical/REJECT；部分囤积（含 opus 囤检索）→Major/CONCERNS；纯错配→Minor
- **Tier-0 豁免门内联展开**（对齐 team-ops Rule 0），不依赖 3KB 截断的注入
- **根因修复**：SYSTEM_INSTRUCTIONS 单引号字符串赋值 → heredoc，消除撇号约束

## 唯一落点

仅改 `SYSTEM_INSTRUCTIONS` 语义层。Layer 1 awk / Layer 2 dispatch-check / manifest schema 全不动。

## 踩坑记录

原方案采纳审阅意见用 `$(cat << 'EOF')`，但 bash 3.2（macOS /bin/bash）会 mis-parse heredoc body 内的 `Task(` 未配对括号，报 `unexpected EOF looking for matching )`。`bash -n` 在 bash 5.3 下 PASS 掩盖了该 bug，靠 git stash 回 HEAD 实测才定位。改用 `IFS= read -r -d '' VAR << 'EOF' ... EOF || true`（真 heredoc 无命令替换，3.2 安全）。

## 测试

- `bats plan-review.bats` **137/137** 全绿（+3 回归用例 135/136/137）
- `bats dispatch-check.bats` **14/14** 全绿
- `/bin/bash -n`（bash 3.2 实际运行环境）语法通过
- 端到端 dry-run smoke test 通过

版本双写 1.0.44 → 1.0.45。

close #33