### PR TITLE
fix(ppt-press): pin Playwright version + version-aware browser check

### DIFF
--- a/plugins/ppt-press/assets/scaffold/package.json
+++ b/plugins/ppt-press/assets/scaffold/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "1.59.1",
     "astro": "^6.2.1",
     "typescript": "^5.9.3"
   }

--- a/plugins/ppt-press/scripts/check-deps.sh
+++ b/plugins/ppt-press/scripts/check-deps.sh
@@ -106,16 +106,20 @@ check_env_file() {
 }
 
 check_playwright() {
-  local PW_DIR
-  if [[ "$(uname)" == "Darwin" ]]; then
-    PW_DIR="$HOME/Library/Caches/ms-playwright"
-  else
-    PW_DIR="$HOME/.cache/ms-playwright"
+  local REVISION
+  REVISION=$(node -p "require('./node_modules/playwright-core/browsers.json').browsers.find(b=>b.name==='chromium').revision" 2>/dev/null) || true
+  if [[ -z "$REVISION" || "$REVISION" == "undefined" ]]; then
+    fail "Playwright — node_modules 中未找到或 browsers.json 异常" "npm install"
+    return
   fi
-  if [[ -d "$PW_DIR" ]] && [[ "$(ls -A "$PW_DIR" 2>/dev/null)" ]]; then
-    pass "Playwright browsers 已安装"
+
+  local PW_DIR
+  [[ "$(uname)" == "Darwin" ]] && PW_DIR="$HOME/Library/Caches/ms-playwright" || PW_DIR="$HOME/.cache/ms-playwright"
+
+  if [[ -d "$PW_DIR/chromium-$REVISION" ]]; then
+    pass "Playwright browsers (chromium-$REVISION)"
   else
-    fail "Playwright browsers — 未安装" "npx playwright install"
+    fail "Playwright browsers — 需要 chromium-$REVISION" "npx playwright install"
   fi
 }
 


### PR DESCRIPTION
## Summary

- Pin `@playwright/test` to exact version `1.59.1` (remove caret) to prevent `npm install` resolving newer versions whose browser binaries aren't locally cached
- Replace naive "any browser directory exists" check in `check-deps.sh` with version-aware validation that reads the expected chromium revision from `playwright-core/browsers.json`
- Handle `set -e` interaction: `|| true` prevents script abort when `node_modules` is missing

## Test plan

- [x] `check-deps.sh --scope deploy` passes on repo with correct browsers installed
- [x] Reports `[FAIL]` with correct revision when browser binary is missing
- [x] Reports `[FAIL]` gracefully when `playwright-core` is absent from `node_modules`
- [x] `"undefined"` edge case handled (future-proofs against schema changes)