### PR TITLE
fix(deep-research): harvest 步数耗尽改强制收尾，不再丢弃已采证据

### DIFF
--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -1007,7 +1007,7 @@ def make_client_factory(config):
 # Panel worker driver
 # ---------------------------------------------------------------------------
 
-def build_system_prompt(goal_text, local_manifest, alias):
+def build_system_prompt(goal_text, local_manifest, alias, max_steps):
     lines = [
         "You are one member of a multi-model research panel. Decompose the "
         "research goal independently and collect evidence with the tools.",
@@ -1020,6 +1020,12 @@ def build_system_prompt(goal_text, local_manifest, alias):
         "excerpt must be copied from the original text.",
         "3. Only cite text that literally appears in a tool result.",
         "4. Search in both Chinese and English for each core concept.",
+        f"5. You have a budget of about {max_steps} tool-use rounds.",
+        "6. Search bilingually to map sources first, then fetch the most relevant "
+        "few, then STOP and output the findings JSON.",
+        "7. A reliable partial result is better than being cut off empty-handed -- "
+        "converge before the budget runs out rather than searching breadth-first "
+        "until the wall.",
         "Final output must be exactly one JSON code block with schema: "
         '{"claims": [{"claim": "...", "excerpt": "...", "url": "...", '
         '"credibility": 1-5, "language": "zh|en|..."}], '
@@ -1051,6 +1057,52 @@ class WorkerResult:
         self.rejected_claims = rejected_claims or []
 
 
+def append_or_merge_user(messages, text):
+    """Append `text` as a new user turn, unless the trailing message is
+    already role=user -- gateways reject two consecutive user-role messages
+    with a 400, and the parse-retry / citation-retry paths both leave a
+    role=user message as the last turn, so a forced-synthesis nudge landing
+    right after one of those retries must merge into it instead of piling on
+    a second one. `content` on a message can be a plain string or a list of
+    content blocks (multi-part messages) -- merge according to whichever
+    shape is already there rather than assuming str."""
+    if messages and messages[-1]["role"] == "user":
+        content = messages[-1]["content"]
+        if isinstance(content, list):
+            content.append({"type": "text", "text": text})
+        elif isinstance(content, str):
+            messages[-1]["content"] = content + "\n" + text
+        else:
+            # Unexpected content shape -- fall back to a safe string merge
+            # rather than guessing at block structure.
+            messages[-1]["content"] = str(content) + "\n" + text
+    else:
+        messages.append({"role": "user", "content": text})
+
+
+def finalize_findings(alias, model_id, data, journal):
+    """Shared tail of the findings pipeline: assign per-claim IDs, verify
+    every citation against the journal, and assemble the OK WorkerResult.
+    Used both by the loop's normal end-of-turn finalize and by the forced-
+    synthesis path after the step budget is exhausted -- both start from a
+    freshly parsed findings dict and finish identically. The citation-retry
+    branch (loop only, at most once per worker) runs *before* this is
+    called; this function never retries, it only finalizes."""
+    claims = assign_claim_ids(alias, data["claims"])
+    fetch_index = build_fetch_index(journal)
+    journal_urls = build_journal_url_set(journal)
+    valid, invalid = validate_claims(claims, fetch_index, journal_urls)
+    data["claims"] = valid
+    data["invalid_claim_count"] = len(invalid)
+    return WorkerResult(alias, model_id, "OK", data, journal, None, rejected_claims=build_rejected_claims(invalid))
+
+
+_FORCED_SYNTHESIS_PROMPT = (
+    "Tool-use budget exhausted. Based ONLY on the evidence you have already "
+    "fetched, output the findings JSON now. Do not call any more tools."
+)
+
+
 def run_worker(alias, model_id, client, config, search_backends, fetch_backends,
                 goal_text, local_manifest, local_dir):
     journal = []
@@ -1059,7 +1111,8 @@ def run_worker(alias, model_id, client, config, search_backends, fetch_backends,
         max_steps = limits["max_steps_per_model"]
         deadline = time.monotonic() + limits["wall_clock_s"]
         messages = [
-            {"role": "system", "content": build_system_prompt(goal_text, local_manifest, alias)},
+            {"role": "system", "content": build_system_prompt(goal_text, local_manifest, alias,
+                                                                limits["max_steps_per_model"])},
             {"role": "user", "content": goal_text},
         ]
         parse_retry_used = False
@@ -1097,11 +1150,28 @@ def run_worker(alias, model_id, client, config, search_backends, fetch_backends,
                 messages.append({"role": "user", "content": build_citation_feedback(invalid)})
                 continue
 
-            data["claims"] = valid
-            data["invalid_claim_count"] = len(invalid)
-            return WorkerResult(alias, model_id, "OK", data, journal, None, rejected_claims=build_rejected_claims(invalid))
+            return finalize_findings(alias, model_id, data, journal)
 
-        return WorkerResult(alias, model_id, "FAILED", None, journal, "step_limit_exceeded")
+        # Step budget exhausted without a normal finalize above -- rather
+        # than discard every claim already fetched (the old behavior:
+        # instant FAILED, throwing away real evidence and risking a
+        # below-quorum panel), force one last no-tools synthesis call so
+        # the worker converts whatever it already gathered into findings.
+        # append_or_merge_user (not a plain append) because the last
+        # message here can already be role=user -- a parse-retry or
+        # citation-retry nudge that ran out of turns before the model
+        # could respond to it -- and two consecutive user messages trip a
+        # 400 on most gateways.
+        append_or_merge_user(messages, _FORCED_SYNTHESIS_PROMPT)
+        resp = client.complete(messages=messages, tools=None)
+        message = _extract_message(resp)
+        if message is None:
+            return WorkerResult(alias, model_id, "FAILED", None, journal, "step_limit_no_synthesis")
+        content = message.get("content") or ""
+        data, err = parse_findings_json(content)
+        if err:
+            return WorkerResult(alias, model_id, "FAILED", None, journal, "step_limit_no_synthesis")
+        return finalize_findings(alias, model_id, data, journal)
     except Exception as e:
         return WorkerResult(alias, model_id, "FAILED", None, journal, f"exception: {e}")
 

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -37,15 +37,23 @@ def base_config(**overrides):
 
 
 class ScriptedClient:
-    """Fake OpenAI-compatible client: returns canned responses in order."""
+    """Fake OpenAI-compatible client: returns canned responses in order.
+    Also records a shallow snapshot of the messages list passed to each
+    complete() call (message dicts are appended-only past this point, never
+    mutated in place after being recorded here -- except by
+    append_or_merge_user's in-place merge, which by construction only ever
+    touches the *last* message and only runs before this snapshot is taken,
+    so the snapshot always reflects what the model actually received)."""
 
     def __init__(self, responses):
         self._responses = list(responses)
         self.calls = 0
+        self.messages_log = []
 
     def complete(self, messages, tools):
         resp = self._responses[self.calls]
         self.calls += 1
+        self.messages_log.append(list(messages))
         if callable(resp):
             return resp(messages, tools)
         return resp
@@ -1412,18 +1420,67 @@ class TestWorkerDriver(unittest.TestCase):
         result = self._run(client)
         self.assertEqual(result.status, "OK")
 
-    def test_step_limit_exhaustion_fails_gracefully(self):
+    def test_step_limit_triggers_forced_synthesis_returns_ok(self):
+        # Budget exhausted after two fetch-only rounds must no longer throw
+        # the already-fetched evidence away -- the forced no-tools
+        # synthesis call (the 3rd client.complete()) gets one last chance
+        # to turn it into findings, and here it does.
+        cfg = base_config()
+        cfg["limits"]["max_steps_per_model"] = 2
+        fact = "Rayleigh scattering explains the blue sky."
+        client = ScriptedClient([
+            assistant_tool_call("c1", "fetch", {"url": "https://a.com/1"}),
+            assistant_tool_call("c2", "fetch", {"url": "https://a.com/2"}),
+            assistant_final(findings_block([
+                {"claim": "c", "excerpt": fact, "url": "https://a.com/2", "credibility": 4, "language": "en"}])),
+        ])
+        with mock.patch("harvest.call_fetch_backend", return_value=fact):
+            result = harvest.run_worker("m1", "model-a", client, cfg, [], self.fetch_backends, "goal", [], None)
+        self.assertEqual(client.calls, 3)
+        self.assertEqual(result.status, "OK")
+        self.assertEqual(len(result.findings["claims"]), 1)
+        self.assertEqual(result.findings["invalid_claim_count"], 0)
+
+    def test_forced_synthesis_still_empty_stays_failed(self):
+        # Forced synthesis is the last chance, not another retry loop -- if
+        # it still comes back invalid/empty, the worker fails with a reason
+        # distinct from the old step_limit_exceeded so callers can tell
+        # "never even tried to synthesize" apart from "tried and failed".
         cfg = base_config()
         cfg["limits"]["max_steps_per_model"] = 2
         client = ScriptedClient([
             assistant_tool_call("c1", "fetch", {"url": "https://a.com/1"}),
             assistant_tool_call("c2", "fetch", {"url": "https://a.com/2"}),
-            assistant_tool_call("c3", "fetch", {"url": "https://a.com/3"}),
+            assistant_final("not valid json"),
         ])
         with mock.patch("harvest.call_fetch_backend", return_value="text"):
             result = harvest.run_worker("m1", "model-a", client, cfg, [], self.fetch_backends, "goal", [], None)
+        self.assertEqual(client.calls, 3)
         self.assertEqual(result.status, "FAILED")
-        self.assertEqual(result.reason, "step_limit_exceeded")
+        self.assertEqual(result.reason, "step_limit_no_synthesis")
+
+    def test_forced_synthesis_after_retry_no_consecutive_user(self):
+        # If the step budget runs out right after a citation-retry nudge
+        # (which leaves messages[-1] as role=user), the forced-synthesis
+        # prompt must merge into that message rather than append a second
+        # consecutive user turn -- most gateways 400 on that.
+        cfg = base_config()
+        cfg["limits"]["max_steps_per_model"] = 1
+        client = ScriptedClient([
+            assistant_final(findings_block([
+                {"claim": "c", "excerpt": "never fetched text", "url": "https://a.com/x"}])),
+            assistant_final(findings_block([])),
+        ])
+        result = harvest.run_worker("m1", "model-a", client, cfg, [], self.fetch_backends, "goal", [], None)
+        self.assertEqual(result.status, "OK")
+        forced_messages = client.messages_log[1]
+        roles = [m["role"] for m in forced_messages]
+        for i in range(len(roles) - 1):
+            self.assertFalse(roles[i] == "user" and roles[i + 1] == "user",
+                              f"consecutive user turns at index {i}: {forced_messages}")
+        self.assertEqual(forced_messages[-1]["role"], "user")
+        self.assertIn("citation verification", forced_messages[-1]["content"])
+        self.assertIn("Tool-use budget exhausted", forced_messages[-1]["content"])
 
     def test_worker_exception_isolated_not_raised(self):
         class ExplodingClient:
@@ -1449,6 +1506,39 @@ class TestWorkerDriver(unittest.TestCase):
         self.assertEqual(result.status, "OK")
         claim = result.findings["claims"][0]
         self.assertNotIn("language", claim)  # absent optional field not injected at worker level
+
+
+class TestAppendOrMergeUser(unittest.TestCase):
+    """Direct unit tests for the append_or_merge_user helper -- covers both
+    content shapes a message can carry (plain string, and a list of
+    OpenAI-style content blocks) independent of run_worker's own retry
+    plumbing."""
+
+    def test_appends_new_user_turn_when_last_is_not_user(self):
+        messages = [{"role": "system", "content": "sys"}, {"role": "assistant", "content": "hi"}]
+        harvest.append_or_merge_user(messages, "nudge")
+        self.assertEqual(len(messages), 3)
+        self.assertEqual(messages[-1], {"role": "user", "content": "nudge"})
+
+    def test_appends_new_user_turn_when_messages_empty(self):
+        messages = []
+        harvest.append_or_merge_user(messages, "nudge")
+        self.assertEqual(messages, [{"role": "user", "content": "nudge"}])
+
+    def test_merges_into_trailing_user_str_content(self):
+        messages = [{"role": "user", "content": "first nudge"}]
+        harvest.append_or_merge_user(messages, "second nudge")
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]["content"], "first nudge\nsecond nudge")
+
+    def test_merges_into_trailing_user_list_content_without_typeerror(self):
+        messages = [{"role": "user", "content": [{"type": "text", "text": "first nudge"}]}]
+        harvest.append_or_merge_user(messages, "second nudge")
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]["content"], [
+            {"type": "text", "text": "first nudge"},
+            {"type": "text", "text": "second nudge"},
+        ])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 变更

修复 harvest.py 步数预算耗尽时丢弃已采证据的 bug（详见 #41）。

**根因**：`run_worker` 的 LLM 步数预算耗尽即判 FAILED、丢弃该 worker 已 fetch 的全部证据；多 worker 同时踩坑使 panel 跌破 quorum → `exit 3 UNAVAILABLE`。真病灶是"步数预算是断头台"，不是模型没研究出来。

**方案 D**（prompt 收敛纪律 + 强制收尾兜底）：
- `build_system_prompt` 增 `max_steps` 参 + 预算/收敛纪律，引导先搜后取再收敛。
- 循环耗尽后发一次 `tools=None` 强制 synthesis，复用现成引用机械门榨出已 fetch 证据；引用校验不放松，新 reason `step_limit_no_synthesis`。
- 新增 `append_or_merge_user`（防连续 user role 触发网关 400，兼容 str/list content）+ `finalize_findings`（消除定稿重复）。
- 不动 quorum/judge/预算单位，不降低成功标准；`wall_clock` 硬停语义保持不变。

## 测试

- 移除 `test_step_limit_exhaustion_fails_gracefully`（语义已变）。
- 新增：强制收尾成功 / 失败兜底 / role 交替回归 3 条 + `TestAppendOrMergeUser` 4 条。
- 全套 **212/212** 通过。

Closes #41
