### PR TITLE
docs(deep-research): 同步强制收尾架构方案 + bump v1.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/agents/research-harvester.md
+++ b/plugins/deep-research/agents/research-harvester.md
@@ -51,6 +51,8 @@ Lead 的采集指令，必须包含：
 | 4 | 解读 merged 输出：共识标签、coverage_gaps、blind_spots | 补采裁判指出的 gaps（若有） |
 | 5 | 执行 Sanitization（脱敏落盘到 `pipeline/2_cleaned/`） | 同现行流程 |
 
+**单模型 step 预算耗尽 = 强制收尾，非该模型失败**：每个 panel 模型的 agentic loop 有 `max_steps_per_model` 轮工具预算。预算耗尽时 harvest.py **不丢弃该模型已 fetch 的证据**，而是强制发一次禁用工具的收尾 synthesis 调用，把已采证据收敛成 findings 并走引用机械门校验；只有收尾仍无合法产出才判该模型 `step_limit_no_synthesis` 失败。因此单个模型跑到步数上限通常仍会贡献有效 claims，不必视为异常——真正影响整轮的是存活模型数是否达 quorum（见下 exit 3）。
+
 **exit 3（`verdict: UNAVAILABLE`，多模型采集不可用）时，harvester 必须立即停止并上报 Lead，严禁自行转 legacy 手工采集继续**——不完整调研冒充完整调研比失败更糟。恢复路径见 deep-research skill 的 references/quality-gates.md（引用校验机械门章节）。
 
 **exit 4**（config 声明了 `curl-cffi` fetch 后端但本机未安装 `curl_cffi`）：不是采集失败，是环境未就绪。按 stderr 输出的指引执行 `pip3 install --user curl_cffi` 后原样重跑第 3 步即可，不需要上报 Lead，也不消耗任何 API 调用（检查发生在 harvest.py 触碰状态文件之前）。

--- a/plugins/deep-research/skills/deep-research/references/web-research.md
+++ b/plugins/deep-research/skills/deep-research/references/web-research.md
@@ -65,6 +65,8 @@ python3 <harvest.py 路径> run --goal-file intake/requirements/research-goal.md
 
 三个异构面板模型（由 `harvest.config.json` 的 `panel_models` 配置，当前为 gemini/gpt/claude 三家族）并行各跑独立 agentic loop 自主检索，内部 search 后端链按优先级降级（agy-cli → 网关 gemini → tavily → DuckDuckGo 兜底，见 [context-economics.md](./context-economics.md)）；merge 阶段裁判模型产出共识标签与 Fusion 五元组分析，落盘 `merged-findings.json` + 带机械门数据的 `fetch-report.md`。exit 3（`UNAVAILABLE`）时 harvester 停止并上报 Lead，**不自行转 fallback**（见 deep-research 插件的 research-harvester subagent 工具链）。
 
+**agentic loop 收敛语义（强制收尾兜底）**：每个 panel worker 的 loop 有 `max_steps_per_model` 轮工具预算（LLM 回合数，非工具调用数），system prompt 会告知该预算并引导「先双语搜索摸清源 → fetch 最相关几篇 → 主动停下吐 findings JSON」。**预算耗尽不再直接丢弃已采证据**：loop 结束后强制发一次 `tools=None` 的收尾 synthesis 调用，让 worker 把已 fetch 的证据收敛成 findings，再走同一套引用机械门校验（追不到已 fetch 内容的 claim 照剔）。收尾仍无合法产出才判 `step_limit_no_synthesis` 失败。此设计避免「worker 采足证据却因未主动收尾被整个作废、进而拖垮 quorum」。`wall_clock_s` 超时是另一条独立硬停路径（濒临墙钟死线不再追加调用），不走强制收尾。
+
 **fallback 链（仅未启用 harvest.py 或经用户豁免 `legacy-exemption.md`）**：
 
 **1. Gemini CLI（主力）**


### PR DESCRIPTION
## 变更

harvest.py 步数耗尽改强制收尾（#41，PR #42 已合并）的收尾：同步架构文档 + 版本 bump。

- **web-research.md**：补 panel worker agentic loop 的收敛语义——预算耗尽强制收尾兜底（`tools=None` synthesis 榨出已 fetch 证据、走引用机械门），`wall_clock` 独立硬停不走收尾。
- **research-harvester.md**：明确"单模型 step 耗尽 = 强制收尾，非该模型失败"，避免 harvester 误判 verdict。
- **版本 bump 1.0.0 → 1.0.1**：`plugin.json` + `marketplace.json` 两处同步，确保 marketplace 分发元数据与插件实际版本一致（否则客户端 `/plugin` 更新拉不到修复）。

关联 #41。文档层，无代码/测试变更。
