### PR TITLE
feat(deep-research): claude 走 Anthropic 原生路径启用 prompt caching (v1.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest.config.json
+++ b/plugins/deep-research/scripts/harvest.config.json
@@ -51,6 +51,7 @@
     "max_steps_per_model": 16,
     "call_timeout_s": 180,
     "completion_timeout_s": 600,
+    "completion_max_tokens": 16384,
     "wall_clock_s": 1800,
     "quorum": 2,
     "search_min_interval_s": 2,

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -1059,6 +1059,8 @@ def _anthropic_post_with_retry(url, payload, headers, timeout):
             if attempt - 1 >= len(backoffs):
                 raise RuntimeError(f"Anthropic network error after {attempt} attempts: {e}") from e
             time.sleep(backoffs[attempt - 1])
+
+
 def _oai_tools_to_anthropic(tools):
     """OpenAI function-tool schema -> Anthropic tool schema. Returns None when
     there are no tools (judge path passes tools=None) so the caller can omit
@@ -1317,16 +1319,17 @@ def _mark_message_tail(messages):
 def _inject_cache_control(system, tools, messages):
     """Attach cache_control breakpoints in place for maximal prefix caching.
 
-    system is passed through unchanged here: the outbound payload always
-    sends system as a top-level string (see AnthropicGatewayClient.complete),
-    and cache_control cannot ride on a bare string, so the system breakpoint
-    is applied by _inject_cache_control's caller only when system is a block
-    list. To keep the static prefix (tools+system) cacheable we convert system
-    to a single cache-marked text block right here when it is a non-empty
-    string, and mark the tail when it is already a block list.
+    cache_control cannot ride on a bare string, so a non-empty system string
+    is promoted here into a single cache-marked text block list (Anthropic
+    accepts system as either a string or a block list); an already-block-list
+    system just gets its tail marked. Because this rewrites system, the value
+    is RETURNED and AnthropicGatewayClient.complete must send the returned
+    system in the payload -- tools and messages are mutated in place. An empty
+    or None system is returned untouched (nothing cacheable).
 
-    Returns the (possibly rewritten) system value so the caller can use it
-    for the payload -- tools and messages are mutated in place."""
+    Breakpoints: tools tail + system tail (static prefix) + last message
+    content block (see _mark_message_tail). Returns the (possibly rewritten)
+    system value."""
     if tools:
         _mark_block_list_tail(tools)
     if isinstance(system, str) and system:

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -1172,9 +1172,16 @@ def _append_user_blocks(anth, content):
     present (Anthropic rejects two consecutive user messages). `content` may
     be a str, a single block dict, or a list of blocks; the merged turn is
     normalized to a block list when mixing shapes."""
-    if content is None:
-        content = ""
-    incoming = content if isinstance(content, list) else [content] if isinstance(content, dict) else [{"type": "text", "text": content}]
+    if isinstance(content, list):
+        incoming = content
+    elif isinstance(content, dict):
+        incoming = [content]
+    elif content:  # non-empty string
+        incoming = [{"type": "text", "text": content}]
+    else:  # None or "" -> contribute nothing; never fabricate an empty text
+        incoming = []  # block (Anthropic rejects empty text blocks -> 400)
+    if not incoming:
+        return
     if anth and anth[-1]["role"] == "user":
         existing = anth[-1]["content"]
         if isinstance(existing, str):

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -1008,6 +1008,335 @@ class GatewayClient:
         return _http_json_post_with_retry(url, payload, headers, self.timeout_s)
 
 
+# ---------------------------------------------------------------------------
+# Anthropic-native client (claude models only)
+#
+# claude models get a dedicated path to the gateway's Anthropic-native
+# /messages endpoint (not the OpenAI-compatible /chat/completions used for
+# gemini/gpt) so that prompt caching (cache_control) actually takes effect --
+# the OpenAI-compat conversion in the gateway silently drops cache_control,
+# so claude via that path never caches. This client speaks the exact same
+# complete(messages, tools) -> OpenAI-shaped-dict interface as GatewayClient,
+# so run_worker / judge_clusters stay identical; all protocol translation is
+# confined to the pure functions below.
+# ---------------------------------------------------------------------------
+
+def _read_http_error_body(e):
+    """Best-effort read of an HTTPError's response body so Anthropic's own
+    error diagnostics (e.g. {"error":{"message":"messages: roles must
+    alternate ..."}}) survive into the raised exception instead of being
+    swallowed as a bare status code."""
+    try:
+        return e.read().decode("utf-8", "replace")[:800]
+    except Exception:
+        return "<error body unavailable>"
+
+
+def _anthropic_post_with_retry(url, payload, headers, timeout):
+    """Retry wrapper for the Anthropic /messages endpoint. Unlike the OpenAI
+    gateway path, a non-transient 4xx (400/401/403/404) is NOT retried -- a
+    malformed request body fails identically on a resend, so we surface the
+    Anthropic error body immediately for debugging. Only 429/408/5xx and
+    network-layer failures follow the transient backoff schedule. HTTPError
+    is caught before URLError (its parent) so the status-bearing case isn't
+    swallowed."""
+    backoffs = _GATEWAY_RETRY_BACKOFFS_TRANSIENT
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            return _http_json_post(url, payload, headers, timeout)
+        except urllib.error.HTTPError as e:
+            status = e.code
+            transient = status in (429, 408) or 500 <= status < 600
+            body = _read_http_error_body(e)
+            if not transient:
+                raise RuntimeError(f"Anthropic HTTP {status}: {body}") from e
+            if attempt - 1 >= len(backoffs):
+                raise RuntimeError(f"Anthropic HTTP {status} after {attempt} attempts: {body}") from e
+            time.sleep(backoffs[attempt - 1])
+        except (urllib.error.URLError, socket.timeout, TimeoutError) as e:
+            if attempt - 1 >= len(backoffs):
+                raise RuntimeError(f"Anthropic network error after {attempt} attempts: {e}") from e
+            time.sleep(backoffs[attempt - 1])
+def _oai_tools_to_anthropic(tools):
+    """OpenAI function-tool schema -> Anthropic tool schema. Returns None when
+    there are no tools (judge path passes tools=None) so the caller can omit
+    the field entirely rather than send tools:null / tools:[]."""
+    if not tools:
+        return None
+    out = []
+    for t in tools:
+        fn = t.get("function", {})
+        out.append({
+            "name": fn.get("name", ""),
+            "description": fn.get("description", ""),
+            "input_schema": fn.get("parameters", {"type": "object", "properties": {}}),
+        })
+    return out
+
+
+def _assistant_to_anthropic_content(msg):
+    """Convert one OpenAI assistant message into an Anthropic assistant
+    content-block list: leading text block (only if non-empty -- Anthropic
+    rejects empty text blocks) followed by one tool_use block per tool_call.
+    A plain-text assistant turn (no tool_calls) returns its string content
+    directly. tool_call arguments are JSON strings (json.dumps output on the
+    outbound side); json.loads restores the dict for tool_use.input, tolerant
+    of a malformed/empty string."""
+    tool_calls = msg.get("tool_calls") or []
+    text = msg.get("content")
+    if not tool_calls:
+        # Plain assistant answer. Anthropic needs a non-empty content; fall
+        # back to a single space if the model somehow returned empty (should
+        # not happen on a no-tool turn, but never emit an empty text block).
+        return text if isinstance(text, str) and text else " "
+    blocks = []
+    if isinstance(text, str) and text:
+        blocks.append({"type": "text", "text": text})
+    for tc in tool_calls:
+        fn = tc.get("function", {})
+        try:
+            args = json.loads(fn.get("arguments") or "{}")
+        except json.JSONDecodeError:
+            args = {}
+        blocks.append({
+            "type": "tool_use",
+            "id": tc.get("id", ""),
+            "name": fn.get("name", ""),
+            "input": args,
+        })
+    return blocks
+
+
+def _oai_messages_to_anthropic(messages):
+    """Split an OpenAI-style messages list into (system, anthropic_messages).
+
+    - role=system  -> hoisted into the top-level `system` (concatenated if
+      more than one; there is only ever one here in practice).
+    - role=user    -> passed through (content is str or a content-block list).
+    - role=assistant -> text + tool_use blocks (see helper).
+    - role=tool    -> a tool_result block; *consecutive* tool messages are
+      merged into a single user turn (Anthropic requires all tool_result
+      blocks answering the previous assistant's tool_use to live in one user
+      message). run_worker appends one role=tool per tool_call, so this run of
+      tool messages must collapse into one user turn.
+
+    Adjacent same-role user turns are also merged, mirroring the gateway's
+    "no two consecutive user messages" constraint that append_or_merge_user
+    already relies on."""
+    system_parts = []
+    anth = []
+    i = 0
+    n = len(messages)
+    while i < n:
+        msg = messages[i]
+        role = msg.get("role")
+        if role == "system":
+            content = msg.get("content")
+            if isinstance(content, str):
+                system_parts.append(content)
+            elif isinstance(content, list):
+                for blk in content:
+                    if isinstance(blk, dict) and blk.get("type") == "text":
+                        system_parts.append(blk.get("text", ""))
+            i += 1
+            continue
+        if role == "tool":
+            # Collapse the maximal run of consecutive tool messages into one
+            # user turn of tool_result blocks.
+            results = []
+            while i < n and messages[i].get("role") == "tool":
+                tmsg = messages[i]
+                results.append({
+                    "type": "tool_result",
+                    "tool_use_id": tmsg.get("tool_call_id", ""),
+                    "content": tmsg.get("content", ""),
+                })
+                i += 1
+            _append_user_blocks(anth, results)
+            continue
+        if role == "assistant":
+            anth.append({"role": "assistant", "content": _assistant_to_anthropic_content(msg)})
+            i += 1
+            continue
+        # role == user (or unknown -> treat as user)
+        _append_user_blocks(anth, msg.get("content"))
+        i += 1
+    system = "\n\n".join(p for p in system_parts if p) if system_parts else None
+    return system, anth
+
+
+def _append_user_blocks(anth, content):
+    """Append `content` as a user turn, merging into a trailing user turn if
+    present (Anthropic rejects two consecutive user messages). `content` may
+    be a str, a single block dict, or a list of blocks; the merged turn is
+    normalized to a block list when mixing shapes."""
+    if content is None:
+        content = ""
+    incoming = content if isinstance(content, list) else [content] if isinstance(content, dict) else [{"type": "text", "text": content}]
+    if anth and anth[-1]["role"] == "user":
+        existing = anth[-1]["content"]
+        if isinstance(existing, str):
+            existing = [{"type": "text", "text": existing}] if existing else []
+        elif isinstance(existing, dict):
+            existing = [existing]
+        existing.extend(incoming)
+        anth[-1]["content"] = existing
+    else:
+        anth.append({"role": "user", "content": incoming})
+
+
+def _anthropic_resp_to_oai(resp):
+    """Anthropic /messages response -> OpenAI chat-completions shape so
+    _extract_message (resp["choices"][0]["message"]) and the run_worker /
+    judge_clusters loops read it unchanged.
+
+    - text blocks are concatenated into `content`.
+    - tool_use blocks become OpenAI tool_calls (arguments re-serialized to a
+      JSON string via json.dumps, matching what the OpenAI path produces).
+    - content is a string for a text-only reply (judge / final synthesis rely
+      on a str here); it is None only when the turn is purely tool_use, which
+      run_worker's `message.get("content") or ""` and the inbound converter
+      both tolerate.
+    - stop_reason is surfaced as finish_reason for observability (e.g.
+      max_tokens truncation shows up instead of silently yielding half a
+      JSON blob)."""
+    content_blocks = resp.get("content") or []
+    text_parts = []
+    tool_calls = []
+    for blk in content_blocks:
+        btype = blk.get("type")
+        if btype == "text":
+            text_parts.append(blk.get("text", ""))
+        elif btype == "tool_use":
+            tool_calls.append({
+                "id": blk.get("id", ""),
+                "type": "function",
+                "function": {
+                    "name": blk.get("name", ""),
+                    "arguments": json.dumps(blk.get("input", {}), ensure_ascii=False),
+                },
+            })
+    message = {"role": "assistant"}
+    if tool_calls:
+        message["content"] = "".join(text_parts) if text_parts else None
+        message["tool_calls"] = tool_calls
+    else:
+        message["content"] = "".join(text_parts)
+    return {
+        "choices": [{"message": message, "finish_reason": resp.get("stop_reason")}],
+        "usage": resp.get("usage", {}),
+    }
+
+
+class AnthropicGatewayClient:
+    def __init__(self, base_url, api_key, model_id, timeout_s, max_tokens):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.model_id = model_id
+        self.timeout_s = timeout_s
+        self.max_tokens = max_tokens
+
+    def complete(self, messages, tools):
+        system, anth_messages = _oai_messages_to_anthropic(messages)
+        anth_tools = _oai_tools_to_anthropic(tools)
+        system = _inject_cache_control(system, anth_tools, anth_messages)
+        payload = {
+            "model": self.model_id,
+            "max_tokens": self.max_tokens,
+            "messages": anth_messages,
+        }
+        if system is not None:
+            payload["system"] = system
+        if anth_tools is not None:
+            payload["tools"] = anth_tools
+        url = self.base_url + "/messages"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+        }
+        resp = _anthropic_post_with_retry(url, payload, headers, self.timeout_s)
+        return _anthropic_resp_to_oai(resp)
+
+
+_CACHE_CONTROL = {"type": "ephemeral"}
+# Anthropic allows at most 4 cache breakpoints. We use 3: tools tail, system
+# tail, and the last message content block (the moving conversation
+# breakpoint). All use the default 5-minute TTL rather than the "1h" option:
+# a worker's agentic loop and the judge call all complete well inside 5
+# minutes, so the longer TTL buys nothing here while its 2x write cost and
+# the unsettled beta-header requirement for "ttl":"1h" (the docs don't state
+# whether it needs an anthropic-beta header) would only add risk. A
+# breakpoint caches the ENTIRE prefix up to and including its block, in the
+# fixed order tools -> system -> messages, so these three points let every
+# turn read the whole static prefix (tools+system) plus all prior history
+# from cache and pay full price only for the newest increment.
+
+
+def _mark_block_list_tail(blocks):
+    """Attach cache_control to the last cacheable (dict) block in a list.
+    Anthropic rejects cache_control on an empty text block, so skip a tail
+    block that is an empty-text block. No-op if there is no dict block."""
+    for blk in reversed(blocks):
+        if not isinstance(blk, dict):
+            continue
+        if blk.get("type") == "text" and not blk.get("text"):
+            continue
+        blk["cache_control"] = dict(_CACHE_CONTROL)
+        return True
+    return False
+
+
+def _mark_message_tail(messages):
+    """Move the conversation breakpoint onto the last content block of the
+    last message. String content is promoted to a one-text-block list so the
+    marker has somewhere to live (Anthropic accepts either shape); an empty
+    string is left untouched (nothing cacheable, and an empty text block is
+    rejected)."""
+    if not messages:
+        return
+    last = messages[-1]
+    content = last.get("content")
+    if isinstance(content, str):
+        if not content:
+            return
+        last["content"] = [{"type": "text", "text": content, "cache_control": dict(_CACHE_CONTROL)}]
+    elif isinstance(content, list) and content:
+        _mark_block_list_tail(content)
+
+
+def _inject_cache_control(system, tools, messages):
+    """Attach cache_control breakpoints in place for maximal prefix caching.
+
+    system is passed through unchanged here: the outbound payload always
+    sends system as a top-level string (see AnthropicGatewayClient.complete),
+    and cache_control cannot ride on a bare string, so the system breakpoint
+    is applied by _inject_cache_control's caller only when system is a block
+    list. To keep the static prefix (tools+system) cacheable we convert system
+    to a single cache-marked text block right here when it is a non-empty
+    string, and mark the tail when it is already a block list.
+
+    Returns the (possibly rewritten) system value so the caller can use it
+    for the payload -- tools and messages are mutated in place."""
+    if tools:
+        _mark_block_list_tail(tools)
+    if isinstance(system, str) and system:
+        system = [{"type": "text", "text": system, "cache_control": dict(_CACHE_CONTROL)}]
+    elif isinstance(system, list) and system:
+        _mark_block_list_tail(system)
+    _mark_message_tail(messages)
+    # Known limit: only the single moving message breakpoint is used, so if
+    # one turn ever appended >=20 content blocks (Anthropic's incremental-
+    # cache lookback window) the prior breakpoint would fall out of window and
+    # that one turn would miss cache. In this pipeline a turn adds ~2 blocks
+    # (one tool_use + one tool_result), so the window is never approached; a
+    # 4th "anchor" breakpoint would only pay off with heavy parallel tool use
+    # and is deliberately omitted to keep the strategy simple.
+    return system
+
+
 def make_client_factory(config):
     gw = config["gateway"]
     api_key = os.environ.get(gw["api_key_env"], "")
@@ -1019,8 +1348,21 @@ def make_client_factory(config):
     # doesn't KeyError; it just falls back to the same default declared in
     # harvest.config.json.
     timeout = config.get("limits", {}).get("completion_timeout_s", 600)
+    # Anthropic requires max_tokens; OpenAI treats it as optional so the
+    # OpenAI path never set it. Read from config with a generous default so
+    # large findings/judge outputs aren't truncated (truncation would surface
+    # as finish_reason=max_tokens and a half-parsed JSON). Same .get()-with-
+    # default back-compat pattern as completion_timeout_s.
+    max_tokens = config.get("limits", {}).get("completion_max_tokens", 16384)
 
     def factory(model_id):
+        # claude models go through the Anthropic-native /messages path so
+        # prompt caching can take effect; everything else (gemini/gpt) stays
+        # on the OpenAI-compatible /chat/completions gateway. Same
+        # complete(messages, tools) interface either way, so run_judge_with_
+        # fallback can freely mix the two client types across its candidates.
+        if model_id.startswith("claude"):
+            return AnthropicGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens)
         return GatewayClient(gw["base_url"], api_key, model_id, timeout)
 
     return factory

--- a/plugins/deep-research/skills/deep-research/references/web-research.md
+++ b/plugins/deep-research/skills/deep-research/references/web-research.md
@@ -71,6 +71,8 @@ python3 <harvest.py 路径> run --goal-file intake/requirements/research-goal.md
 
 **超时与重试（gateway completion 独立于 fetch）**：panel/judge 的 chat-completion 调用有独立超时 `completion_timeout_s`（`harvest.config.json` 的 `limits`，默认 **600s**），与 fetch/search 后端的 `call_timeout_s`（默认 180s）解耦——completion 要跑完整个 agentic 推理，长上下文下远超单次抓取耗时，二者共用一个超时会互相拖累。读取用带默认值的安全方式，旧 config 无该字段时回退 600s（向后兼容）。completion 调用的重试按**异常类归一**：HTTP 状态码错误（429/5xx）与网络层瞬时故障（读超时 `socket.timeout` / `URLError` 无状态码）走同一条 transient 退避链，避免「读超时穿透判死整个 worker」——最该重试的瞬时故障恰恰是无状态码那类。
 
+**claude 模型走 Anthropic 原生路径（prompt caching 生效）**：`panel_models` / `judge_model` 里模型名以 `claude` 开头的，由 `harvest.py` 的 `make_client_factory` 路由到 `AnthropicGatewayClient`——走网关的 Anthropic 原生 `/v1/messages` 入站，而非 gemini/gpt 用的 OpenAI 兼容 `/chat/completions`。原因：OpenAI 兼容转换路径会静默丢弃 `cache_control`，claude 经该路径**永远不缓存**；原生路径下 system/tools/messages 三处的 `cache_control` 原样透传给上游 Anthropic，prompt caching 真正生效（实测二次调用 `cache_read_input_tokens` 命中，历史 token 仅付 0.1× 价）。协议转换（OpenAI↔Anthropic 双向）封装在 client 内的模块级纯函数，`run_worker` / `judge_clusters` 循环零改动、仍只见 OpenAI 形状。缓存断点采**最大化**策略：tools 末块 + system 末块（静态前缀，一次写入长期复用）+ messages 最后一个 content block（每轮移动的会话断点），共 3 个断点（上限 4），全用默认 5min TTL（worker loop 与 judge 均远短于 5min，不必冒 1h TTL 的 beta-header 风险与 2× 写入成本）。`completion_max_tokens`（`limits`，默认 **16384**）为 Anthropic 必填的 `max_tokens` 供值，旧 config 无该字段时回退 16384。claude 原生路径的错误可观测性独立：非 transient 4xx（400 等协议错误）**不重试**，并把 Anthropic 返回的 error body 带进异常，便于现场调协议。
+
 **fallback 链（仅未启用 harvest.py 或经用户豁免 `legacy-exemption.md`）**：
 
 **1. Gemini CLI（主力）**

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -2499,6 +2499,28 @@ class TestAnthropicConversion(unittest.TestCase):
         results = anth[1]["content"]
         self.assertEqual([r["tool_use_id"] for r in results], ["a", "b"])
         self.assertTrue(all(r["type"] == "tool_result" for r in results))
+    def test_empty_user_content_produces_no_empty_text_block(self):
+        # Anthropic rejects empty text blocks; an empty/None user turn must
+        # contribute nothing rather than {"type":"text","text":""}.
+        for empty in ("", None):
+            _s, anth = harvest._oai_messages_to_anthropic([{"role": "user", "content": empty}])
+            for m in anth:
+                blocks = m["content"] if isinstance(m["content"], list) else []
+                for b in blocks:
+                    self.assertFalse(b.get("type") == "text" and b.get("text") == "",
+                                     f"empty text block leaked for content={empty!r}")
+
+    def test_empty_user_after_tool_result_does_not_append_empty_block(self):
+        # Merging an empty user turn into a trailing tool_result user turn must
+        # not tack on an empty text block.
+        msgs = [
+            {"role": "tool", "tool_call_id": "a", "content": "res"},
+            {"role": "user", "content": ""},
+        ]
+        _s, anth = harvest._oai_messages_to_anthropic(msgs)
+        user_blocks = anth[-1]["content"]
+        self.assertEqual([b["type"] for b in user_blocks], ["tool_result"])
+
     def test_no_two_consecutive_user_turns(self):
         # A tool-result user turn immediately followed by a user message must
         # merge, not produce back-to-back user turns (Anthropic 400).

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -2499,6 +2499,7 @@ class TestAnthropicConversion(unittest.TestCase):
         results = anth[1]["content"]
         self.assertEqual([r["tool_use_id"] for r in results], ["a", "b"])
         self.assertTrue(all(r["type"] == "tool_result" for r in results))
+
     def test_empty_user_content_produces_no_empty_text_block(self):
         # Anthropic rejects empty text blocks; an empty/None user turn must
         # contribute nothing rather than {"type":"text","text":""}.

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -2446,6 +2446,164 @@ class TestFetchReportRealStats(unittest.TestCase):
             tmpdir.cleanup()
 
 
+# ---------------------------------------------------------------------------
+# Anthropic-native client: OpenAI <-> Anthropic protocol conversion
+# ---------------------------------------------------------------------------
+
+class TestAnthropicConversion(unittest.TestCase):
+    def test_system_hoisted_to_top_level(self):
+        msgs = [{"role": "system", "content": "SYS"}, {"role": "user", "content": "hi"}]
+        system, anth = harvest._oai_messages_to_anthropic(msgs)
+        self.assertEqual(system, "SYS")
+        self.assertEqual(anth, [{"role": "user", "content": [{"type": "text", "text": "hi"}]}])
+
+    def test_no_system_yields_none(self):
+        system, anth = harvest._oai_messages_to_anthropic([{"role": "user", "content": "hi"}])
+        self.assertIsNone(system)
+
+    def test_assistant_tool_calls_become_tool_use_blocks(self):
+        msgs = [{"role": "assistant", "content": None,
+                 "tool_calls": [{"id": "tc1", "function": {"name": "search",
+                                 "arguments": json.dumps({"query": "中文"})}}]}]
+        _system, anth = harvest._oai_messages_to_anthropic(msgs)
+        self.assertEqual(anth[0]["role"], "assistant")
+        blocks = anth[0]["content"]
+        self.assertEqual(len(blocks), 1)  # no empty text block prepended
+        self.assertEqual(blocks[0]["type"], "tool_use")
+        self.assertEqual(blocks[0]["id"], "tc1")
+        self.assertEqual(blocks[0]["input"], {"query": "中文"})
+
+    def test_assistant_text_plus_tool_call(self):
+        msgs = [{"role": "assistant", "content": "thinking",
+                 "tool_calls": [{"id": "t", "function": {"name": "fetch", "arguments": "{}"}}]}]
+        _s, anth = harvest._oai_messages_to_anthropic(msgs)
+        blocks = anth[0]["content"]
+        self.assertEqual(blocks[0], {"type": "text", "text": "thinking"})
+        self.assertEqual(blocks[1]["type"], "tool_use")
+
+    def test_plain_assistant_returns_string(self):
+        _s, anth = harvest._oai_messages_to_anthropic([{"role": "assistant", "content": "answer"}])
+        self.assertEqual(anth[0]["content"], "answer")
+
+    def test_consecutive_tool_messages_merged_into_one_user_turn(self):
+        msgs = [
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "a", "function": {"name": "search", "arguments": "{}"}},
+                {"id": "b", "function": {"name": "fetch", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "a", "content": "resA"},
+            {"role": "tool", "tool_call_id": "b", "content": "resB"},
+        ]
+        _s, anth = harvest._oai_messages_to_anthropic(msgs)
+        self.assertEqual(len(anth), 2)  # assistant + single merged user
+        self.assertEqual(anth[1]["role"], "user")
+        results = anth[1]["content"]
+        self.assertEqual([r["tool_use_id"] for r in results], ["a", "b"])
+        self.assertTrue(all(r["type"] == "tool_result" for r in results))
+    def test_no_two_consecutive_user_turns(self):
+        # A tool-result user turn immediately followed by a user message must
+        # merge, not produce back-to-back user turns (Anthropic 400).
+        msgs = [
+            {"role": "tool", "tool_call_id": "a", "content": "res"},
+            {"role": "user", "content": "nudge"},
+        ]
+        _s, anth = harvest._oai_messages_to_anthropic(msgs)
+        user_turns = [m for m in anth if m["role"] == "user"]
+        self.assertEqual(len(user_turns), 1)
+        types = [b["type"] for b in user_turns[0]["content"]]
+        self.assertEqual(types, ["tool_result", "text"])
+
+    def test_tools_none_returns_none(self):
+        self.assertIsNone(harvest._oai_tools_to_anthropic(None))
+        self.assertIsNone(harvest._oai_tools_to_anthropic([]))
+
+    def test_tools_converted_to_input_schema(self):
+        anth = harvest._oai_tools_to_anthropic(harvest.TOOL_SCHEMAS)
+        self.assertEqual(len(anth), len(harvest.TOOL_SCHEMAS))
+        self.assertEqual(anth[0]["name"], "search")
+        self.assertIn("input_schema", anth[0])
+        self.assertNotIn("parameters", anth[0])
+
+    def test_outbound_text_only_content_is_string(self):
+        resp = {"content": [{"type": "text", "text": "hello"}], "stop_reason": "end_turn"}
+        oai = harvest._anthropic_resp_to_oai(resp)
+        msg = oai["choices"][0]["message"]
+        self.assertEqual(msg["content"], "hello")
+        self.assertNotIn("tool_calls", msg)
+        self.assertEqual(oai["choices"][0]["finish_reason"], "end_turn")
+
+    def test_outbound_tool_use_only_content_none(self):
+        resp = {"content": [{"type": "tool_use", "id": "x", "name": "search",
+                             "input": {"query": "q"}}], "stop_reason": "tool_use"}
+        msg = harvest._anthropic_resp_to_oai(resp)["choices"][0]["message"]
+        self.assertIsNone(msg["content"])
+        self.assertEqual(msg["tool_calls"][0]["id"], "x")
+        self.assertEqual(json.loads(msg["tool_calls"][0]["function"]["arguments"]), {"query": "q"})
+
+    def test_outbound_extract_message_compatible(self):
+        # _extract_message must read the converted shape unchanged.
+        resp = {"content": [{"type": "text", "text": "j"}], "stop_reason": "end_turn"}
+        oai = harvest._anthropic_resp_to_oai(resp)
+        self.assertEqual(harvest._extract_message(oai), oai["choices"][0]["message"])
+
+    def test_roundtrip_tool_use_idempotent(self):
+        # outbound -> append -> inbound must preserve id/name/input.
+        resp = {"content": [{"type": "tool_use", "id": "rid", "name": "fetch",
+                             "input": {"url": "http://x", "q": "中文查询"}},
+                            {"type": "text", "text": "note"}], "stop_reason": "tool_use"}
+        msg = harvest._anthropic_resp_to_oai(resp)["choices"][0]["message"]
+        _s, anth = harvest._oai_messages_to_anthropic([msg])
+        blocks = anth[0]["content"]
+        # text block first (non-empty), then tool_use with restored input
+        self.assertEqual(blocks[0], {"type": "text", "text": "note"})
+        tu = blocks[1]
+        self.assertEqual(tu["id"], "rid")
+        self.assertEqual(tu["name"], "fetch")
+        self.assertEqual(tu["input"], {"url": "http://x", "q": "中文查询"})
+
+    def test_cache_control_on_tools_tail_only(self):
+        tools = [{"name": "a", "input_schema": {}}, {"name": "b", "input_schema": {}}]
+        harvest._inject_cache_control(None, tools, [])
+        self.assertNotIn("cache_control", tools[0])
+        self.assertEqual(tools[1]["cache_control"], {"type": "ephemeral"})
+
+    def test_cache_control_promotes_system_string_to_block(self):
+        system = harvest._inject_cache_control("SYS", None, [])
+        self.assertEqual(system, [{"type": "text", "text": "SYS",
+                                   "cache_control": {"type": "ephemeral"}}])
+
+    def test_cache_control_empty_system_untouched(self):
+        self.assertIsNone(harvest._inject_cache_control(None, None, []))
+        self.assertEqual(harvest._inject_cache_control("", None, []), "")
+
+    def test_cache_control_on_message_tail_string_content(self):
+        msgs = [{"role": "user", "content": "hi"}]
+        harvest._inject_cache_control(None, None, msgs)
+        self.assertEqual(msgs[0]["content"],
+                         [{"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}])
+
+    def test_cache_control_on_message_tail_block_list(self):
+        msgs = [{"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "a", "content": "r1"},
+            {"type": "tool_result", "tool_use_id": "b", "content": "r2"}]}]
+        harvest._inject_cache_control(None, None, msgs)
+        blocks = msgs[0]["content"]
+        self.assertNotIn("cache_control", blocks[0])
+        self.assertEqual(blocks[1]["cache_control"], {"type": "ephemeral"})
+
+    def test_cache_control_skips_empty_tail_text_block(self):
+        # An empty text block cannot carry cache_control; mark the prior real
+        # block instead.
+        blocks = [{"type": "text", "text": "real"}, {"type": "text", "text": ""}]
+        harvest._mark_block_list_tail(blocks)
+        self.assertEqual(blocks[0]["cache_control"], {"type": "ephemeral"})
+        self.assertNotIn("cache_control", blocks[1])
+
+    def test_empty_message_content_not_marked(self):
+        msgs = [{"role": "user", "content": ""}]
+        harvest._inject_cache_control(None, None, msgs)
+        self.assertEqual(msgs[0]["content"], "")  # untouched, no empty block created
+
+
 class argparse_ns:
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)


### PR DESCRIPTION
## 摘要

给 harvest.py 的 claude 模型单开 Anthropic 原生 `/v1/messages` 路径,启用 prompt caching。此前所有模型统一走 OpenAI 兼容 `/chat/completions`,claude 经网关 OpenAI→Claude 转换会静默丢弃 `cache_control`,缓存完全没生效——成本高、速度慢。

## 设计:client 多态,worker/judge 循环零改动

- `AnthropicGatewayClient` 暴露与 `GatewayClient` 相同的 `complete(messages, tools)` 接口、返回 OpenAI 形状 dict,内部三个模块级纯函数做 OpenAI↔Anthropic 双向协议转换。
- `make_client_factory` 按 `model_id.startswith("claude")` 路由;gemini/gpt 走原路,`run_judge_with_fallback` 可自由混用两种 client。
- 缓存最大化断点:tools 末块 + system 末块(静态前缀,长期复用)+ messages 末 content block(每轮移动会话断点),共 3 断点(上限 4),默认 5min TTL。
- `completion_max_tokens`(config,默认 16384)供 Anthropic 必填的 `max_tokens`。
- claude 路径错误可观测性独立:非 transient 4xx(400 协议错误)不重试,带出 Anthropic error body 便于现场调协议。

## 测试

- **单测 236 passed**(新增 20 个转换/缓存单测:往返幂等、tool_use-only content 语义、连续 tool_result 合并成单 user turn、tools=None、cache_control 打点边界与空 text block 跳过)。
- **真实调用网关验证**:
  - claude-sonnet 二次调用 `cache_creation_input_tokens=1734` → `cache_read_input_tokens=1473`,prompt caching 端到端确认生效。
  - judge 路径(tools=None + 纯文本):content 为 str、无 tool_calls、payload 省略 tools 字段,通过。
  - 多轮 tool_use 往返(最险的 assistant tool_use + 连续 tool_result 回程合并):真调不 400。

## 范围外(YAGNI)

不做流式;不做超 20-block 回溯窗口的第 4 锚点断点(本管线每轮仅增 ~2 block);不碰 gemini/gpt 路径;不引第三方 SDK。

## 版本

deep-research 1.0.2 → 1.1.0(plugin.json + marketplace.json 同步)。

close #48
