### PR TITLE
fix(harvest): 采集鲁棒性三缺陷修复（v1.1.0 基线）

### DIFF
--- a/plugins/deep-research/scripts/harvest.config.json
+++ b/plugins/deep-research/scripts/harvest.config.json
@@ -55,6 +55,7 @@
     "wall_clock_s": 1800,
     "quorum": 2,
     "search_min_interval_s": 2,
+    "fetch_min_interval_s": 0.5,
     "fetch_max_chars": 20000
   },
   "blacklist_domains": [

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -1392,7 +1392,10 @@ def build_system_prompt(goal_text, local_manifest, alias, max_steps):
         "citing a bare search snippet is forbidden.",
         "2. excerpt must be 100% verbatim in the source's original language -- "
         "never translate, paraphrase, or truncate it. claim may be in Chinese; "
-        "excerpt must be copied from the original text.",
+        "excerpt must be copied from the original text. excerpt must be a "
+        "verbatim fragment of the fetched page's BODY content -- never "
+        "substitute the page title, a search-result snippet, a byline, or a "
+        "paper's title for it. A title is not body text.",
         "3. Only cite text that literally appears in a tool result.",
         "4. Search in both Chinese and English for each core concept.",
         f"5. You have a budget of about {max_steps} tool-use rounds.",

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -971,6 +971,39 @@ def execute_tool_call(tc, search_backends, fetch_backends, journal, config, loca
     return json.dumps({"error": f"unknown tool {name}"})
 
 
+_PARALLEL_FETCH_MAX_WORKERS = 3
+
+
+def _run_fetch_calls_parallel(tool_calls, search_backends, fetch_backends, journal, config, local_dir):
+    """Only called when every tool_call in this round is a `fetch` and there
+    is more than one -- mixed/search/single rounds stay on the plain
+    sequential path in run_worker. Each call still runs execute_tool_call ->
+    do_fetch in its own pool thread, so the SSRF guard's tool_request_guard
+    (thread-local) and the guarded socket.getaddrinfo() are entered on the
+    same thread that performs the actual DNS resolution -- do_fetch is the
+    parallel unit, the guard is never restructured out of it.
+
+    Returns results in the SAME ORDER as `tool_calls` (by original index),
+    not completion order -- as_completed()'s arrival order would otherwise
+    scramble which result_text pairs with which tool_call_id. A future that
+    raises is not propagated; it is converted to a synthetic tool-error
+    JSON string so every tool_call_id still gets exactly one role:tool
+    message (a missing one is a 400 on most gateways)."""
+    results = [None] * len(tool_calls)
+    with ThreadPoolExecutor(max_workers=min(len(tool_calls), _PARALLEL_FETCH_MAX_WORKERS)) as pool:
+        future_to_index = {
+            pool.submit(execute_tool_call, tc, search_backends, fetch_backends, journal, config, local_dir): i
+            for i, tc in enumerate(tool_calls)
+        }
+        for fut in as_completed(future_to_index):
+            i = future_to_index[fut]
+            try:
+                results[i] = fut.result()
+            except Exception as e:
+                results[i] = json.dumps({"error": f"parallel fetch failed: {e}"})
+    return results
+
+
 # ---------------------------------------------------------------------------
 # Backend registry (global instantiation, shared across worker threads)
 # ---------------------------------------------------------------------------
@@ -978,13 +1011,24 @@ def execute_tool_call(tc, search_backends, fetch_backends, journal, config, loca
 def build_backends(config):
     limiters = {}
 
-    def limiter_for(key):
+    def limiter_for(key, min_interval_s):
         if key not in limiters:
-            limiters[key] = RateLimiter(config["limits"]["search_min_interval_s"])
+            limiters[key] = RateLimiter(min_interval_s)
         return limiters[key]
 
-    search_backends = [(b, limiter_for(f"search:{i}")) for i, b in enumerate(config.get("search_backends", []))]
-    fetch_backends = [(b, limiter_for(f"fetch:{i}")) for i, b in enumerate(config.get("fetch_backends", []))]
+    limits = config["limits"]
+    search_interval = limits["search_min_interval_s"]
+    # fetch previously shared search's interval outright (wrong unit of
+    # concern: search backends are quota-limited external APIs, fetch
+    # backends are mostly our own outbound HTTP). Independent key with a
+    # fallback to the search interval so an older config missing this key
+    # still works exactly as before rather than KeyError-ing.
+    fetch_interval = limits.get("fetch_min_interval_s", search_interval)
+
+    search_backends = [(b, limiter_for(f"search:{i}", search_interval))
+                        for i, b in enumerate(config.get("search_backends", []))]
+    fetch_backends = [(b, limiter_for(f"fetch:{i}", fetch_interval))
+                       for i, b in enumerate(config.get("fetch_backends", []))]
     return search_backends, fetch_backends
 
 
@@ -1505,9 +1549,18 @@ def run_worker(alias, model_id, client, config, search_backends, fetch_backends,
             messages.append(message)
             tool_calls = message.get("tool_calls") or []
             if tool_calls:
-                for tc in tool_calls:
-                    result_text = execute_tool_call(tc, search_backends, fetch_backends, journal, config, local_dir)
-                    messages.append({"role": "tool", "tool_call_id": tc.get("id", ""), "content": result_text})
+                is_all_fetch = len(tool_calls) > 1 and all(
+                    tc.get("function", {}).get("name") == "fetch" for tc in tool_calls
+                )
+                if is_all_fetch:
+                    results = _run_fetch_calls_parallel(tool_calls, search_backends, fetch_backends,
+                                                          journal, config, local_dir)
+                    for tc, result_text in zip(tool_calls, results):
+                        messages.append({"role": "tool", "tool_call_id": tc.get("id", ""), "content": result_text})
+                else:
+                    for tc in tool_calls:
+                        result_text = execute_tool_call(tc, search_backends, fetch_backends, journal, config, local_dir)
+                        messages.append({"role": "tool", "tool_call_id": tc.get("id", ""), "content": result_text})
                 continue
 
             content = message.get("content") or ""

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -1752,23 +1752,23 @@ def compute_consensus_stats(merged):
 # Verify.json (single-exit-point writer, tombstones, state cleanup)
 # ---------------------------------------------------------------------------
 
-def write_verify_json(verify_dir, goal_hash, verdict, extra=None):
+def write_verify_json(verify_dir, goal_hash, verdict, extra=None, verify_filename=VERIFY_FILE):
     verify_dir.mkdir(parents=True, exist_ok=True)
     payload = {"verdict": verdict, "goal_file_sha256": goal_hash, "run_timestamp": time.time()}
     if extra:
         payload.update(extra)
-    (verify_dir / VERIFY_FILE).write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    (verify_dir / verify_filename).write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
     return payload
 
 
-def write_tombstone(verify_dir, goal_hash):
-    return write_verify_json(verify_dir, goal_hash, "RUNNING")
+def write_tombstone(verify_dir, goal_hash, verify_filename=VERIFY_FILE):
+    return write_verify_json(verify_dir, goal_hash, "RUNNING", verify_filename=verify_filename)
 
 
-def abort_unavailable(verify_dir, goal_hash, reason, extra=None):
+def abort_unavailable(verify_dir, goal_hash, reason, extra=None, verify_filename=VERIFY_FILE):
     payload = dict(extra or {})
     payload["reason"] = reason
-    write_verify_json(verify_dir, goal_hash, "UNAVAILABLE", payload)
+    write_verify_json(verify_dir, goal_hash, "UNAVAILABLE", payload, verify_filename=verify_filename)
     sys.exit(3)
 
 
@@ -1776,10 +1776,40 @@ def cleanup_stale_state(pipeline_dir, verify_dir, raw_dir):
     """Unconditional cleanup before any network request: a failed run must
     never let a hook read last run's stale verify.json / exemption and
     silently pass. The exemption is single-use -- rerunning run() means the
-    user is re-accepting the gate for this round."""
+    user is re-accepting the gate for this round.
+
+    Primary-track only: touches the main VERIFY_FILE/EXEMPTION and the main
+    raw_dir's shared artifacts. A supplementary (backfill) run must never
+    call this -- see cleanup_stale_supplementary_state()."""
     for f in (verify_dir / VERIFY_FILE, verify_dir / LEGACY_EXEMPTION_FILE):
         if f.exists():
             f.unlink()
+    merged_file = raw_dir / MERGED_FINDINGS_FILE
+    if merged_file.exists():
+        merged_file.unlink()
+    harvest_dir = raw_dir / HARVEST_SUBDIR
+    if harvest_dir.exists():
+        shutil.rmtree(harvest_dir)
+
+
+def track_verify_filename(raw_dir):
+    """Supplementary (backfill) runs get their own state file, named after
+    the --out subdirectory they write to, instead of sharing the primary
+    track's VERIFY_FILE -- see cmd_run()'s is_supplementary branch."""
+    return f"track_{raw_dir.name}.json"
+
+
+def cleanup_stale_supplementary_state(verify_dir, raw_dir, verify_filename):
+    """Supplementary-run counterpart of cleanup_stale_state(): scoped
+    strictly to this track's own state file (verify_dir/verify_filename)
+    and its own --out subdirectory (raw_dir). Must never touch the primary
+    track's VERIFY_FILE or LEGACY_EXEMPTION_FILE -- the main gate's
+    verdict is not this run's to clear. A track rerunning itself cleans up
+    only its own prior track file, so backfill runs don't accumulate
+    orphaned track_*.json files across retries."""
+    track_file = verify_dir / verify_filename
+    if track_file.exists():
+        track_file.unlink()
     merged_file = raw_dir / MERGED_FINDINGS_FILE
     if merged_file.exists():
         merged_file.unlink()
@@ -1967,9 +1997,36 @@ def cmd_run(args):
     _check_curl_cffi_available(config)
 
     raw_dir = Path(args.out)
-    pipeline_dir = raw_dir.parent
-    project_dir = pipeline_dir.parent
-    verify_dir = pipeline_dir / "verification"
+    # getattr(...) rather than args.project_dir: keeps this importable by
+    # older test/caller code that builds an args namespace without the new
+    # attribute at all.
+    project_dir_arg = getattr(args, "project_dir", None)
+    if project_dir_arg:
+        # Explicit --project-dir: pipeline_dir/verify_dir are re-anchored to
+        # it directly, never derived from raw_dir. This is what makes a
+        # supplementary run's --out (a subdirectory, e.g.
+        # pipeline/1_raw/track_A) safe -- the old raw_dir.parent/.parent
+        # derivation assumed --out was always exactly ".../pipeline/1_raw"
+        # and silently miscomputed project_dir for anything nested deeper.
+        project_dir = Path(project_dir_arg).resolve()
+        pipeline_dir = project_dir / "pipeline"
+        verify_dir = pipeline_dir / "verification"
+        # Supplementary (backfill) run iff --out isn't the canonical primary
+        # raw dir -- e.g. a subdirectory of it used to re-collect specific
+        # coverage_gaps without disturbing the main track's state.
+        is_supplementary = raw_dir.resolve() != (pipeline_dir / "1_raw").resolve()
+    else:
+        # Unchanged legacy derivation -- zero behavior change for existing
+        # callers that never pass --project-dir.
+        pipeline_dir = raw_dir.parent
+        project_dir = pipeline_dir.parent
+        verify_dir = pipeline_dir / "verification"
+        is_supplementary = False
+
+    # Supplementary runs get their own state file (track_<out-dir-name>.json)
+    # so they never overwrite the primary track's gate verdict; the primary
+    # gate (check_project()) only ever reads VERIFY_FILE.
+    verify_filename = track_verify_filename(raw_dir) if is_supplementary else VERIFY_FILE
 
     # canonical_goal_file (single shared resolver, same one check_project()
     # uses) is the sole source of truth for both the hash and the text that
@@ -1994,8 +2051,15 @@ def cmd_run(args):
     goal_text = canonical_goal_file.read_text(encoding="utf-8")
     goal_hash = hashlib.sha256(canonical_goal_file.read_bytes()).hexdigest()
 
-    cleanup_stale_state(pipeline_dir, verify_dir, raw_dir)
-    write_tombstone(verify_dir, goal_hash)
+    if is_supplementary:
+        # Never cleanup_stale_state() here -- that function unconditionally
+        # unlinks the PRIMARY VERIFY_FILE/EXEMPTION, which would erase the
+        # main track's already-recorded gate verdict. Scoped equivalent
+        # touches only this track's own state file + its own --out dir.
+        cleanup_stale_supplementary_state(verify_dir, raw_dir, verify_filename)
+    else:
+        cleanup_stale_state(pipeline_dir, verify_dir, raw_dir)
+    write_tombstone(verify_dir, goal_hash, verify_filename=verify_filename)
 
     try:
         install_ssrf_guard()
@@ -2032,13 +2096,15 @@ def cmd_run(args):
 
         if not quorum_met:
             abort_unavailable(verify_dir, goal_hash, "quorum not met",
-                               {"quorum_met": False, "models_alive": [r.alias for r in alive]})
+                               {"quorum_met": False, "models_alive": [r.alias for r in alive]},
+                               verify_filename=verify_filename)
 
         worker_findings_by_alias = {r.alias: r.findings for r in alive}
         judge_data, judge_err = run_judge_with_fallback(config, client_factory, worker_findings_by_alias, config["panel_models"])
         if judge_data is None:
             abort_unavailable(verify_dir, goal_hash, f"judge failed: {judge_err}",
-                               {"quorum_met": True, "models_alive": [r.alias for r in alive]})
+                               {"quorum_met": True, "models_alive": [r.alias for r in alive]},
+                               verify_filename=verify_filename)
 
         merged = merge_findings(worker_findings_by_alias, judge_data)
         consensus_stats = compute_consensus_stats(merged)
@@ -2061,12 +2127,12 @@ def cmd_run(args):
             "invalid_claim_count": invalid_total,
             "consensus_stats": consensus_stats,
             "total_claims": total_claims,
-        })
+        }, verify_filename=verify_filename)
         print(f"harvest run complete: verdict={verdict}")
     except SystemExit:
         raise
     except Exception as e:
-        abort_unavailable(verify_dir, goal_hash, f"unexpected error: {e}")
+        abort_unavailable(verify_dir, goal_hash, f"unexpected error: {e}", verify_filename=verify_filename)
 
 
 _VERDICT_EXIT_CODES = {"PASS": 0, "FAIL": 1, "N_A": 2}
@@ -2087,6 +2153,12 @@ def build_arg_parser():
     run_p.add_argument("--out", required=True)
     run_p.add_argument("--config", default=str(Path(__file__).with_name("harvest.config.json")))
     run_p.add_argument("--local-dir", default=None)
+    run_p.add_argument("--project-dir", default=None,
+                        help="Explicit project root; pipeline_dir/verify_dir are anchored to it "
+                             "instead of being derived from --out's parent directories. Required "
+                             "for a supplementary/backfill run where --out is a subdirectory of "
+                             "the primary pipeline/1_raw (otherwise the old raw_dir.parent.parent "
+                             "derivation miscomputes the project root).")
     run_p.set_defaults(func=cmd_run)
 
     check_p = sub.add_parser("check")

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -142,6 +142,79 @@ class TestRateLimiter(unittest.TestCase):
         self.assertGreaterEqual(total_span, 4 * 0.02 * 0.6)
 
 
+class TestBuildBackendsFetchInterval(unittest.TestCase):
+    """Defect 2 (rate-limit decoupling): fetch backends must get their own
+    fetch_min_interval_s, not search's -- with a fallback to the search
+    interval so an older config missing the new key doesn't KeyError."""
+
+    def test_fetch_backend_uses_independent_interval_when_key_present(self):
+        config = base_config(
+            search_backends=[{"type": "duckduckgo"}],
+            fetch_backends=[{"type": "urllib-ua"}],
+        )
+        config["limits"]["search_min_interval_s"] = 2.0
+        config["limits"]["fetch_min_interval_s"] = 0.5
+        _, fetch_backends = harvest.build_backends(config)
+        limiter = fetch_backends[0][1]
+        self.assertEqual(limiter._min_interval, 0.5)
+
+    def test_fetch_backend_falls_back_to_search_interval_when_key_absent(self):
+        # Older config with no fetch_min_interval_s key at all -- must not
+        # KeyError, must fall back to the existing search interval so
+        # pre-upgrade behavior is unchanged.
+        config = base_config(
+            search_backends=[{"type": "duckduckgo"}],
+            fetch_backends=[{"type": "urllib-ua"}],
+        )
+        config["limits"]["search_min_interval_s"] = 2.0
+        self.assertNotIn("fetch_min_interval_s", config["limits"])
+        _, fetch_backends = harvest.build_backends(config)
+        limiter = fetch_backends[0][1]
+        self.assertEqual(limiter._min_interval, 2.0)
+
+    def test_search_backend_interval_unaffected_by_fetch_key(self):
+        config = base_config(
+            search_backends=[{"type": "duckduckgo"}],
+            fetch_backends=[{"type": "urllib-ua"}],
+        )
+        config["limits"]["search_min_interval_s"] = 2.0
+        config["limits"]["fetch_min_interval_s"] = 0.5
+        search_backends, _ = harvest.build_backends(config)
+        limiter = search_backends[0][1]
+        self.assertEqual(limiter._min_interval, 2.0)
+
+
+class TestRunFetchCallsParallel(unittest.TestCase):
+    """Defect 2 (parallel fetch): a raising future must still yield exactly
+    one tool response per tool_call_id, in the original call order -- not
+    the arrival order as_completed() would otherwise produce."""
+
+    def test_parallel_fetch_exception_still_yields_tool_response(self):
+        config = base_config(fetch_backends=[{"type": "urllib-ua"}])
+        journal = []
+        tool_calls = [
+            {"id": "c1", "function": {"name": "fetch", "arguments": json.dumps({"url": "https://a.com/1"})}},
+            {"id": "c2", "function": {"name": "fetch", "arguments": json.dumps({"url": "https://a.com/2"})}},
+            {"id": "c3", "function": {"name": "fetch", "arguments": json.dumps({"url": "https://a.com/3"})}},
+        ]
+
+        def fake_execute(tc, search_backends, fetch_backends, journal, config, local_dir):
+            args = json.loads(tc["function"]["arguments"])
+            if args["url"] == "https://a.com/2":
+                raise RuntimeError("boom")
+            return json.dumps({"content": args["url"]})
+
+        with mock.patch("harvest.execute_tool_call", side_effect=fake_execute):
+            results = harvest._run_fetch_calls_parallel(tool_calls, [], [], journal, config, None)
+
+        self.assertEqual(len(results), 3)
+        self.assertEqual(json.loads(results[0])["content"], "https://a.com/1")
+        error_payload = json.loads(results[1])
+        self.assertIn("error", error_payload)
+        self.assertIn("boom", error_payload["error"])
+        self.assertEqual(json.loads(results[2])["content"], "https://a.com/3")
+
+
 # ---------------------------------------------------------------------------
 # SSRF guard
 # ---------------------------------------------------------------------------

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -2398,6 +2398,148 @@ class TestCmdRunGoalFileResolution(unittest.TestCase):
         self.assertFalse(verify_file.exists())
 
 
+class TestSupplementaryRunIsolation(unittest.TestCase):
+    """Defect 3: --project-dir re-anchoring + supplementary (backfill) run
+    isolation. A supplementary run's --out is not the canonical
+    pipeline/1_raw -- it must never write to, or clean up, the primary
+    track's VERIFY_FILE/LEGACY_EXEMPTION_FILE."""
+
+    class Dead:
+        """client.complete() raises -> run_worker catches it as FAILED for
+        every model -> alive=[] -> quorum not met -> abort_unavailable, the
+        same early-exit path TestCmdRunGoalFileResolution already relies on
+        to observe state-file writes without a real model call."""
+        def complete(self, messages, tools):
+            raise RuntimeError("down")
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.project_dir = Path(self.tmpdir.name) / "project"
+        goal_dir = self.project_dir / "intake" / "requirements"
+        goal_dir.mkdir(parents=True)
+        self.goal_file = goal_dir / harvest.GOAL_FILE_NAME
+        self.goal_file.write_text("why is the sky blue?", encoding="utf-8")
+        self.config = base_config()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _run(self, raw_dir, project_dir_arg):
+        kwargs = dict(goal_file=str(self.goal_file), out=str(raw_dir), config="unused", local_dir=None)
+        if project_dir_arg is not None:
+            kwargs["project_dir"] = str(project_dir_arg)
+        args = argparse_ns(**kwargs)
+        with mock.patch("harvest.load_config", return_value=self.config), \
+             mock.patch("harvest.make_client_factory", return_value=lambda model_id: self.Dead()):
+            with self.assertRaises(SystemExit) as ctx:
+                harvest.cmd_run(args)
+        return ctx.exception.code
+
+    def test_project_dir_reanchors_verify_dir(self):
+        # --out deliberately nested outside the pipeline/1_raw convention --
+        # the legacy reverse-derivation (raw_dir.parent.parent) would anchor
+        # verify_dir under project_dir/custom/nested/verification, which is
+        # wrong. With --project-dir given explicitly, verify_dir must land
+        # at project_dir/pipeline/verification regardless of where --out
+        # physically sits.
+        raw_dir = self.project_dir / "custom" / "nested" / "out"
+        code = self._run(raw_dir, self.project_dir)
+        self.assertEqual(code, 3)  # past goal resolution, aborted on quorum
+
+        wrong_verify_dir = self.project_dir / "custom" / "nested" / "verification"
+        self.assertFalse(wrong_verify_dir.exists())
+
+        # raw_dir != project_dir/pipeline/1_raw -> supplementary -> its own
+        # track_<name>.json under the correctly-anchored verify_dir.
+        correct_verify_dir = self.project_dir / "pipeline" / "verification"
+        track_file = correct_verify_dir / harvest.track_verify_filename(raw_dir)
+        self.assertTrue(track_file.exists())
+
+    def test_supplementary_run_does_not_clobber_main_verify(self):
+        # Primary track already has a recorded gate verdict from a prior
+        # real run -- the supplementary backfill run below must leave it
+        # byte-for-byte untouched.
+        primary_raw_dir = self.project_dir / "pipeline" / "1_raw"
+        primary_raw_dir.mkdir(parents=True)
+        primary_verify_dir = self.project_dir / "pipeline" / "verification"
+        primary_verify_dir.mkdir(parents=True)
+        primary_verify_file = primary_verify_dir / harvest.VERIFY_FILE
+        primary_payload = json.dumps({"verdict": "OK", "goal_file_sha256": "deadbeef"}, ensure_ascii=False)
+        primary_verify_file.write_text(primary_payload, encoding="utf-8")
+
+        supplementary_raw_dir = primary_raw_dir / "track_gap_A"
+        code = self._run(supplementary_raw_dir, self.project_dir)
+        self.assertEqual(code, 3)
+
+        # Primary VERIFY_FILE must be exactly what it was before -- never
+        # overwritten with the supplementary run's own RUNNING/UNAVAILABLE
+        # tombstone.
+        self.assertEqual(primary_verify_file.read_text(encoding="utf-8"), primary_payload)
+
+        # The supplementary run's own state landed in its own track file.
+        track_file = primary_verify_dir / harvest.track_verify_filename(supplementary_raw_dir)
+        self.assertTrue(track_file.exists())
+        track_payload = json.loads(track_file.read_text(encoding="utf-8"))
+        self.assertEqual(track_payload["verdict"], "UNAVAILABLE")
+
+    def test_supplementary_cleanup_never_touches_main_state(self):
+        # Unit-test cleanup_stale_supplementary_state() directly against a
+        # primary track that has real artifacts + a legacy exemption, plus
+        # stale artifacts of its own -- confirms the scoped cleanup only
+        # ever removes its own track file / its own --out subdirectory.
+        primary_raw_dir = self.project_dir / "pipeline" / "1_raw"
+        primary_raw_dir.mkdir(parents=True)
+        verify_dir = self.project_dir / "pipeline" / "verification"
+        verify_dir.mkdir(parents=True)
+
+        primary_verify_file = verify_dir / harvest.VERIFY_FILE
+        primary_verify_file.write_text("{}", encoding="utf-8")
+        primary_exemption_file = verify_dir / harvest.LEGACY_EXEMPTION_FILE
+        primary_exemption_file.write_text("exempt", encoding="utf-8")
+        primary_merged = primary_raw_dir / harvest.MERGED_FINDINGS_FILE
+        primary_merged.write_text("{}", encoding="utf-8")
+        primary_harvest_dir = primary_raw_dir / harvest.HARVEST_SUBDIR
+        primary_harvest_dir.mkdir()
+        (primary_harvest_dir / "marker.txt").write_text("keep me", encoding="utf-8")
+
+        supplementary_raw_dir = primary_raw_dir / "track_gap_A"
+        supplementary_raw_dir.mkdir()
+        verify_filename = harvest.track_verify_filename(supplementary_raw_dir)
+        stale_track_file = verify_dir / verify_filename
+        stale_track_file.write_text('{"verdict": "RUNNING"}', encoding="utf-8")
+        stale_merged = supplementary_raw_dir / harvest.MERGED_FINDINGS_FILE
+        stale_merged.write_text("{}", encoding="utf-8")
+        stale_harvest_dir = supplementary_raw_dir / harvest.HARVEST_SUBDIR
+        stale_harvest_dir.mkdir()
+
+        harvest.cleanup_stale_supplementary_state(verify_dir, supplementary_raw_dir, verify_filename)
+
+        # Own stale state gone.
+        self.assertFalse(stale_track_file.exists())
+        self.assertFalse(stale_merged.exists())
+        self.assertFalse(stale_harvest_dir.exists())
+
+        # Primary state never touched.
+        self.assertTrue(primary_verify_file.exists())
+        self.assertTrue(primary_exemption_file.exists())
+        self.assertTrue(primary_merged.exists())
+        self.assertTrue((primary_harvest_dir / "marker.txt").exists())
+
+    def test_no_project_dir_preserves_legacy_reverse_derivation(self):
+        # No --project-dir at all (attribute absent from the args namespace,
+        # matching every pre-existing caller) -- getattr fallback must keep
+        # the old raw_dir.parent / raw_dir.parent.parent derivation and the
+        # plain (non-track-prefixed) VERIFY_FILE untouched.
+        raw_dir = self.project_dir / "pipeline" / "1_raw"
+        code = self._run(raw_dir, project_dir_arg=None)
+        self.assertEqual(code, 3)
+
+        verify_file = self.project_dir / "pipeline" / "verification" / harvest.VERIFY_FILE
+        self.assertTrue(verify_file.exists())
+        track_glob = list((self.project_dir / "pipeline" / "verification").glob("track_*.json"))
+        self.assertEqual(track_glob, [])
+
+
 class TestFetchReportRealStats(unittest.TestCase):
     def test_count_blacklist_hits_aggregates_across_workers(self):
         r1 = harvest.WorkerResult("m1", "model-a", "OK", {"claims": []},


### PR DESCRIPTION
## Summary

deep-research 插件 harvest.py 采集鲁棒性三缺陷修复，基于 v1.1.0 (4ac95d9) 基线。详见 #50。

> 说明：本 PR 取代已关闭的 #51（那版基于 v1.0.2，因插件仓更新到 v1.1.0 而重做）。经确认三处改动均为纯插入，与 #49 的 Anthropic 原生路径无逻辑冲突。

- **缺陷1**（`1b9cb15`）：`build_system_prompt` 加显式反例，禁止用页面标题/搜索摘要/byline/论文标题冒充正文 excerpt。triage 证明原 44% INVALID 是模型标题冒充正文、机械门本就正确，故不动 `validate_claims`，改在 prompt 治理源头（撤回了曾被 redteam 判为后门的 soft 三态方案）。
- **缺陷2**（`3f6d478`）：fetch 限流从 search 解耦（独立 `fetch_min_interval_s`，默认 0.5s，双默认兜底）+ 同回合全 fetch 有界并行（max 3，以 do_fetch 为并行单元保 SSRF colocation，index 回填保 tool_call_id 完整性，future 异常合成 error）。
- **缺陷3**（`360d13c`）：`--project-dir` 显式解耦（含 CLI flag 注册）修 `--out` 子目录补采 exit 1 + 补采独立状态位（`track_<name>.json`），`write_verify_json`/`write_tombstone`/`abort_unavailable` 全链 `verify_filename` 参数化，`cleanup_stale_supplementary_state` 绝不碰主 gate 状态。

## Test

`python3.11 -m pytest test_harvest.py test_gate_check.py -q` → **250 passed, 9 skipped**（9 skip 为 curl_cffi 可选依赖，与本次改动无关）。

新增测试：`TestBuildBackendsFetchInterval`（限流解耦 3 个）、`TestRunFetchCallsParallel`（并行 fetch 异常回填 tool_call_id 完整性）、`TestSupplementaryRunIsolation`（4 个，含关键安全测试 `test_supplementary_run_does_not_clobber_main_verify`）。

## Review

已过 redteam 两轮对抗审阅（首轮 3 Critical + 3 Major，收敛后复审 APPROVED）。三缺陷均向后兼容零破坏。
