### PR TITLE
chore(deep-research): bump 1.1.0 → 1.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [


### PR DESCRIPTION
三缺陷修复 #52 已 merge 但漏升版本号，补丁级 bump 使 cache 下次 reload 正确刷新。内容即 d82f77e（详见 #50）。无代码改动，仅 plugin.json version。