### PR TITLE
fix(deep-research): 项目落点幂等归一到 projects/ + 修 tmpl 死引用 (v1.1.2)

### DIFF
--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/README.md
+++ b/plugins/deep-research/README.md
@@ -90,5 +90,6 @@ python3 -m pytest plugins/deep-research/tests/
 
 ## Version History
 
+- **v1.1.2** — `create-research-project.sh` scaffolds into `projects/` idempotently: a path-segment `case` resolves the single `projects/` root no matter where cwd sits in the tree, so it appends exactly once and never nests. Fixed two stale `framework/*.md` references in `assets/` templates (→ skill `references/`).
 - **v1.0.0** — Initial release: extracted from the standalone research framework v3 into a distributable plugin; 3 roles converted to native subagents; harvest.py + gate_check.py path-decoupled from the framework repo.
 

--- a/plugins/deep-research/scripts/create-research-project.sh
+++ b/plugins/deep-research/scripts/create-research-project.sh
@@ -119,9 +119,24 @@ fi
 
 # ---------------------------------------------------------------------------
 # 目录名和路径
+#
+# 落点规则：若当前工作目录已是研究存档库根（存在 projects/ 子目录），
+# 项目落进 projects/ 下（独立性原则 principles.md:1「projects/{name}/」）；
+# 否则退回当前工作目录，保持插件对非存档库场景的通用性。
+# 这样「存档库根直接跑脚本却落在根目录」的特殊情况被消除，无需用户记规矩。
 # ---------------------------------------------------------------------------
 DIR_NAME=$(echo "$TOPIC_NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '_')
-PROJECT_DIR="$(pwd)/$DIR_NAME"
+
+# 落点：研究项目一律住 projects/{name}/（独立性原则 principles.md:1）。
+# 幂等解析 projects 根——无论 cwd 站在 projects 树的哪一层，都归一到
+# 同一个 projects/，永远追加一次、绝不嵌套（消除「cwd 在哪」这个特殊情况）。
+CWD="$(pwd)"
+case "$CWD" in
+    */projects)   PROJECT_ROOT="$CWD" ;;                          # 正站在 projects/ 里
+    */projects/*) PROJECT_ROOT="${CWD%%/projects/*}/projects" ;;  # 在 projects/ 子树深处，归一到最上层 projects
+    *)            PROJECT_ROOT="$CWD/projects" ;;                  # 其他，总是建 projects/
+esac
+PROJECT_DIR="$PROJECT_ROOT/$DIR_NAME"
 
 if [[ -d "$PROJECT_DIR" ]]; then
     echo "错误: 目录 $PROJECT_DIR 已存在" >&2

--- a/plugins/deep-research/skills/deep-research/SKILL.md
+++ b/plugins/deep-research/skills/deep-research/SKILL.md
@@ -56,7 +56,7 @@ python3 <路径> run --goal-file <goal-file> --out pipeline/1_raw/
 
 ## 新建研究项目
 
-在**用户当前工作目录**创建项目骨架：
+创建项目骨架。研究项目一律落在 `projects/{name}/`（独立性原则）。脚本幂等解析 `projects/` 根：无论当前工作目录站在 `projects/` 树的哪一层（存档库根 / `projects/` 内 / 某项目子目录深处），都归一到同一个 `projects/`，只追加一次、绝不嵌套；不在 `projects/` 树内时则在当前工作目录下建 `projects/`。
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/create-research-project.sh "研究主题" --type web-research

--- a/plugins/deep-research/skills/deep-research/assets/fetch-report.md.tmpl
+++ b/plugins/deep-research/skills/deep-research/assets/fetch-report.md.tmpl
@@ -98,7 +98,7 @@
 <!--
 仅当 research-goal.md 研究类型 = selection（N 个互斥方案择一）时填写本节。
 非选型类研究（综述/趋势/事实核验）→ 本节整体填 "N/A（非选型类研究）"，不强制。
-对应 G1 候选集完备性检查（framework/quality-gates.md）。
+对应 G1 候选集完备性检查（deep-research skill 的 references/quality-gates.md）。
 -->
 
 | 项 | 内容 |

--- a/plugins/deep-research/skills/deep-research/assets/research-goal.md.tmpl
+++ b/plugins/deep-research/skills/deep-research/assets/research-goal.md.tmpl
@@ -4,7 +4,7 @@ research-goal.md — 研究根本目标锚（举证责任锚定元原则的物�
 何时填：G0 Problem Validation Gate，由 Lead 与用户对齐后填写。
 作用：全程唯一价值基准。G3 证伪审计据此做 cite 回链检查——任何评判判据
 必须能 cite 本文件的小节标题或原句文本，cite 不上即判据无效。
-机制说明见 framework/principles.md「举证责任锚定（横切元原则）」。
+机制说明见 deep-research skill 的 references/principles.md「举证责任锚定（横切元原则）」。
 -->
 
 # 研究根本目标 — {TOPIC_NAME}


### PR DESCRIPTION
## 背景

`create-research-project.sh` 原来无条件用 `$(pwd)/$DIR_NAME` 创建项目，落点有两类缺陷：

1. **不合独立性原则**：研究项目应住 `projects/{name}/`，但脚本直接落在 cwd。在研究存档库根目录运行时项目落在了仓库根。
2. **嵌套隐患**：cwd 已在 `projects/` 树内时（如先 `cd projects/`，或在某项目子目录深处），旧逻辑会造出 `projects/projects/` 或 `projects/某项目/projects/` 的病态嵌套。

## 修复

**落点幂等解析**：用路径段 `case` 归一到唯一 `projects/` 根，无论 cwd 站在 `projects/` 树哪一层，只追加一次、绝不嵌套：
- cwd 以 `/projects` 结尾 → 直接用之
- cwd 在 `/projects/*` 子树 → 砍回最上层 `projects/`
- 其他 → cwd 下建 `projects/`

**死引用修复**：`assets/research-goal.md.tmpl`、`assets/fetch-report.md.tmpl` 的 `framework/xxx.md` → `deep-research skill 的 references/xxx.md`（框架抽离后残留）。

**文档同步**：SKILL.md「新建研究项目」段落 + README Version History。

## 验证

- 落点 5 场景全 PASS：存档库根 / cwd 在 projects/ 内 / 项目子目录深处 / 普通目录 / `projectsfoo` 边界不误判。全树 `projects/` 恒为一层、零嵌套。
- `pytest plugins/deep-research/tests/`：250 passed, 9 skipped（rebase 到最新 main 后回归）。

版本 bump：1.1.1 → **1.1.2**（1.1.1 已被 #53 纯 bump 占用）。

close #54