### PR TITLE
chore(deep-research): 模型更新 panel claude-sonnet-5 + 兜底 gemini-3.5-flash (v1.1.3)

### DIFF
--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/README.md
+++ b/plugins/deep-research/README.md
@@ -90,6 +90,7 @@ python3 -m pytest plugins/deep-research/tests/
 
 ## Version History
 
+- **v1.1.3** — Model refresh: panel `claude-sonnet-4-6` → `claude-sonnet-5`; fallback `gateway-gemini` search backend `gemini-2.5-flash` → `gemini-3.5-flash` (plus the mirrored default in `harvest.py`, doc examples, and test fixture). The `startswith("claude")` dispatch keeps `claude-sonnet-5` on the Anthropic-native `/messages` path (prompt caching intact).
 - **v1.1.2** — `create-research-project.sh` scaffolds into `projects/` idempotently: a path-segment `case` resolves the single `projects/` root no matter where cwd sits in the tree, so it appends exactly once and never nests. Fixed two stale `framework/*.md` references in `assets/` templates (→ skill `references/`).
 - **v1.0.0** — Initial release: extracted from the standalone research framework v3 into a distributable plugin; 3 roles converted to native subagents; harvest.py + gate_check.py path-decoupled from the framework repo.
 

--- a/plugins/deep-research/scripts/harvest.config.json
+++ b/plugins/deep-research/scripts/harvest.config.json
@@ -6,7 +6,7 @@
   "panel_models": [
     "gemini-3.5-flash",
     "gpt-5.4",
-    "claude-sonnet-4-6"
+    "claude-sonnet-5"
   ],
   "judge_model": "claude-opus-4-6",
   "search_backends": [
@@ -16,7 +16,7 @@
     },
     {
       "type": "gateway-gemini",
-      "model": "gemini-2.5-flash"
+      "model": "gemini-3.5-flash"
     },
     {
       "type": "tavily",

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -497,7 +497,7 @@ def _http_json_post_with_retry(url, payload, headers, timeout):
 def _search_gemini_cli(cfg, query, timeout):
     try:
         proc = subprocess.run(
-            ["gemini", "-m", cfg.get("model", "gemini-2.5-flash"), "-p", query],
+            ["gemini", "-m", cfg.get("model", "gemini-3.5-flash"), "-p", query],
             capture_output=True, timeout=timeout, stdin=subprocess.DEVNULL, text=True,
         )
     except subprocess.TimeoutExpired:

--- a/plugins/deep-research/skills/deep-research/references/context-economics.md
+++ b/plugins/deep-research/skills/deep-research/references/context-economics.md
@@ -81,7 +81,7 @@ fetch 后端链同理降级：curl-cffi（本地免费直连，软依赖）→ t
 
 1. **Gemini CLI**（主力）：
    ```bash
-   gemini -m gemini-2.5-flash -p '使用Google搜索查找以下问题的最新信息。
+   gemini -m gemini-3.5-flash -p '使用Google搜索查找以下问题的最新信息。
    规则：必须联网搜索，严禁使用内置知识回答...'
    ```
 2. **WebSearch**（fallback）：当 Gemini CLI 输出包含 `SEARCH_FAILED`、输出为空、或退出码非零时降级

--- a/plugins/deep-research/skills/deep-research/references/web-research.md
+++ b/plugins/deep-research/skills/deep-research/references/web-research.md
@@ -77,7 +77,7 @@ python3 <harvest.py 路径> run --goal-file intake/requirements/research-goal.md
 
 **1. Gemini CLI（主力）**
 ```bash
-gemini -m gemini-2.5-flash -p $'使用Google搜索查找以下问题的最新信息。\n\n规则：\n1. 必须联网搜索，严禁使用内置知识回答\n2. 搜索失败则只返回SEARCH_FAILED\n3. 返回最相关的5-10条结果\n4. 每条格式：标题 | 关键信息（1-2句） | 完整来源URL（必须包含完整路径）\n5. 不要做总结或分析，只返回搜索结果\n6. 去重：同一来源只保留最相关的一条\n7. 排除以下内容农场：CSDN、百度云、腾讯云、华为云、阿里云、火山引擎、稀土掘金\n\n搜索问题：{query}'
+gemini -m gemini-3.5-flash -p $'使用Google搜索查找以下问题的最新信息。\n\n规则：\n1. 必须联网搜索，严禁使用内置知识回答\n2. 搜索失败则只返回SEARCH_FAILED\n3. 返回最相关的5-10条结果\n4. 每条格式：标题 | 关键信息（1-2句） | 完整来源URL（必须包含完整路径）\n5. 不要做总结或分析，只返回搜索结果\n6. 去重：同一来源只保留最相关的一条\n7. 排除以下内容农场：CSDN、百度云、腾讯云、华为云、阿里云、火山引擎、稀土掘金\n\n搜索问题：{query}'
 ```
 
 **2. WebSearch（fallback）**：Gemini CLI 输出包含 `SEARCH_FAILED`、输出为空、或退出码非零时降级使用。

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -25,7 +25,7 @@ def base_config(**overrides):
         "gateway": {"base_url": "https://gw.example.com/v1", "api_key_env": "TEST_GATEWAY_KEY"},
         "panel_models": ["model-a", "model-b", "model-c"],
         "judge_model": "model-judge",
-        "search_backends": [{"type": "gemini-cli", "model": "gemini-2.5-flash"}],
+        "search_backends": [{"type": "gemini-cli", "model": "gemini-3.5-flash"}],
         "fetch_backends": [{"type": "urllib-ua"}],
         "local_sources": {"enabled": False, "dir": "intake/local_sources"},
         "limits": {"max_steps_per_model": 6, "call_timeout_s": 5, "wall_clock_s": 60,


### PR DESCRIPTION
## 变更

- **面板模型**：`claude-sonnet-4-6` → `claude-sonnet-5`（`harvest.config.json` panel_models）
- **兜底搜索后端**：`gateway-gemini` 的 `gemini-2.5-flash` → `gemini-3.5-flash`（search_backends）

## 同步镜像点

保持全仓一致，避免 config 缺失退回旧型号 / 文档示例脱节：`harvest.py` 兜底默认值、`references/context-economics.md`、`references/web-research.md` 的 gemini CLI 命令示例、`tests/test_harvest.py` fixture。

## 路由确认

`harvest.py` 客户端分派为 `model_id.startswith("claude")`（纯前缀匹配）。`claude-sonnet-5` 命中 → 走 `AnthropicGatewayClient` 的 Anthropic-native `/messages` 路径，prompt caching 不受影响。已运行时实测验证分派正确。

未改动：`judge_model: claude-opus-4-6`、`agy-cli` 的 `Gemini 3.5 Flash (Low)`（本就是新版）。

## 验证

- `pytest plugins/deep-research/tests/`：250 passed, 9 skipped。
- JSON 合法性校验通过；旧型号全仓零残留。

版本 bump：v1.1.2 → **v1.1.3**。

close #56