### PR TITLE
refactor(deep-research): 简化 harvest 架构 — 去除 excerpt gate 和 consensus labels

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-      "version": "1.1.5",
+      "version": "1.2.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/README.md
+++ b/plugins/deep-research/README.md
@@ -85,7 +85,7 @@ python3 -m pytest plugins/deep-research/tests/
 
 | Suite | Coverage |
 |-------|----------|
-| `test_harvest.py` | multi-model harvest, citation verification, consensus labels, SSRF guard, exit-code semantics |
+| `test_harvest.py` | multi-model harvest, citation verification, SSRF guard, exit-code semantics |
 | `test_gate_check.py` | SubagentStop gate: PASS-claim verification, project-dir location, fail-open behavior |
 
 ## Version History

--- a/plugins/deep-research/agents/research-harvester.md
+++ b/plugins/deep-research/agents/research-harvester.md
@@ -142,7 +142,7 @@ Lead 的采集指令，必须包含：
 - 候选类别清单: [已识别的候选方案类别]
 - 候选基数: N (selection 类型须 ≥ 3，否则 G1 强制补搜)
 - 饱和轮次记录: [最近 2 轮有无新候选类别；无则 "saturation reached after N rounds"]
-## 多模型共识统计（仅 harvest.py 项目；legacy 链填 N/A）
+## 多模型参与情况（仅 harvest.py 项目；legacy 链填 N/A）
 - 参与模型: [gemini/gpt/claude 存活列表]
 - 法定人数状态: quorum_met (true/false)，未达标时列出缺席模型及原因
 ## 引用校验统计（仅 harvest.py 项目；legacy 链填 N/A）

--- a/plugins/deep-research/agents/research-harvester.md
+++ b/plugins/deep-research/agents/research-harvester.md
@@ -144,10 +144,7 @@ Lead 的采集指令，必须包含：
 - 饱和轮次记录: [最近 2 轮有无新候选类别；无则 "saturation reached after N rounds"]
 ## 多模型共识统计（仅 harvest.py 项目；legacy 链填 N/A）
 - 参与模型: [gemini/gpt/claude 存活列表]
-- 法定人数状态: quorum_met (true/false)，DEGRADED 时列出缺席模型及原因
-- strong: N（≥2 模型支持）
-- minority: N（仅 1 模型支持）
-- disputed: N（同簇矛盾）
+- 法定人数状态: quorum_met (true/false)，未达标时列出缺席模型及原因
 ## 引用校验统计（仅 harvest.py 项目；legacy 链填 N/A）
 - 校验总数: N
 - INVALID 剔除数: N

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -2,9 +2,9 @@
 
 Three heterogeneous panel models each run a minimal agentic loop (search/fetch/
 read_local tools) to independently collect claims. A judge model clusters the
-claims (ID-only output); this script mechanically assembles the merged result
-and computes consensus labels. All citations are verified by exact substring/
-URL matching against a recorded tool-call journal -- never by LLM judgment.
+claims (ID-only output); this script mechanically assembles the merged result.
+All citations are verified at the URL level against a recorded tool-call
+journal -- never by LLM judgment.
 
 Stdlib only, with one optional soft dependency: curl_cffi (only used by the
 "curl-cffi" fetch backend; every other code path is pure stdlib). Config
@@ -30,7 +30,6 @@ import subprocess
 import sys
 import threading
 import time
-import unicodedata
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -270,28 +269,6 @@ def normalize_url(url):
         return url
 
 
-# Excerpt matching must stay exact-substring (no fuzzy matching -- verbatim
-# auditability is a hard requirement), but the surface encoding of "the same
-# text" varies harmlessly between what a model pastes and what a page serves:
-# HTML entities, typographic quote/dash variants, and compatibility Unicode
-# forms. This whitelist folds only those known-harmless variants; it must
-# never grow into anything that could paper over an actual paraphrase (e.g.
-# a model-inserted "..." truncation is a real verbatim violation and stays
-# rejected -- folding it away would defeat the citation check's purpose).
-_QUOTE_DASH_TRANSLATION = str.maketrans({
-    "‘": "'", "’": "'", "‚": "'", "‛": "'",
-    "“": '"', "”": '"', "„": '"', "‟": '"',
-    "–": "-", "—": "-", "−": "-",
-})
-
-
-def normalize_citation_text(text):
-    text = unicodedata.normalize("NFKC", text or "")
-    text = html.unescape(text)
-    text = text.translate(_QUOTE_DASH_TRANSLATION)
-    return re.sub(r"\s+", " ", text).strip()
-
-
 # ---------------------------------------------------------------------------
 # Findings / judge JSON parsing
 # ---------------------------------------------------------------------------
@@ -389,7 +366,6 @@ def build_journal_url_set(journal):
 _REJECT_REASON_MESSAGES = {
     "url_not_in_journal": "url never appeared in any search/fetch/read_local call",
     "url_not_fetched": "url was seen but never successfully fetched; fetch full text before citing",
-    "excerpt_not_substring": "excerpt is not a substring of fetched content (copy the original text verbatim)",
 }
 
 
@@ -401,10 +377,6 @@ def validate_claims(claims, fetch_index, journal_urls):
         if not contents:
             reason = "url_not_fetched" if key in journal_urls else "url_not_in_journal"
             invalid.append((c, reason, None))
-            continue
-        excerpt_norm = normalize_citation_text(c.get("excerpt", ""))
-        if not excerpt_norm or not any(excerpt_norm in normalize_citation_text(ct) for ct in contents):
-            invalid.append((c, "excerpt_not_substring", key))
             continue
         valid.append(c)
     return valid, invalid
@@ -1542,13 +1514,10 @@ def build_system_prompt(goal_text, local_manifest, alias, max_steps):
         "Hard rules:",
         "1. Never cite a URL before fetching its full text via fetch/read_local; "
         "citing a bare search snippet is forbidden.",
-        "2. excerpt must be 100% verbatim in the source's original language -- "
-        "never translate, paraphrase, or truncate it. claim may be in Chinese; "
-        "excerpt must be copied from the original text. excerpt must be a "
-        "verbatim fragment of the fetched page's BODY content -- never "
-        "substitute the page title, a search-result snippet, a byline, or a "
-        "paper's title for it. A title is not body text.",
-        "3. Only cite text that literally appears in a tool result.",
+        "2. excerpt should quote the source's original text as closely as "
+        "possible for auditability -- prefer copying from the fetched page's "
+        "body content.",
+        "3. Only cite URLs that appear in your tool results.",
         "4. Search in both Chinese and English for each core concept.",
         f"5. You have a budget of about {max_steps} tool-use rounds.",
         "6. Search bilingually to map sources first, then fetch the most relevant "
@@ -1794,15 +1763,15 @@ def merge_findings(worker_findings_by_alias, judge_data):
     # later cluster claiming the same ID has that ID dropped and logged to
     # dedup_notes. The judge prompt asks for this too, but this invariant
     # must hold even if the judge ignores the instruction.
-    all_claims, alias_by_claim = {}, {}
+    all_claims = {}
     for alias, data in worker_findings_by_alias.items():
         for c in data["claims"]:
             all_claims[c["_id"]] = c
-            alias_by_claim[c["_id"]] = alias
 
     clusters_out = []
     claimed_ids = set()
     dedup_notes = []
+    contradictions = []
     for cluster in judge_data.get("clusters", []):
         summary = cluster.get("summary", "")
         candidate_ids = [cid for cid in cluster.get("source_claim_ids", []) if cid in all_claims]
@@ -1816,14 +1785,9 @@ def merge_findings(worker_findings_by_alias, judge_data):
         if not ids:
             continue
         claimed_ids.update(ids)
-        aliases_in_cluster = {alias_by_claim[cid] for cid in ids}
         relation = cluster.get("relation", "agree")
         if relation == "contradict":
-            consensus = "disputed"
-        elif len(aliases_in_cluster) >= 2:
-            consensus = "strong"
-        else:
-            consensus = "minority"
+            contradictions.append(summary)
         assembled = []
         for cid in ids:
             c = all_claims[cid]
@@ -1835,10 +1799,9 @@ def merge_findings(worker_findings_by_alias, judge_data):
                 "language": c.get("language", "unknown"),
                 "credibility": c.get("credibility", 3),
             })
-        clusters_out.append({"summary": summary, "consensus": consensus, "claims": assembled})
+        clusters_out.append({"summary": summary, "claims": assembled})
 
     unique_insights = [cid for cid in judge_data.get("unique_insights", []) if cid in all_claims]
-    contradictions = [c["summary"] for c in clusters_out if c["consensus"] == "disputed"]
     return {
         "clusters": clusters_out,
         "coverage_gaps": judge_data.get("coverage_gaps", []),
@@ -1847,13 +1810,6 @@ def merge_findings(worker_findings_by_alias, judge_data):
         "contradictions": contradictions,
         "dedup_notes": dedup_notes,
     }
-
-
-def compute_consensus_stats(merged):
-    stats = {"strong": 0, "minority": 0, "disputed": 0}
-    for c in merged["clusters"]:
-        stats[c["consensus"]] = stats.get(c["consensus"], 0) + 1
-    return stats
 
 
 # ---------------------------------------------------------------------------
@@ -1954,7 +1910,7 @@ def check_project(project_dir):
     verdict = data.get("verdict")
     if verdict == "UNAVAILABLE":
         return "FAIL", "multi-model harvest UNAVAILABLE: retry / fix config / or request user exemption to legacy"
-    if verdict not in ("OK", "DEGRADED"):
+    if verdict != "OK":
         return "FAIL", f"unknown or incomplete verdict: {verdict!r}"
 
     goal_note = None
@@ -2045,7 +2001,7 @@ def detect_research_type(goal_text):
     return None
 
 
-def write_fetch_report(raw_dir, results, alive, consensus_stats, invalid_total, invalid_rate, local_manifest, goal_text="", quorum_required=2):
+def write_fetch_report(raw_dir, results, alive, invalid_total, invalid_rate, local_manifest, goal_text="", quorum_required=2):
     lines = ["# Fetch Report - Multi-Model Harvest", "", "## 采集统计", f"- 总请求数: {len(results)}"]
     for r in results:
         lines.append(f"- {r.alias} ({r.model_id}): status={r.status} reason={r.reason or '-'}")
@@ -2070,9 +2026,7 @@ def write_fetch_report(raw_dir, results, alive, consensus_stats, invalid_total, 
     if blacklist_hits:
         lines.append(f"  - 列表: {blacklist_hits}")
     lines.append("")
-    lines.append("## 多模型共识统计")
-    for label, count in consensus_stats.items():
-        lines.append(f"- {label}: {count}")
+    lines.append("## 多模型参与情况")
     lines.append(f"- 参与模型: {[r.alias for r in alive]}")
     lines.append(f"- 法定人数状态: {'met' if len(alive) >= quorum_required else 'not met'}")
     per_model_invalid = {r.alias: len(r.rejected_claims) for r in alive}
@@ -2244,25 +2198,27 @@ def cmd_run(args):
                                verify_filename=verify_filename)
 
         merged = merge_findings(worker_findings_by_alias, judge_data)
-        consensus_stats = compute_consensus_stats(merged)
 
         total_claims = sum(len(d["claims"]) for d in worker_findings_by_alias.values())
         invalid_total = sum(r.findings.get("invalid_claim_count", 0) for r in alive)
         denom = total_claims + invalid_total
         invalid_rate = (invalid_total / denom) if denom > 0 else 0.0
 
+        if total_claims == 0:
+            abort_unavailable(verify_dir, goal_hash, "quorum met but zero valid claims",
+                               verify_filename=verify_filename)
+
         raw_dir.mkdir(parents=True, exist_ok=True)
         (raw_dir / MERGED_FINDINGS_FILE).write_text(json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8")
-        write_fetch_report(raw_dir, results, alive, consensus_stats, invalid_total, invalid_rate, local_manifest, goal_text,
+        write_fetch_report(raw_dir, results, alive, invalid_total, invalid_rate, local_manifest, goal_text,
                             quorum_required=config["limits"]["quorum"])
 
-        verdict = "OK" if len(alive) == len(config["panel_models"]) else "DEGRADED"
+        verdict = "OK"
         write_verify_json(verify_dir, goal_hash, verdict, {
             "quorum_met": quorum_met,
             "models_alive": [r.alias for r in alive],
             "invalid_citation_rate": invalid_rate,
             "invalid_claim_count": invalid_total,
-            "consensus_stats": consensus_stats,
             "total_claims": total_claims,
         }, verify_filename=verify_filename)
         print(f"harvest run complete: verdict={verdict}")

--- a/plugins/deep-research/skills/deep-research/references/principles.md
+++ b/plugins/deep-research/skills/deep-research/references/principles.md
@@ -101,18 +101,9 @@ deliverables/          → 最终交付物（draft/ + final/）
 源1: {URL} (credibility: X, language: zh/en, excerpt: "{逐字摘录}")
 源2: {URL} (credibility: X, language: zh/en, excerpt: "{逐字摘录}")
 一致性: 一致 / 有差异（说明差异点）
-consensus: strong / minority / disputed
 ```
 
-**consensus 标签**（由 `harvest.py` merge 阶段按簇成员数**机械打标**，非人工判断）：
-
-- **strong**：≥2 个独立模型/源支持同一结论簇
-- **minority**：仅 1 个模型/源支持
-- **disputed**：同一簇内存在互相矛盾的结论
-
-**minority 降权规则**：minority / disputed 结论只能以「少数派观点 / 存争议」措辞出现在正文分析中，**不得**直接进入结论与建议章节——除非 Lead 显式提级并记录 Correction Record（复用上方原则 5 机制）。
-
-> **共识 ≠ 正确**：多源重合度只是降权信号，不是真值判据——三源一致可能共享同一上游谣言，单源观点也可能是唯一说对的。[quality-gates.md](./quality-gates.md) G3 证伪审计不因 `consensus: strong` 而放松审查。
+> **共识 ≠ 正确**：多源重合度是参考信号，不是真值判据——三源一致可能共享同一上游谣言，单源观点也可能是唯一说对的。[quality-gates.md](./quality-gates.md) G3 证伪审计不因多源重合而放松审查。
 
 - 中英文信息出现矛盾时，必须在分析中标注并说明可能原因（地域差异、时间差异、翻译失真）
 - 单一信息源引用不得超过 3 次（防止单源偏见）

--- a/plugins/deep-research/skills/deep-research/references/quality-gates.md
+++ b/plugins/deep-research/skills/deep-research/references/quality-gates.md
@@ -105,7 +105,6 @@ reviewer（mode=sufficiency）在 G1/G2/G3 三个门使用。维度 1-6 是 1-5 
   - **反驳搜索**：强制回答「如果结论是错的，最可能因为什么」+ 是否已采集足以反驳的证据（Diagnostic Time-out，对抗 Einstellung Effect）。未做 → 不通过。
   - **判据回链（机械门）**：每个评判判据必须能 cite `research-goal.md` 的**具体小节标题或原句文本**（不用行号——行号随编辑漂移会误杀）。cite 不上即判据无效。这是机械裁决，不要求 reviewer 主观重判前提（跳出同模型回音壁）。
   - **证伪不可省 + 对称举证**：结论为「维持现状 / 省成本」时，唯一能证伪当前假设的步骤必须「已做」或「已显式记录豁免理由（确证无法证伪 / 成本不对称）」二选一，**皆无 → 不通过**。现状不享有「默认正确」信用，但回链得上 primary_job 的现状结论不被额外惩罚（防矫枉过正）。
-  - **共识分级逐条处置量化下限（harvest.py 项目）**：`merged-findings.json` 中每条 `minority` / `disputed` 标签的结论，reviewer 必须**逐条**给出处置结论——**采纳提级**（记录 Correction Record）/ **维持降权**（保留「少数派观点/存争议」措辞）/ **驳回**（不采信），并各附一句理由。未逐条处置 → 此项不通过（FAIL）。这是把「质性检查无下限」的缺口补成量化门槛：minority/disputed 数量再多，也不能被笼统一句「已核实」带过。
 
 详解见 [principles.md](./principles.md) 元原则 0。
 
@@ -166,7 +165,7 @@ GATE_VERDICT: G<N> PASS|FAIL|RECYCLE
 
 引用率门槛是**双条件与**：被拒 claim 数 ≥ 2 **且** INVALID 引用率 > 5% 才判 FAIL——真实冒烟中出现过小样本下单条孤立被拒（已过一次重试、已被剔除出最终产物）把整锅判 FAIL 的假阳性，门槛本意是拦系统性造假，不是拦单条噪声。被拒 claim 的具体内容和拒绝原因见 `harvest/<alias>/rejected_claims.json`。
 
-DEGRADED（法定人数 2/3，即三模型中一路失败但 ≥quorum 存活）不算 FAIL，但 reviewer 须在报告中标注哪一路模型缺席及原因。
+法定人数达标但存在缺席模型（quorum_met = true，非全员存活）不算 FAIL，但 reviewer 须在报告中标注哪一路模型缺席及原因。
 
 机械门与 Sufficiency 评分是**与**关系：机械门 FAIL 直接阻塞，不进入评分；机械门 PASS/N/A 后仍须过既有覆盖度/时效性/可信度/双语平衡评分。
 

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -374,9 +374,6 @@ class TestNormalization(unittest.TestCase):
     def test_local_url_normalized(self):
         self.assertEqual(harvest.normalize_url("local://foo/bar/"), harvest.normalize_url("local://foo/bar"))
 
-    def test_whitespace_normalization(self):
-        self.assertEqual(harvest.normalize_citation_text("a   b\n\tc"), "a b c")
-
     def test_malformed_url_does_not_raise(self):
         # copilot review on #25: an unclosed IPv6 bracket makes urlsplit()
         # raise ValueError. Model output or a search backend result can
@@ -470,23 +467,15 @@ class TestCitationValidation(unittest.TestCase):
         self.assertEqual(len(invalid), 1)
         self.assertEqual(invalid[0][1], "url_not_in_journal")
 
-    def test_tampered_excerpt_rejected(self):
+    def test_url_fetched_accepted_regardless_of_excerpt_content(self):
+        # Citation verification is URL-level only: any excerpt text is
+        # accepted as long as the URL was actually fetched.
         journal = [{"tool": "fetch", "url": "https://a.com/x", "content": "The quick brown fox."}]
         claims = harvest.assign_claim_ids("m1", [
-            {"claim": "c", "excerpt": "the slow red fox", "url": "https://a.com/x"}])
+            {"claim": "c", "excerpt": "the slow red fox (not verbatim at all)", "url": "https://a.com/x"}])
         valid, invalid = self._validate(journal, claims)
-        self.assertEqual(valid, [])
-        self.assertEqual(len(invalid), 1)
-        self.assertEqual(invalid[0][1], "excerpt_not_substring")
-
-    def test_translated_excerpt_rejected_with_verbatim_hint(self):
-        journal = [{"tool": "fetch", "url": "https://a.com/x", "content": "白日依山尽，黄河入海流。"}]
-        claims = harvest.assign_claim_ids("m1", [
-            {"claim": "c", "excerpt": "The sun sets behind the mountains", "url": "https://a.com/x"}])
-        valid, invalid = self._validate(journal, claims)
-        self.assertEqual(valid, [])
-        feedback = harvest.build_citation_feedback(invalid)
-        self.assertIn("verbatim", feedback.lower())
+        self.assertEqual(len(valid), 1)
+        self.assertEqual(invalid, [])
 
     def test_url_seen_in_search_but_never_fetched_rejected_as_not_fetched(self):
         journal = [{"tool": "search", "query": "q", "lang": "en", "backend": "gemini-cli",
@@ -515,11 +504,11 @@ class TestCitationValidation(unittest.TestCase):
     def test_rejected_claims_record_shape(self):
         journal = [{"tool": "fetch", "url": "https://a.com/x", "content": "The quick brown fox."}]
         claims = harvest.assign_claim_ids("m1", [
-            {"claim": "c", "excerpt": "the slow red fox", "url": "https://a.com/x"}])
+            {"claim": "c", "excerpt": "the slow red fox", "url": "https://a.com/NEVER-SEEN"}])
         _, invalid = self._validate(journal, claims)
         records = harvest.build_rejected_claims(invalid)
-        self.assertEqual(records, [{"claim": "c", "url": "https://a.com/x", "excerpt": "the slow red fox",
-                                     "reject_reason": "excerpt_not_substring", "matched_url_normalized": "https://a.com/x"}])
+        self.assertEqual(records, [{"claim": "c", "url": "https://a.com/NEVER-SEEN", "excerpt": "the slow red fox",
+                                     "reject_reason": "url_not_in_journal", "matched_url_normalized": None}])
 
     def test_rejected_claims_record_no_matched_url_when_not_fetched(self):
         journal = [{"tool": "fetch", "url": "https://a.com/x", "content": "The quick brown fox."}]
@@ -528,37 +517,6 @@ class TestCitationValidation(unittest.TestCase):
         _, invalid = self._validate(journal, claims)
         records = harvest.build_rejected_claims(invalid)
         self.assertIsNone(records[0]["matched_url_normalized"])
-
-
-class TestCitationNormalization(unittest.TestCase):
-    def _accepted(self, content, excerpt):
-        journal = [{"tool": "fetch", "url": "https://a.com/x", "content": content}]
-        claims = harvest.assign_claim_ids("m1", [{"claim": "c", "excerpt": excerpt, "url": "https://a.com/x"}])
-        idx = harvest.build_fetch_index(journal)
-        urls = harvest.build_journal_url_set(journal)
-        valid, _ = harvest.validate_claims(claims, idx, urls)
-        return len(valid) == 1
-
-    def test_nbsp_folded_as_before(self):
-        self.assertTrue(self._accepted("The quick\xa0brown fox.", "quick brown fox"))
-
-    def test_smart_quotes_match_straight_quotes(self):
-        self.assertTrue(self._accepted("She said “hello” to ‘Bob’.", 'She said "hello" to \'Bob\'.'))
-
-    def test_straight_quotes_match_smart_quotes(self):
-        self.assertTrue(self._accepted('She said "hello" to \'Bob\'.', "She said “hello” to ‘Bob’."))
-
-    def test_em_dash_and_en_dash_match_ascii_hyphen(self):
-        self.assertTrue(self._accepted("A—B and C–D.", "A-B and C-D."))
-
-    def test_html_entity_residue_matches_decoded_text(self):
-        self.assertTrue(self._accepted("Fish &amp; chips &quot;classic&quot;.", 'Fish & chips "classic".'))
-
-    def test_ellipsis_truncation_still_rejected_not_a_false_positive(self):
-        # A model-inserted "..." to skip words is a real verbatim violation,
-        # not an encoding artifact -- normalization must NOT paper over it.
-        self.assertFalse(self._accepted("The quick brown fox jumps over the lazy dog.",
-                                         "The quick brown ... jumps over the lazy dog."))
 
 
 # ---------------------------------------------------------------------------
@@ -1643,23 +1601,23 @@ class TestWorkerDriver(unittest.TestCase):
         client = ScriptedClient([
             assistant_tool_call("c1", "fetch", {"url": "https://a.com/x"}),
             assistant_final(findings_block([
-                {"claim": "c", "excerpt": "this text was never fetched", "url": "https://a.com/x"}])),
+                {"claim": "c", "excerpt": "never actually fetched", "url": "https://a.com/NEVER-SEEN"}])),
             assistant_final(findings_block([
-                {"claim": "c", "excerpt": "still made up text", "url": "https://a.com/x"}])),
+                {"claim": "c", "excerpt": "still a hallucinated url", "url": "https://a.com/NEVER-SEEN"}])),
         ])
         result = self._run(client)
         self.assertEqual(result.status, "OK")
         self.assertEqual(result.findings["claims"], [])
         self.assertEqual(result.findings["invalid_claim_count"], 1)
         self.assertEqual(len(result.rejected_claims), 1)
-        self.assertEqual(result.rejected_claims[0]["reject_reason"], "excerpt_not_substring")
-        self.assertEqual(result.rejected_claims[0]["excerpt"], "still made up text")
+        self.assertEqual(result.rejected_claims[0]["reject_reason"], "url_not_in_journal")
+        self.assertEqual(result.rejected_claims[0]["excerpt"], "still a hallucinated url")
 
     def test_citation_retry_recovers_on_second_attempt(self):
         client = ScriptedClient([
             assistant_tool_call("c1", "fetch", {"url": "https://a.com/x"}),
             assistant_final(findings_block([
-                {"claim": "c", "excerpt": "made up", "url": "https://a.com/x"}])),
+                {"claim": "c", "excerpt": "anything", "url": "https://a.com/NEVER-SEEN"}])),
             assistant_final(findings_block([
                 {"claim": "c", "excerpt": "Rayleigh scattering explains the blue sky.", "url": "https://a.com/x"}])),
         ])
@@ -1776,8 +1734,8 @@ class TestWorkerDriver(unittest.TestCase):
         self.assertNotIn("language", claim)  # absent optional field not injected at worker level
 
     def test_mixed_valid_and_invalid_claims_stripped_not_failed(self):
-        # 10 valid claims (real fetched text) + 3 invalid (never-fetched
-        # excerpts) in the same findings JSON, on the very first turn --
+        # 10 valid claims (citing the fetched URL) + 3 invalid (citing a url
+        # never fetched) in the same findings JSON, on the very first turn --
         # citation_retry_used is still False so this triggers the one nudge,
         # and the model's retry response repeats the same 3 invalid claims
         # unchanged. The worker must not FAIL: finalize_findings() strips
@@ -1787,7 +1745,7 @@ class TestWorkerDriver(unittest.TestCase):
         valid_claims = [{"claim": f"valid claim {i}", "excerpt": fact, "url": "https://a.com/x"}
                         for i in range(10)]
         invalid_claims = [{"claim": f"invalid claim {i}", "excerpt": f"never fetched text {i}",
-                            "url": "https://a.com/x"} for i in range(3)]
+                            "url": "https://a.com/NEVER-SEEN"} for i in range(3)]
         client = ScriptedClient([
             assistant_tool_call("c1", "fetch", {"url": "https://a.com/x"}),
             assistant_final(findings_block(valid_claims + invalid_claims)),
@@ -1798,7 +1756,7 @@ class TestWorkerDriver(unittest.TestCase):
         self.assertEqual(len(result.findings["claims"]), 10)
         self.assertEqual(result.findings["invalid_claim_count"], 3)
         self.assertEqual(len(result.rejected_claims), 3)
-        self.assertTrue(all(rc["reject_reason"] == "excerpt_not_substring" for rc in result.rejected_claims))
+        self.assertTrue(all(rc["reject_reason"] == "url_not_in_journal" for rc in result.rejected_claims))
 
 
 class TestAppendOrMergeUser(unittest.TestCase):
@@ -1888,29 +1846,10 @@ class TestMergeFindings(unittest.TestCase):
                                 "credibility": 5, "language": "zh"}]},
         }
 
-    def test_strong_consensus_3_of_3(self):
-        judge = {"clusters": [{"summary": "s", "source_claim_ids": ["m1-1", "m2-1", "m3-1"], "relation": "agree"}],
-                 "coverage_gaps": [], "unique_insights": [], "blind_spots": []}
-        merged = harvest.merge_findings(self.worker_findings, judge)
-        self.assertEqual(merged["clusters"][0]["consensus"], "strong")
-
-    def test_strong_consensus_2_of_3(self):
-        judge = {"clusters": [{"summary": "s", "source_claim_ids": ["m1-1", "m2-1"], "relation": "agree"}],
-                 "coverage_gaps": [], "unique_insights": [], "blind_spots": []}
-        merged = harvest.merge_findings(self.worker_findings, judge)
-        self.assertEqual(merged["clusters"][0]["consensus"], "strong")
-
-    def test_minority_1_of_3(self):
-        judge = {"clusters": [{"summary": "s", "source_claim_ids": ["m1-1"], "relation": "agree"}],
-                 "coverage_gaps": [], "unique_insights": [], "blind_spots": []}
-        merged = harvest.merge_findings(self.worker_findings, judge)
-        self.assertEqual(merged["clusters"][0]["consensus"], "minority")
-
     def test_disputed_relation(self):
         judge = {"clusters": [{"summary": "s", "source_claim_ids": ["m1-1", "m2-1"], "relation": "contradict"}],
                  "coverage_gaps": [], "unique_insights": [], "blind_spots": []}
         merged = harvest.merge_findings(self.worker_findings, judge)
-        self.assertEqual(merged["clusters"][0]["consensus"], "disputed")
         self.assertIn("s", merged["contradictions"])
 
     def test_hallucinated_claim_id_dropped(self):
@@ -1935,11 +1874,6 @@ class TestMergeFindings(unittest.TestCase):
         merged = harvest.merge_findings(self.worker_findings, judge)
         self.assertEqual(merged["coverage_gaps"], ["gap1"])
         self.assertEqual(merged["blind_spots"], ["blind1"])
-
-    def test_consensus_stats_counts(self):
-        merged = {"clusters": [{"consensus": "strong"}, {"consensus": "strong"}, {"consensus": "minority"}]}
-        stats = harvest.compute_consensus_stats(merged)
-        self.assertEqual(stats, {"strong": 2, "minority": 1, "disputed": 0})
 
     def test_claim_in_two_clusters_kept_only_in_first(self):
         # Reproduces the real smoke-test defect: m2-1 assigned to both
@@ -2152,11 +2086,6 @@ class TestCheckProject(unittest.TestCase):
         verdict, reason = harvest.check_project(self.project_dir)
         self.assertEqual(verdict, "PASS")
 
-    def test_degraded_still_passes(self):
-        self._write_verify(verdict="DEGRADED")
-        verdict, reason = harvest.check_project(self.project_dir)
-        self.assertEqual(verdict, "PASS")
-
     def test_goal_hash_checked_against_conventional_intake_path(self):
         goal_dir = self.project_dir / "intake" / "requirements"
         goal_dir.mkdir(parents=True)
@@ -2335,13 +2264,11 @@ class TestCmdRunEndToEnd(unittest.TestCase):
         self.assertTrue(data["quorum_met"])
         self.assertEqual(data["total_claims"], 3)
         self.assertEqual(data["invalid_citation_rate"], 0.0)
-        self.assertEqual(data["consensus_stats"]["strong"], 1)
 
         merged_file = self.raw_dir / harvest.MERGED_FINDINGS_FILE
         self.assertTrue(merged_file.exists())
         merged = json.loads(merged_file.read_text(encoding="utf-8"))
         self.assertEqual(len(merged["clusters"]), 1)
-        self.assertEqual(merged["clusters"][0]["consensus"], "strong")
 
         self.assertTrue((self.raw_dir / "fetch-report.md").exists())
         for alias in ("m1", "m2", "m3"):
@@ -2350,6 +2277,94 @@ class TestCmdRunEndToEnd(unittest.TestCase):
             rejected_file = self.raw_dir / "harvest" / alias / "rejected_claims.json"
             self.assertTrue(rejected_file.exists())
             self.assertEqual(json.loads(rejected_file.read_text(encoding="utf-8")), [])
+
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "PASS", reason)
+
+    def test_zero_valid_claims_aborts_unavailable(self):
+        # Quorum is met (all three workers return status OK) but every
+        # claim cites a url the worker never fetched -- finalize_findings
+        # strips them all, leaving total_claims == 0. cmd_run must treat
+        # that as UNAVAILABLE (exit 3), not silently write an OK verdict
+        # over an empty merged-findings file.
+        bad_claim = {"claim": "c", "excerpt": "hallucinated", "url": "https://a.com/NEVER-SEEN"}
+        panel_scripts = {
+            model_id: ScriptedClient([
+                assistant_tool_call("c1", "fetch", {"url": "https://example.com/page1"}),
+                assistant_final(findings_block([bad_claim])),
+                assistant_final(findings_block([bad_claim])),
+            ])
+            for model_id in ["model-a", "model-b", "model-c"]
+        }
+        judge_text = ('```json\n{"clusters": [], "coverage_gaps": [], '
+                      '"unique_insights": [], "blind_spots": []}\n```')
+        judge_client = ScriptedClient([assistant_final(judge_text)])
+
+        def factory(model_id):
+            if model_id == "model-judge":
+                return judge_client
+            return panel_scripts[model_id]
+
+        config = base_config()
+        args = argparse_ns(goal_file=str(self.goal_file), out=str(self.raw_dir), config="unused", local_dir=None)
+
+        with mock.patch("harvest.load_config", return_value=config), \
+             mock.patch("harvest.make_client_factory", return_value=factory), \
+             mock.patch("harvest.call_fetch_backend", return_value="irrelevant fetched text"):
+            with self.assertRaises(SystemExit) as ctx:
+                harvest.cmd_run(args)
+        self.assertEqual(ctx.exception.code, 3)
+
+        verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
+        data = json.loads(verify_file.read_text(encoding="utf-8"))
+        self.assertEqual(data["verdict"], "UNAVAILABLE")
+
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "FAIL")
+
+    def test_partial_failure_yields_ok(self):
+        # 2 of 3 models alive (one dead outright) still meets quorum(2) and
+        # must produce verdict OK -- there is no "DEGRADED" tier anymore.
+        fact = "Rayleigh scattering explains why the sky looks blue."
+
+        def good_script(model_id):
+            return ScriptedClient([
+                assistant_tool_call("c1", "fetch", {"url": "https://example.com/page1"}),
+                assistant_final(findings_block([
+                    {"claim": f"claim from {model_id}", "excerpt": fact, "url": "https://example.com/page1",
+                     "credibility": 4, "language": "en"}])),
+            ])
+
+        class Dead:
+            def complete(self, messages, tools):
+                raise RuntimeError("down")
+
+        judge_text = ('```json\n{"clusters": [{"summary": "blue sky", '
+                      '"source_claim_ids": ["m1-1", "m2-1"], "relation": "agree"}], '
+                      '"coverage_gaps": [], "unique_insights": [], "blind_spots": []}\n```')
+        judge_client = ScriptedClient([assistant_final(judge_text)])
+
+        def factory(model_id):
+            if model_id == "model-judge":
+                return judge_client
+            if model_id == "model-c":
+                return Dead()
+            return good_script(model_id)
+
+        config = base_config()
+        args = argparse_ns(goal_file=str(self.goal_file), out=str(self.raw_dir), config="unused", local_dir=None)
+
+        with mock.patch("harvest.load_config", return_value=config), \
+             mock.patch("harvest.make_client_factory", return_value=factory), \
+             mock.patch("harvest.call_fetch_backend", return_value=fact):
+            harvest.cmd_run(args)
+
+        verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
+        data = json.loads(verify_file.read_text(encoding="utf-8"))
+        self.assertEqual(data["verdict"], "OK")
+        self.assertTrue(data["quorum_met"])
+        self.assertEqual(set(data["models_alive"]), {"m1", "m2"})
+        self.assertEqual(data["total_claims"], 2)
 
         verdict, reason = harvest.check_project(self.project_dir)
         self.assertEqual(verdict, "PASS", reason)
@@ -2782,7 +2797,7 @@ class TestFetchReportRealStats(unittest.TestCase):
             raw_dir = Path(tmpdir.name)
             r1 = harvest.WorkerResult("m1", "model-a", "OK", {"claims": [], "keywords_used": {"zh": [], "en": []}},
                                        [{"tool": "fetch", "url": "https://blog.csdn.net/x", "blocked": "blacklist", "content": None}])
-            harvest.write_fetch_report(raw_dir, [r1], [r1], {"strong": 0, "minority": 0, "disputed": 0}, 0, 0.0, [])
+            harvest.write_fetch_report(raw_dir, [r1], [r1], 0, 0.0, [])
             report = (raw_dir / "fetch-report.md").read_text(encoding="utf-8")
             self.assertIn("屏蔽源命中: 1", report)
             self.assertIn("blog.csdn.net", report)
@@ -2796,18 +2811,18 @@ class TestFetchReportRealStats(unittest.TestCase):
             r1 = harvest.WorkerResult(
                 "m1", "model-a", "OK", {"claims": [], "keywords_used": {"zh": [], "en": []}}, [],
                 rejected_claims=[
-                    {"claim": "c1", "url": "u1", "excerpt": "e1", "reject_reason": "excerpt_not_substring", "matched_url_normalized": "u1"},
+                    {"claim": "c1", "url": "u1", "excerpt": "e1", "reject_reason": "url_not_fetched", "matched_url_normalized": None},
                     {"claim": "c2", "url": "u2", "excerpt": "e2", "reject_reason": "url_not_in_journal", "matched_url_normalized": None},
                 ])
             r2 = harvest.WorkerResult(
                 "m2", "model-b", "OK", {"claims": [], "keywords_used": {"zh": [], "en": []}}, [],
                 rejected_claims=[
-                    {"claim": "c3", "url": "u3", "excerpt": "e3", "reject_reason": "excerpt_not_substring", "matched_url_normalized": "u3"},
+                    {"claim": "c3", "url": "u3", "excerpt": "e3", "reject_reason": "url_not_fetched", "matched_url_normalized": None},
                 ])
-            harvest.write_fetch_report(raw_dir, [r1, r2], [r1, r2], {"strong": 0, "minority": 0, "disputed": 0}, 3, 1.0, [])
+            harvest.write_fetch_report(raw_dir, [r1, r2], [r1, r2], 3, 1.0, [])
             report = (raw_dir / "fetch-report.md").read_text(encoding="utf-8")
             self.assertIn("按模型分布: {'m1': 2, 'm2': 1}", report)
-            self.assertIn("'excerpt_not_substring': 2", report)
+            self.assertIn("'url_not_fetched': 2", report)
             self.assertIn("'url_not_in_journal': 1", report)
         finally:
             tmpdir.cleanup()
@@ -2818,13 +2833,13 @@ class TestFetchReportRealStats(unittest.TestCase):
             raw_dir = Path(tmpdir.name)
             r1 = harvest.WorkerResult("m1", "model-a", "OK", {"claims": [], "keywords_used": {"zh": [], "en": []}}, [])
             # 1 alive model with default quorum_required=2 -> "not met".
-            harvest.write_fetch_report(raw_dir, [r1], [r1], {"strong": 0, "minority": 0, "disputed": 0}, 0, 0.0, [])
+            harvest.write_fetch_report(raw_dir, [r1], [r1], 0, 0.0, [])
             self.assertIn("法定人数状态: not met",
                            (raw_dir / "fetch-report.md").read_text(encoding="utf-8"))
 
             # Same 1 alive model, but limits.quorum=1 -> must report "met",
             # not the hardcoded-2 "not met".
-            harvest.write_fetch_report(raw_dir, [r1], [r1], {"strong": 0, "minority": 0, "disputed": 0}, 0, 0.0, [],
+            harvest.write_fetch_report(raw_dir, [r1], [r1], 0, 0.0, [],
                                         quorum_required=1)
             self.assertIn("法定人数状态: met",
                            (raw_dir / "fetch-report.md").read_text(encoding="utf-8"))
@@ -2836,7 +2851,7 @@ class TestFetchReportRealStats(unittest.TestCase):
         try:
             raw_dir = Path(tmpdir.name)
             r1 = harvest.WorkerResult("m1", "model-a", "OK", {"claims": [], "keywords_used": {"zh": [], "en": []}}, [])
-            harvest.write_fetch_report(raw_dir, [r1], [r1], {"strong": 0, "minority": 0, "disputed": 0}, 0, 0.0, [])
+            harvest.write_fetch_report(raw_dir, [r1], [r1], 0, 0.0, [])
             report = (raw_dir / "fetch-report.md").read_text(encoding="utf-8")
             self.assertIn("PENDING", report)
             self.assertNotIn("候选集完备性\n- N/A", report)
@@ -2860,7 +2875,7 @@ class TestFetchReportRealStats(unittest.TestCase):
         try:
             raw_dir = Path(tmpdir.name)
             r1 = harvest.WorkerResult("m1", "model-a", "OK", {"claims": [], "keywords_used": {"zh": [], "en": []}}, [])
-            harvest.write_fetch_report(raw_dir, [r1], [r1], {"strong": 0, "minority": 0, "disputed": 0}, 0, 0.0, [],
+            harvest.write_fetch_report(raw_dir, [r1], [r1], 0, 0.0, [],
                                         goal_text="研究类型\nnon-selection（事实核验类）")
             report = (raw_dir / "fetch-report.md").read_text(encoding="utf-8")
             self.assertIn("N/A（non-selection）", report)
@@ -2873,7 +2888,7 @@ class TestFetchReportRealStats(unittest.TestCase):
         try:
             raw_dir = Path(tmpdir.name)
             r1 = harvest.WorkerResult("m1", "model-a", "OK", {"claims": [], "keywords_used": {"zh": [], "en": []}}, [])
-            harvest.write_fetch_report(raw_dir, [r1], [r1], {"strong": 0, "minority": 0, "disputed": 0}, 0, 0.0, [],
+            harvest.write_fetch_report(raw_dir, [r1], [r1], 0, 0.0, [],
                                         goal_text="研究类型\nselection（选型类）")
             report = (raw_dir / "fetch-report.md").read_text(encoding="utf-8")
             self.assertIn("PENDING——harvester 须补填（selection 类必填）", report)


### PR DESCRIPTION
## Summary

harvest.py 多模型采集管线的三条架构减法：

- **引用校验 excerpt→URL**：只验证 URL 被 fetch 过，不再要求 excerpt verbatim substring。消除简繁体/HTML渲染差异导致的 false rejection（实测 gemini-flash 繁体源被误杀的根因）
- **砍掉 consensus labels**：不再计算 strong/minority/disputed 标签。共识是 judge 聚类的自然产物，不需要人为标签
- **verdict 二态化**：去掉 DEGRADED，quorum 满足+有 valid claims = OK

净减 ~44 行。同样的模型表现，旧版 DEGRADED 阻塞管线，新版 OK 继续走。

## Test plan

- [x] `python3.11 -m pytest plugins/deep-research/tests/test_harvest.py` → 242 passed, 9 skipped
- [x] Live run on 镜片选型项目 brand tuning track → verdict=OK
- [x] merged-findings.json: clusters 无 consensus 字段，contradictions 正确填充
- [x] harvest-verify.json: 无 consensus_stats，verdict 只有 OK/UNAVAILABLE

## Related

- Unblocks #62 (m3 步数耗尽不再导致 DEGRADED)
- Root cause for #63 (gemini grounding side-channel) 不在本 PR 范围
- Root cause for #64 (mid-loop network crash) 不在本 PR 范围