### PR TITLE
fix(harvest): completion 专用重试 + grounding 审计闭环 (v1.2.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -422,9 +422,10 @@ def _http_json_post(url, payload, headers, timeout):
 # degrade-to-next-backend behavior and are not retried here.
 _GATEWAY_RETRY_BACKOFFS_TRANSIENT = (5, 15)  # 429/408/5xx: up to 2 retries
 _GATEWAY_RETRY_BACKOFFS_OTHER_4XX = (5,)     # other 4xx (401/403/404...): 1 retry
+_COMPLETION_RETRY_BACKOFFS = (2, 5, 15, 30)  # 4 retries, 52s total backoff
 
 
-def _http_json_post_with_retry(url, payload, headers, timeout):
+def _http_json_post_with_retry(url, payload, headers, timeout, transient_backoffs=None):
     """Bounded retry around _http_json_post for transient gateway failures.
     Classification is fixed on the first failure's status code and the
     matching backoff schedule is followed to exhaustion -- no lock is held
@@ -447,16 +448,16 @@ def _http_json_post_with_retry(url, payload, headers, timeout):
             status = e.code
             if backoffs is None:
                 transient = status in (429, 408) or 500 <= status < 600
-                backoffs = _GATEWAY_RETRY_BACKOFFS_TRANSIENT if transient else _GATEWAY_RETRY_BACKOFFS_OTHER_4XX
+                backoffs = (transient_backoffs if transient_backoffs is not None else _GATEWAY_RETRY_BACKOFFS_TRANSIENT) if transient else _GATEWAY_RETRY_BACKOFFS_OTHER_4XX
             retries_done = attempt - 1
             if retries_done >= len(backoffs):
                 raise RuntimeError(f"HTTP {status} after {attempt} attempts") from e
             time.sleep(backoffs[retries_done])
-        except (urllib.error.URLError, socket.timeout, TimeoutError) as e:
+        except (urllib.error.URLError, socket.timeout, TimeoutError, json.JSONDecodeError) as e:
             # No status code (connection refused/reset, DNS failure, read
             # timeout, ...) -- always transient, same schedule as 429/5xx.
             if backoffs is None:
-                backoffs = _GATEWAY_RETRY_BACKOFFS_TRANSIENT
+                backoffs = transient_backoffs if transient_backoffs is not None else _GATEWAY_RETRY_BACKOFFS_TRANSIENT
             retries_done = attempt - 1
             if retries_done >= len(backoffs):
                 raise RuntimeError(f"network error after {attempt} attempts: {e}") from e
@@ -781,6 +782,11 @@ def do_search(query, lang, search_backends, journal, config):
                 # try the next backend instead of returning an empty set.
                 attempts.append({"backend": backend_cfg["type"], "error": "all results filtered by blacklist"})
                 continue
+            if backend_cfg["type"] == "gemini-grounding":
+                for r in filtered:
+                    journal.append({"tool": "fetch", "url": r["url"],
+                                    "backend": "grounding",
+                                    "content": r.get("title") or r["url"]})
             journal.append({"tool": "search", "query": query, "lang": lang,
                              "backend": backend_cfg["type"], "urls": [r["url"] for r in filtered],
                              "attempts": attempts})
@@ -1129,7 +1135,8 @@ class GatewayClient:
         if tools:
             payload["tools"] = tools
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
-        return _http_json_post_with_retry(url, payload, headers, self.timeout_s)
+        return _http_json_post_with_retry(url, payload, headers, self.timeout_s,
+                                           transient_backoffs=_COMPLETION_RETRY_BACKOFFS)
 
 
 # ---------------------------------------------------------------------------
@@ -1156,7 +1163,7 @@ def _read_http_error_body(e):
         return "<error body unavailable>"
 
 
-def _anthropic_post_with_retry(url, payload, headers, timeout):
+def _anthropic_post_with_retry(url, payload, headers, timeout, transient_backoffs=None):
     """Retry wrapper for the Anthropic /messages endpoint. Unlike the OpenAI
     gateway path, a non-transient 4xx (400/401/403/404) is NOT retried -- a
     malformed request body fails identically on a resend, so we surface the
@@ -1164,7 +1171,7 @@ def _anthropic_post_with_retry(url, payload, headers, timeout):
     network-layer failures follow the transient backoff schedule. HTTPError
     is caught before URLError (its parent) so the status-bearing case isn't
     swallowed."""
-    backoffs = _GATEWAY_RETRY_BACKOFFS_TRANSIENT
+    backoffs = transient_backoffs if transient_backoffs is not None else _GATEWAY_RETRY_BACKOFFS_TRANSIENT
     attempt = 0
     while True:
         attempt += 1
@@ -1179,7 +1186,7 @@ def _anthropic_post_with_retry(url, payload, headers, timeout):
             if attempt - 1 >= len(backoffs):
                 raise RuntimeError(f"Anthropic HTTP {status} after {attempt} attempts: {body}") from e
             time.sleep(backoffs[attempt - 1])
-        except (urllib.error.URLError, socket.timeout, TimeoutError) as e:
+        except (urllib.error.URLError, socket.timeout, TimeoutError, json.JSONDecodeError) as e:
             if attempt - 1 >= len(backoffs):
                 raise RuntimeError(f"Anthropic network error after {attempt} attempts: {e}") from e
             time.sleep(backoffs[attempt - 1])
@@ -1390,7 +1397,8 @@ class AnthropicGatewayClient:
             "Content-Type": "application/json",
             "anthropic-version": "2023-06-01",
         }
-        resp = _anthropic_post_with_retry(url, payload, headers, self.timeout_s)
+        resp = _anthropic_post_with_retry(url, payload, headers, self.timeout_s,
+                                          transient_backoffs=_COMPLETION_RETRY_BACKOFFS)
         return _anthropic_resp_to_oai(resp)
 
 
@@ -1619,7 +1627,10 @@ def run_worker(alias, model_id, client, config, search_backends, fetch_backends,
         for _ in range(max_steps):
             if time.monotonic() > deadline:
                 return WorkerResult(alias, model_id, "FAILED", None, journal, "wall_clock_exceeded")
-            resp = client.complete(messages=messages, tools=TOOL_SCHEMAS)
+            try:
+                resp = client.complete(messages=messages, tools=TOOL_SCHEMAS)
+            except Exception:
+                break
             message = _extract_message(resp)
             if message is None:
                 return WorkerResult(alias, model_id, "FAILED", None, journal, "bad_response")
@@ -1686,7 +1697,11 @@ def run_worker(alias, model_id, client, config, search_backends, fetch_backends,
         # the unchanged prefix instead of invalidating it over a
         # tools-block diff. The prompt text is what actually stops the
         # model from calling a tool, not the schema's absence.
-        resp = client.complete(messages=messages, tools=TOOL_SCHEMAS)
+        try:
+            resp = client.complete(messages=messages, tools=TOOL_SCHEMAS)
+        except Exception as e:
+            return WorkerResult(alias, model_id, "FAILED", None, journal,
+                                f"synthesis_failed ({type(e).__name__}): {e}")
         message = _extract_message(resp)
         if message is None:
             return WorkerResult(alias, model_id, "FAILED", None, journal, "step_limit_no_synthesis")

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -907,7 +907,8 @@ class TestGeminiGroundingFallThrough(unittest.TestCase):
             result = harvest.do_search("q", "en", backends, journal, cfg)
         data = json.loads(result)
         self.assertEqual(data["results"][0]["url"], "https://real.example.com/article")
-        self.assertEqual(journal[0]["backend"], "gemini-grounding")
+        search_entries = [e for e in journal if e.get("tool") == "search"]
+        self.assertEqual(search_entries[0]["backend"], "gemini-grounding")
 
 
 # ---------------------------------------------------------------------------
@@ -971,15 +972,22 @@ class TestGatewayRetry(unittest.TestCase):
         self.assertEqual(calls, [5])
 
     def test_worker_records_http_status_and_attempt_count_in_reason(self):
+        # Every call.complete() exhausts its own 3-attempt 503 retry budget,
+        # so both the main loop's call (caught, breaks to forced synthesis)
+        # and the forced-synthesis call itself raise -- landing on
+        # synthesis_failed with the underlying HTTP detail preserved.
         class FlakyClient:
             def complete(self, messages, tools):
                 url = "http://gw/chat/completions"
                 return harvest._http_json_post_with_retry(url, {}, {}, 5)
 
-        with mock.patch("harvest._http_json_post", side_effect=[_http_error(503), _http_error(503), _http_error(503)]), \
+        with mock.patch("harvest._http_json_post",
+                         side_effect=[_http_error(503), _http_error(503), _http_error(503),
+                                      _http_error(503), _http_error(503), _http_error(503)]), \
              mock.patch("harvest.time.sleep"):
             result = harvest.run_worker("m1", "model-a", FlakyClient(), base_config(), [], [], "goal", [], None)
         self.assertEqual(result.status, "FAILED")
+        self.assertTrue(result.reason.startswith("synthesis_failed (RuntimeError):"), result.reason)
         self.assertIn("HTTP 503 after 3 attempts", result.reason)
 
     def test_gateway_client_complete_uses_retry_wrapper(self):
@@ -1709,12 +1717,16 @@ class TestWorkerDriver(unittest.TestCase):
         self.assertIn("Tool-use budget exhausted", forced_messages[-1]["content"])
 
     def test_worker_exception_isolated_not_raised(self):
+        # An always-raising client never propagates out of run_worker -- the
+        # main loop's except breaks to forced synthesis, which raises again
+        # and is caught there too, so the worker returns FAILED instead of
+        # letting the exception escape.
         class ExplodingClient:
             def complete(self, messages, tools):
                 raise RuntimeError("network exploded")
         result = harvest.run_worker("m1", "model-a", ExplodingClient(), self.config, [], self.fetch_backends, "goal", [], None)
         self.assertEqual(result.status, "FAILED")
-        self.assertIn("exception", result.reason)
+        self.assertIn("network exploded", result.reason)
 
     def test_bad_response_shape_handled(self):
         client = ScriptedClient([{"unexpected": "shape"}])
@@ -3075,6 +3087,117 @@ class TestAnthropicConversion(unittest.TestCase):
         msgs = [{"role": "user", "content": ""}]
         harvest._inject_cache_control(None, None, msgs)
         self.assertEqual(msgs[0]["content"], "")  # untouched, no empty block created
+
+
+# ---------------------------------------------------------------------------
+# #64: completion-call retry schedule + forced-synthesis recovery on
+# exhausted retries
+# ---------------------------------------------------------------------------
+
+def _raise_network_error(messages, tools):
+    raise RuntimeError("network error after 5 attempts: Connection reset")
+
+
+class TestCompletionRetryAndForcedSynthesisRecovery(unittest.TestCase):
+    def setUp(self):
+        self.config = base_config()
+        self.fetch_backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
+        patcher = mock.patch("harvest._ssrf_precheck")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_retry_with_completion_backoffs_recovers_after_two_transient_failures(self):
+        ok_response = {"choices": [{"message": {"role": "assistant", "content": "hi"}}]}
+        with mock.patch("harvest._http_json_post",
+                         side_effect=[harvest.urllib.error.URLError("connection reset"),
+                                      harvest.urllib.error.URLError("connection reset"),
+                                      ok_response]) as m, \
+             mock.patch("harvest.time.sleep") as sleep_mock:
+            result = harvest._http_json_post_with_retry(
+                "http://gw/chat/completions", {}, {}, 5,
+                transient_backoffs=harvest._COMPLETION_RETRY_BACKOFFS)
+        self.assertEqual(result, ok_response)
+        self.assertEqual(m.call_count, 3)
+        sleep_mock.assert_has_calls([mock.call(2), mock.call(5)])
+
+    def test_transient_failure_mid_loop_recovers_via_forced_synthesis(self):
+        # First round does real search/fetch work and lands in the journal;
+        # the second round's completion call exhausts its retry budget and
+        # raises -- run_worker's existing `except Exception: break` drops out
+        # of the main loop (not straight to FAILED) and the forced-synthesis
+        # call that follows successfully turns the round-1 evidence into OK
+        # findings.
+        fact = "Rayleigh scattering explains the blue sky."
+        client = ScriptedClient([
+            assistant_tool_call("c1", "fetch", {"url": "https://a.com/x"}),
+            _raise_network_error,
+            assistant_final(findings_block([
+                {"claim": "c", "excerpt": fact, "url": "https://a.com/x",
+                 "credibility": 4, "language": "en"}])),
+        ])
+        with mock.patch("harvest.call_fetch_backend", return_value=fact):
+            result = harvest.run_worker("m1", "model-a", client, self.config, [],
+                                         self.fetch_backends, "goal", [], None)
+        self.assertEqual(result.status, "OK")
+        self.assertEqual(len(result.findings["claims"]), 1)
+        self.assertTrue(any(e.get("tool") == "fetch" and e.get("url") == "https://a.com/x"
+                             for e in result.journal))
+
+    def test_persistent_failure_gives_synthesis_failed_reason(self):
+        class AlwaysFails:
+            def complete(self, messages, tools):
+                raise RuntimeError("network error after 5 attempts: Connection reset")
+
+        result = harvest.run_worker("m1", "model-a", AlwaysFails(), self.config, [],
+                                     self.fetch_backends, "goal", [], None)
+        self.assertEqual(result.status, "FAILED")
+        self.assertTrue(result.reason.startswith("synthesis_failed (RuntimeError):"),
+                         result.reason)
+
+
+# ---------------------------------------------------------------------------
+# #63: gemini-grounding search results are also injected into the journal as
+# synthetic fetch entries, so a claim citing a grounding-search URL validates
+# without needing an explicit fetch() tool call.
+# ---------------------------------------------------------------------------
+
+class TestGeminiGroundingJournalInjection(unittest.TestCase):
+    def _grounding_results(self):
+        return [
+            {"url": "https://example.com/page1", "title": "Page One", "snippet": "Page One"},
+            {"url": "https://example.com/page2", "title": "", "snippet": ""},
+        ]
+
+    def test_search_injects_fetch_entries_with_title_or_url_fallback(self):
+        journal = []
+        cfg = base_config()
+        backends = [({"type": "gemini-grounding", "model": "g"}, harvest.RateLimiter(0))]
+        with mock.patch("harvest.call_search_backend", return_value=self._grounding_results()):
+            harvest.do_search("q", "en", backends, journal, cfg)
+
+        fetch_entries = [e for e in journal if e.get("tool") == "fetch"]
+        self.assertEqual(len(fetch_entries), 2)
+        self.assertTrue(all(e["backend"] == "grounding" for e in fetch_entries))
+        by_url = {e["url"]: e["content"] for e in fetch_entries}
+        self.assertEqual(by_url["https://example.com/page1"], "Page One")
+        self.assertEqual(by_url["https://example.com/page2"], "https://example.com/page2")
+
+    def test_grounding_journal_entries_pass_citation_validation(self):
+        journal = []
+        cfg = base_config()
+        backends = [({"type": "gemini-grounding", "model": "g"}, harvest.RateLimiter(0))]
+        with mock.patch("harvest.call_search_backend", return_value=self._grounding_results()):
+            harvest.do_search("q", "en", backends, journal, cfg)
+
+        claims = harvest.assign_claim_ids("m1", [
+            {"claim": "c1", "excerpt": "Page One", "url": "https://example.com/page1"},
+            {"claim": "c2", "excerpt": "https://example.com/page2", "url": "https://example.com/page2"},
+        ])
+        idx = harvest.build_fetch_index(journal)
+        urls = harvest.build_journal_url_set(journal)
+        valid, invalid = harvest.validate_claims(claims, idx, urls)
+        self.assertEqual(len(valid), 2)
+        self.assertEqual(invalid, [])
 
 
 class argparse_ns:


### PR DESCRIPTION
## Summary
Reapply of #66 (reverted for Copilot review gate compliance).

- **#64**: `client.complete()` 网络错误不再跳过 forced synthesis
  - `_COMPLETION_RETRY_BACKOFFS (2,5,15,30)` 专用重试时间表
  - agentic loop 内异常 break → forced synthesis 抢救路径
  - retry 层扩展捕获 `json.JSONDecodeError`
- **#63**: gemini-grounding side-channel 纳入 journal 审计链
  - `do_search` 对 grounding 结果注入 `tool=fetch, backend=grounding` 条目
- **版本**: deep-research 1.2.0 → 1.2.1

## Test plan
- [x] 256 tests passed, 0 regressions
- [ ] Copilot code review

Closes #63, closes #64