### PR TITLE
feat(deep-research): Stage 7 增加 HTML 报告发布能力 (research-publisher)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -51,8 +51,8 @@
     },
     {
       "name": "deep-research",
-      "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-      "version": "1.2.1",
+      "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
+      "version": "1.3.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,12 +1,13 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [
     "./agents/research-harvester.md",
     "./agents/research-analyst.md",
-    "./agents/research-reviewer.md"
+    "./agents/research-reviewer.md",
+    "./agents/research-publisher.md"
   ]
 }

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-research",
-  "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer) + multi-model harvest & citation-verification gate",
+  "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
   "version": "1.3.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],

--- a/plugins/deep-research/agents/research-publisher.md
+++ b/plugins/deep-research/agents/research-publisher.md
@@ -1,0 +1,79 @@
+---
+name: research-publisher
+description: |
+  负责深度研究管线 Stage 7 Delivery 末端的发布执行者。当已审阅通过的
+  report.md（+ executive_summary.md / references.md）在 deliverables/final/
+  定稿后，需要渲染成自包含 HTML 展示视图（report.html）时，spawn 此
+  subagent。典型触发场景：Stage 6 Validation 审阅 APPROVED、deliverables/final
+  下的 report.md 已是终稿、需要产出可离线打开的单文件 HTML 展示版本。铁律：
+  零新事实、保留全部引用链接、自包含（零外部资源）、只读 deliverables/final
+  不改上游 pipeline、不改 report.md 本身。
+tools: Read, Write, Bash
+model: sonnet
+color: cyan
+---
+
+# research-publisher 角色定义
+
+**职责**：Stage 7 Delivery 末端的渲染执行者。把已审阅通过的 report.md 渲染成自包含 HTML 展示视图，不产出新事实。
+
+---
+
+## 输入
+
+| 来源 | 目录/路径 | 权限 |
+|------|----------|------|
+| 报告正文 | `deliverables/final/report.md` | 只读 |
+| 执行摘要 | `deliverables/final/executive_summary.md` | 只读（若存在） |
+| 引用清单 | `deliverables/final/references.md` | 只读（若存在） |
+| 多文档索引 | `deliverables/final/INDEX.md` | 只读（若存在） |
+| HTML 模板 | `${CLAUDE_PLUGIN_ROOT}/skills/deep-research/assets/report-shell.html.tmpl` | 只读 |
+| 渲染规范 | `${CLAUDE_PLUGIN_ROOT}/skills/deep-research/assets/report-html-guide.md` | 只读 |
+
+**铁律**：只读 `deliverables/final/`，禁止修改 `pipeline/` 下任何目录，禁止修改 `report.md`/`executive_summary.md`/`references.md` 本身。
+
+## 输出
+
+| 产物 | 目录 | Stage |
+|------|------|-------|
+| 自包含 HTML 展示报告 | `deliverables/final/report.html` | Stage 7 Delivery |
+
+## 工作模式（渲染流程）
+
+1. 读 `report.md`（+ `executive_summary.md` + `references.md` + 若存在 `INDEX.md`），建立内容与结构的完整认知
+2. 读 `report-shell.html.tmpl` 模板结构 + `report-html-guide.md` 的组件词汇表与内容→组件映射规则
+3. 按映射规则把 markdown 内容渲染进对应组件（结论/推荐方案对应 verdict-bar；方案对比矩阵对应 signal 染色表；分阶段路线图对应 phase-timeline；数据就绪度对应 data-grid；并列风险/要点对应 card-grid；关键提示对应 callout；并列问题清单对应 pain-list；ASCII 架构图对应 arch-diagram；拿不准就用朴素 section + p，不硬套组件）。填充模板占位符：`{{TITLE}}` `{{THEME}}` `{{HERO_EYEBROW}}` `{{HERO_H1}}` `{{HERO_SUB}}` `{{HERO_META}}` `{{CONTENT}}`
+4. 写出 `deliverables/final/report.html`
+5. **自检（强制）**：调用 verify 脚本自校验（见下「自检机械门」）；不 PASS 则修正后复渲，循环直到 PASS 才算完成
+
+## 渲染铁律
+
+- **零新事实**：HTML 只能包含 report.md（+ executive_summary.md / references.md）已有信息，不得新增数据、编造示例或"合理推测"补全空白
+- **引用链接零丢失**：report.md 中所有 markdown 引用链接必须一个不漏地渲染为可点击超链接
+- **双语术语原样保留**：中英文术语对照渲染时不做增删改写
+- **自包含**：零外部资源，字体用 local() 引用系统字体，CSS 内联在 style 标签中，不引用外部脚本、样式表或图片资源，产出单文件必须能离线打开
+- **Correction Record / 多文档权威关系如实呈现**：若 report.md 头部有 SUPERSEDED/部分修正声明，或 INDEX.md 标注了 PRIMARY/CURRENT/HISTORICAL 权威关系，HTML 必须用 callout 组件显著标出，不得抹平已修正、已下调的结论
+
+## 自检机械门
+
+渲染完成后**必须**运行：
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/verify_report_html.py <项目 deliverables/final 目录 或 report.html 路径>
+```
+
+三态 exit code：`0`=PASS（自包含 + 链接/章节守恒）/ `1`=FAIL（打印缺失清单，须修正后复渲）/ `2`=N/A（report.html 尚不存在）。
+
+**能力边界（如实声明，不夸大）**：机械门只覆盖**结构性丢失**——链接是否守恒、章节是否守恒、有无违规外部资源引用。它不能校验**语义性捏造**（凭空新增事实、扭曲原文含义），这部分由 Lead 的视觉核验兜底。verify 脚本 PASS 不等于内容零新事实，publisher 自己在渲染时就要守住这条线。
+
+## 主题选择
+
+默认 `midnight`（暗色），技术/工程类报告适用大多数场景；仅当报告明显偏商业/评审场景或用户明确偏好亮色阅读时选 `daylight`。详见 `report-html-guide.md` ③ 主题变体选择规则。
+
+## 上下文经济学
+
+publisher 在自己的 Task 内直接使用 Read/Write/Bash 完成渲染与自检，不嵌套 subagent。渲染是 Delivery 末端的纯派生动作，只产出 `report.html`，不回写 `pipeline/` 或修改 `report.md` 本身。
+
+---
+
+**关联文件**：deep-research skill 的 references/pipeline.md（Stage 7）· assets/report-shell.html.tmpl · assets/report-html-guide.md · assets/deliverable-matrix.md · scripts/verify_report_html.py

--- a/plugins/deep-research/scripts/verify_report_html.py
+++ b/plugins/deep-research/scripts/verify_report_html.py
@@ -104,11 +104,22 @@ def _normalize_url(url: str) -> str:
 
 
 def extract_md_urls(text: str) -> set:
-    """Extract all URLs referenced from markdown text: link-form and bare."""
+    """Extract all URLs referenced from markdown text: link-form and bare.
+
+    Fenced code blocks are stripped first (symmetric with extract_md_headings):
+    a URL inside a ```code block``` -- an example curl command, a repo URL in
+    a config snippet -- is not a citation. Per report-html-guide.md the
+    publisher renders code blocks as arch-diagram/<pre> plain text and MUST
+    NOT linkify their contents, so such URLs never get an href/src in the
+    HTML. Counting them as "must-be-conserved links" would false-positive a
+    correctly rendered report into an unsatisfiable FAIL (a deadlock trap
+    the publisher cannot fix). Only prose-level links must survive.
+    """
+    body = strip_code_fences(text)
     urls = set()
-    for m in _MD_LINK_URL_RE.finditer(text):
+    for m in _MD_LINK_URL_RE.finditer(body):
         urls.add(_normalize_url(m.group(1)))
-    for m in _BARE_URL_RE.finditer(text):
+    for m in _BARE_URL_RE.finditer(body):
         urls.add(_normalize_url(_strip_trailing_punct(m.group(0))))
     return urls
 

--- a/plugins/deep-research/scripts/verify_report_html.py
+++ b/plugins/deep-research/scripts/verify_report_html.py
@@ -5,9 +5,12 @@ Contract under test: report.html = f(report.md), zero new facts. This script
 cannot verify "zero new facts" (that's semantic, left to Lead's visual review)
 but it CAN mechanically verify the structural half of the contract:
 
-1. Link conservation: every URL in report.md (+ references.md, if present)
+1. Link conservation: every URL in report.md's prose (both [text](url) and
+   bare http(s):// forms; fenced code blocks and inline code spans excluded)
    must survive into report.html's href/src attributes (after HTML-unescaping,
-   since markdown "&" in a URL renders as "&amp;" in HTML).
+   since markdown "&" in a URL renders as "&amp;" in HTML). Scoped to report.md
+   only -- references.md is a separate deliverable the publisher does not
+   render into report.html, so its URLs are NOT in the must-conserve set.
 2. Section conservation: every ## / ### heading in report.md must have its
    text appear somewhere in report.html's rendered text.
 3. Self-containment: no external <link>/<script>/<img> resource loads, no

--- a/plugins/deep-research/scripts/verify_report_html.py
+++ b/plugins/deep-research/scripts/verify_report_html.py
@@ -53,6 +53,11 @@ _BARE_URL_RE = re.compile(r"(?<!\]\()https?://[^\s)>\]]+")
 # code (shell comments, etc.) never masquerades as a markdown heading.
 _CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
 
+# Inline code span (single backtick pair). Stripped ONLY on the URL-extraction
+# path (not headings): a URL inside `...` renders as <code> plain text with no
+# href, so it must not be counted as a must-conserve link.
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
 # ## or ### heading, but not #### or deeper (negative lookahead on the 4th #).
 _HEADING_RE = re.compile(r"^(#{2,3})(?!#)\s+(.+?)\s*$", re.MULTILINE)
 
@@ -106,16 +111,22 @@ def _normalize_url(url: str) -> str:
 def extract_md_urls(text: str) -> set:
     """Extract all URLs referenced from markdown text: link-form and bare.
 
-    Fenced code blocks are stripped first (symmetric with extract_md_headings):
-    a URL inside a ```code block``` -- an example curl command, a repo URL in
-    a config snippet -- is not a citation. Per report-html-guide.md the
-    publisher renders code blocks as arch-diagram/<pre> plain text and MUST
-    NOT linkify their contents, so such URLs never get an href/src in the
-    HTML. Counting them as "must-be-conserved links" would false-positive a
-    correctly rendered report into an unsatisfiable FAIL (a deadlock trap
-    the publisher cannot fix). Only prose-level links must survive.
+    Both fenced code blocks (```...```) AND inline code spans (`...`) are
+    stripped first: a URL inside code -- an example curl command, a repo URL
+    in a config snippet, an API endpoint written as `https://api.example/v1`
+    -- is not a citation. Per report-html-guide.md the publisher renders code
+    as arch-diagram/<pre> or <code> plain text and MUST NOT linkify its
+    contents, so such URLs never get an href/src in the HTML. Counting them
+    as "must-be-conserved links" would false-positive a correctly rendered
+    report into an unsatisfiable FAIL (a deadlock trap the publisher cannot
+    fix). Only prose-level links must survive.
+
+    NOTE: this code-span stripping is intentionally confined to the URL
+    path. extract_md_headings does NOT strip inline code, because a heading
+    like `## 关于 primary_job` needs its identifier text preserved for the
+    _normalize_for_match comparison (see the underscore/em-dash fix).
     """
-    body = strip_code_fences(text)
+    body = _INLINE_CODE_RE.sub(" ", strip_code_fences(text))
     urls = set()
     for m in _MD_LINK_URL_RE.finditer(body):
         urls.add(_normalize_url(m.group(1)))
@@ -239,7 +250,12 @@ def check_report_html(path_arg: str):
     "PASS" / "FAIL" / "N_A". details is a list of human-readable strings
     (empty on PASS/N_A, itemized violations on FAIL).
     """
-    report_md_path, references_md_path, report_html_path = resolve_paths(path_arg)
+    # references.md is intentionally NOT unpacked/used here: the HTML is
+    # strictly f(report.md), and references.md is an independent deliverable
+    # (the full >=20-link bibliography) that the publisher does not render.
+    # Requiring its links to survive into the HTML would be an unsatisfiable
+    # FAIL. Link conservation is scoped to report.md's own links only.
+    report_md_path, _references_md_path, report_html_path = resolve_paths(path_arg)
 
     if report_html_path is None:
         return "N_A", "report.html does not exist yet -- nothing to verify", []
@@ -248,17 +264,16 @@ def check_report_html(path_arg: str):
         return "N_A", "report.md not found alongside report.html -- cannot verify against a primary source", []
 
     md_text = report_md_path.read_text(encoding="utf-8")
-    references_text = references_md_path.read_text(encoding="utf-8") if references_md_path else ""
     html_text = report_html_path.read_text(encoding="utf-8")
 
     details = []
 
-    # 1. Link conservation
-    md_urls = extract_md_urls(md_text) | extract_md_urls(references_text)
+    # 1. Link conservation (scoped to report.md only -- see note above)
+    md_urls = extract_md_urls(md_text)
     html_urls = extract_html_urls(html_text)
     missing_urls = sorted(md_urls - html_urls)
     for url in missing_urls:
-        details.append(f"missing link: {url} (present in report.md/references.md, absent from report.html)")
+        details.append(f"missing link: {url} (present in report.md, absent from report.html)")
 
     # 2. Section conservation (compare on normalized keys so lossless
     #    display-layer typography -- separator swaps, punctuation -- doesn't

--- a/plugins/deep-research/scripts/verify_report_html.py
+++ b/plugins/deep-research/scripts/verify_report_html.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""verify_report_html.py -- deterministic mechanical gate for research-publisher.
+
+Contract under test: report.html = f(report.md), zero new facts. This script
+cannot verify "zero new facts" (that's semantic, left to Lead's visual review)
+but it CAN mechanically verify the structural half of the contract:
+
+1. Link conservation: every URL in report.md (+ references.md, if present)
+   must survive into report.html's href/src attributes (after HTML-unescaping,
+   since markdown "&" in a URL renders as "&amp;" in HTML).
+2. Section conservation: every ## / ### heading in report.md must have its
+   text appear somewhere in report.html's rendered text.
+3. Self-containment: no external <link>/<script>/<img> resource loads, no
+   external @import -- report.html must open offline as a single file.
+   (Content-level <a href="http..."> reference links are legitimate and NOT
+   flagged -- those are the report's citations, not resource loads.)
+4. Zero-JS house style (bonus): no <script> tag at all, external or not.
+
+Stdlib only. Three-state exit code, mirroring harvest.py's cmd_check /
+gate_check.py convention:
+
+    0 = PASS   (all checks satisfied)
+    1 = FAIL   (structural loss or self-containment violation; details printed)
+    2 = N/A    (report.html does not exist yet -- nothing to verify)
+
+CLI:
+    python3 verify_report_html.py <path>
+
+<path> is either a deliverables/final/ directory (report.md, references.md,
+report.html resolved by convention inside it) or a direct path to report.html
+(report.md / references.md resolved as siblings in the same directory).
+"""
+
+import argparse
+import html
+import re
+import sys
+from pathlib import Path
+
+_VERDICT_EXIT_CODES = {"PASS": 0, "FAIL": 1, "N_A": 2}
+
+# Markdown link URL: `[text](url)` -- captured group is the URL, terminated
+# at the first unescaped ')' or whitespace (URLs containing literal ')' are
+# a rare edge case we intentionally don't chase -- correctness on the common
+# case matters more than exhaustive coverage here).
+_MD_LINK_URL_RE = re.compile(r"\[[^\]]*\]\((https?://[^\s)]+)\)")
+
+# Bare http(s) URL not immediately preceded by "](" (i.e. not the URL portion
+# of a markdown link we already captured above via _MD_LINK_URL_RE).
+_BARE_URL_RE = re.compile(r"(?<!\]\()https?://[^\s)>\]]+")
+
+# Fenced code blocks, stripped before header/link scanning so that '#' inside
+# code (shell comments, etc.) never masquerades as a markdown heading.
+_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+
+# ## or ### heading, but not #### or deeper (negative lookahead on the 4th #).
+_HEADING_RE = re.compile(r"^(#{2,3})(?!#)\s+(.+?)\s*$", re.MULTILINE)
+
+# href="..." or src="..." attribute value, single or double quoted.
+_HTML_ATTR_RE = re.compile(r"""(?:href|src)\s*=\s*["']([^"']+)["']""", re.IGNORECASE)
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+_MD_LINK_TEXT_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+
+# Match-normalization: keep only alphanumerics and CJK, drop everything else
+# (punctuation, separators, whitespace, markdown emphasis markers). Applied
+# identically to both md heading text and HTML text before the containment
+# check, so display-layer typographic rewrites don't cause false positives:
+#   - "primary_job" -> "primaryjob" on BOTH sides (underscore dropped) so an
+#     identifier heading matches whether or not it kept the underscore;
+#   - " — " (em dash) and " · " (middle dot) both vanish, so a separator
+#     swap during rendering ("层 1 — X" -> "层 1 · X") still matches.
+# CJK range 㐀-鿿 covers CJK Unified Ideographs + Extension A, which
+# spans the Han characters that appear in these reports.
+_MATCH_STRIP_RE = re.compile(r"[^0-9a-z㐀-鿿]+")
+
+
+def _normalize_for_match(text: str) -> str:
+    """Reduce text to a comparison key: lowercase, alphanumerics + CJK only.
+
+    Shared by md-side (needle) and HTML-side (haystack) so the section
+    containment check compares semantic content, not exact byte sequences.
+    This does NOT weaken real-loss detection: an entirely dropped section's
+    substantive characters still won't appear anywhere in the normalized
+    HTML, so it still fails to match. It only tolerates lossless typographic
+    rewrites of a heading that IS present (separator/punctuation changes,
+    identifier underscores kept-or-dropped).
+    """
+    return _MATCH_STRIP_RE.sub("", text.lower())
+
+
+def _strip_trailing_punct(url: str) -> str:
+    """Strip trailing sentence punctuation markdown authors commonly leave
+    stuck to a bare URL (e.g. "see https://x.com/a." at end of a sentence)."""
+    return url.rstrip(".,;:)]}>'\"")
+
+
+def _normalize_url(url: str) -> str:
+    url = _strip_trailing_punct(url.strip())
+    if url.endswith("/") and url.count("/") > 2:
+        url = url[:-1]
+    return url
+
+
+def extract_md_urls(text: str) -> set:
+    """Extract all URLs referenced from markdown text: link-form and bare."""
+    urls = set()
+    for m in _MD_LINK_URL_RE.finditer(text):
+        urls.add(_normalize_url(m.group(1)))
+    for m in _BARE_URL_RE.finditer(text):
+        urls.add(_normalize_url(_strip_trailing_punct(m.group(0))))
+    return urls
+
+
+def extract_html_urls(html_text: str) -> set:
+    """Extract href/src attribute values from HTML, unescaped and normalized.
+
+    html.unescape() is the crux fix: markdown "&" in a URL renders as
+    "&amp;" in HTML attributes, so comparing raw attribute strings against
+    markdown URLs would false-positive on every ampersand-bearing URL.
+    """
+    urls = set()
+    for m in _HTML_ATTR_RE.finditer(html_text):
+        urls.add(_normalize_url(html.unescape(m.group(1))))
+    return urls
+
+
+def strip_code_fences(md_text: str) -> str:
+    return _CODE_FENCE_RE.sub("", md_text)
+
+
+def extract_md_headings(md_text: str) -> list:
+    """Extract ## / ### heading texts from markdown, code fences excluded.
+
+    Heading text keeps its raw characters (only markdown link syntax is
+    collapsed to its label); all punctuation/emphasis/separator normalization
+    is deferred to _normalize_for_match at comparison time, applied identically
+    to both sides. In particular underscores are preserved here so identifier
+    headings like "primary_job" are not mangled before the shared normalizer
+    runs.
+    """
+    body = strip_code_fences(md_text)
+    headings = []
+    for m in _HEADING_RE.finditer(body):
+        text = m.group(2)
+        text = _MD_LINK_TEXT_RE.sub(lambda lm: lm.group(1), text)
+        text = _WHITESPACE_RE.sub(" ", text).strip()
+        if text:
+            headings.append(text)
+    return headings
+
+
+def html_to_text(html_text: str) -> str:
+    """Strip tags to plain text for substring containment checks.
+
+    Not a full HTML parser -- deliberately simple, matching this project's
+    stdlib-only, mechanically-verifiable-by-inspection style (see
+    gate_check.py / harvest.py precedent). Good enough for "is this heading
+    text present somewhere in the rendered page."
+    """
+    # Drop <style>/<script> blocks wholesale -- their content is CSS/JS, not
+    # rendered prose, and could otherwise spuriously contain heading-like text.
+    no_style = re.sub(r"<style[^>]*>.*?</style>", " ", html_text, flags=re.DOTALL | re.IGNORECASE)
+    no_script = re.sub(r"<script[^>]*>.*?</script>", " ", no_style, flags=re.DOTALL | re.IGNORECASE)
+    no_comments = re.sub(r"<!--.*?-->", " ", no_script, flags=re.DOTALL)
+    text = _TAG_RE.sub(" ", no_comments)
+    text = html.unescape(text)
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+_EXTERNAL_RESOURCE_RE = re.compile(
+    r"""<(link|script|img)\b[^>]*\b(?:href|src)\s*=\s*["'](https?://[^"']+)["'][^>]*>""",
+    re.IGNORECASE,
+)
+_IMPORT_URL_RE = re.compile(r"@import\s+(?:url\()?[\"']?(https?://[^\"')\s]+)", re.IGNORECASE)
+_SCRIPT_TAG_RE = re.compile(r"<script\b", re.IGNORECASE)
+
+
+def find_external_resources(html_text: str) -> list:
+    """Return violations: external <link>/<script>/<img> resource loads or
+    @import url(http...). Content-level <a href="http..."> reference links
+    are NOT flagged here -- those are legitimate citations, not resource
+    fetches; see the caller for the <a> exclusion rationale.
+    """
+    violations = []
+    for m in _EXTERNAL_RESOURCE_RE.finditer(html_text):
+        tag, url = m.group(1).lower(), m.group(2)
+        violations.append(f'<{tag}> loads external resource: {url}')
+    for m in _IMPORT_URL_RE.finditer(html_text):
+        violations.append(f"@import loads external resource: {m.group(1)}")
+    return violations
+
+
+def find_script_tags(html_text: str) -> list:
+    """House style is zero-JS. Any <script> tag at all is a violation,
+    regardless of whether its src is external or inline."""
+    return [m.group(0) for m in _SCRIPT_TAG_RE.finditer(html_text)]
+
+
+def resolve_paths(path_arg: str):
+    """Resolve (report_md, references_md_or_None, report_html) from either
+    a deliverables/final/ directory or a direct report.html path.
+
+    Returns None for report_html specifically when it does not exist yet --
+    callers use that to signal the N/A verdict (nothing to verify yet).
+    """
+    p = Path(path_arg).resolve()
+    if p.is_dir():
+        directory = p
+        report_html = directory / "report.html"
+    else:
+        directory = p.parent
+        report_html = p
+
+    report_md = directory / "report.md"
+    references_md = directory / "references.md"
+
+    return (
+        report_md if report_md.exists() else None,
+        references_md if references_md.exists() else None,
+        report_html if report_html.exists() else None,
+    )
+
+
+def check_report_html(path_arg: str):
+    """Returns (verdict, reason, details). verdict is exactly one of
+    "PASS" / "FAIL" / "N_A". details is a list of human-readable strings
+    (empty on PASS/N_A, itemized violations on FAIL).
+    """
+    report_md_path, references_md_path, report_html_path = resolve_paths(path_arg)
+
+    if report_html_path is None:
+        return "N_A", "report.html does not exist yet -- nothing to verify", []
+
+    if report_md_path is None:
+        return "N_A", "report.md not found alongside report.html -- cannot verify against a primary source", []
+
+    md_text = report_md_path.read_text(encoding="utf-8")
+    references_text = references_md_path.read_text(encoding="utf-8") if references_md_path else ""
+    html_text = report_html_path.read_text(encoding="utf-8")
+
+    details = []
+
+    # 1. Link conservation
+    md_urls = extract_md_urls(md_text) | extract_md_urls(references_text)
+    html_urls = extract_html_urls(html_text)
+    missing_urls = sorted(md_urls - html_urls)
+    for url in missing_urls:
+        details.append(f"missing link: {url} (present in report.md/references.md, absent from report.html)")
+
+    # 2. Section conservation (compare on normalized keys so lossless
+    #    display-layer typography -- separator swaps, punctuation -- doesn't
+    #    false-positive; see _normalize_for_match).
+    md_headings = extract_md_headings(md_text)
+    html_match_key = _normalize_for_match(html_to_text(html_text))
+    missing_headings = [
+        h for h in md_headings if _normalize_for_match(h) not in html_match_key
+    ]
+    for h in missing_headings:
+        details.append(f'missing section: "{h}" (## / ### heading in report.md, absent from report.html)')
+
+    # 3. Self-containment
+    for violation in find_external_resources(html_text):
+        details.append(f"external resource: {violation}")
+
+    # 4. Zero-JS house style
+    for script_tag in find_script_tags(html_text):
+        details.append(f"script tag present (house style is zero-JS): {script_tag}")
+
+    if details:
+        reason = (
+            f"{len(missing_urls)} missing link(s), {len(missing_headings)} missing section(s), "
+            f"{len(details) - len(missing_urls) - len(missing_headings)} self-containment/JS violation(s)"
+        )
+        return "FAIL", reason, details
+
+    reason = f"{len(md_urls)} link(s) conserved, {len(md_headings)} section(s) conserved, self-contained OK"
+    return "PASS", reason, []
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="verify_report_html.py")
+    parser.add_argument(
+        "path",
+        help="deliverables/final/ directory, or a direct path to report.html",
+    )
+    args = parser.parse_args()
+
+    verdict, reason, details = check_report_html(args.path)
+    print(f"{verdict}: {reason}")
+    for line in details:
+        print(f"  - {line}")
+    sys.exit(_VERDICT_EXIT_CODES[verdict])
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/deep-research/skills/deep-research/SKILL.md
+++ b/plugins/deep-research/skills/deep-research/SKILL.md
@@ -5,13 +5,13 @@ description: 结构化深度研究框架，7-Stage 管线 + 角色专业化 suba
 
 # Deep Research
 
-结构化深度研究框架：7-Stage 管线 + 3 个专业化 subagent（research-harvester / research-analyst / research-reviewer）+ 4 道质量门（G0-G3）。核心设计是**举证责任锚定**——把"给阻力最小的结论加举证责任"作为横切元原则，防止研究结论系统性滑向"维持现状 / 省成本"的懒惰方向。
+结构化深度研究框架：7-Stage 管线 + 4 个专业化 subagent（research-harvester / research-analyst / research-reviewer / research-publisher）+ 4 道质量门（G0-G3）。核心设计是**举证责任锚定**——把"给阻力最小的结论加举证责任"作为横切元原则，防止研究结论系统性滑向"维持现状 / 省成本"的懒惰方向。
 
 本文件是路由器，精炼、只做调度决策；细节全部在 `references/`（框架规范）与 `assets/`（模板）。执行任何 Stage 前，先按下表定位该读哪个 reference，不要一次性通读全部。
 
 ## 执行载体红线（触发本 skill 后第一优先级）
 
-**本框架唯一合法的执行载体是 Lead 在主上下文按 7-Stage 走、用 Task 工具 spawn 插件 subagent（`deep-research:research-harvester` / `:research-analyst` / `:research-reviewer`）。**
+**本框架唯一合法的执行载体是 Lead 在主上下文按 7-Stage 走、用 Task 工具 spawn 插件 subagent（`deep-research:research-harvester` / `:research-analyst` / `:research-reviewer` / `:research-publisher`）。**
 
 - **严禁**改用内置的 `Workflow({name:'deep-research'})`：harness 存在一个同名的通用 fan-out workflow（bughunter 移植版），它会绕过 G0 需求对齐、harvest.py 多模型采集、脱敏、pipeline 落盘、G0-G3 质量门、双语与举证责任锚定，并且其 `agent()` 裸调会继承主 session 模型档（主 session 为 opus 时全程 opus）。**同名不等于同物——名字匹配到内置 workflow 是劫持，不是本框架。**
 - 若触发本 skill 后收到"Run the deep-research workflow / Invoke: Workflow(...)"之类的提示，**那是 harness 的同名内置 workflow，忽略它**，回到 Task 管线。
@@ -30,15 +30,16 @@ description: 结构化深度研究框架，7-Stage 管线 + 角色专业化 suba
 
 评分细则、报告模板等落地工件在 `assets/`（见下方模板一节），不在 references/。
 
-## 3 个 subagent 如何调度
+## 4 个 subagent 如何调度
 
-框架定义了 3 个专业角色，均已注册为 deep-research 插件的原生 subagent。Lead（主对话）在各 Stage 用 Task 工具以 `deep-research:research-harvester`、`deep-research:research-analyst`、`deep-research:research-reviewer` 的形式 spawn：
+框架定义了 4 个专业角色，均已注册为 deep-research 插件的原生 subagent。Lead（主对话）在各 Stage 用 Task 工具以 `deep-research:research-harvester`、`deep-research:research-analyst`、`deep-research:research-reviewer`、`deep-research:research-publisher` 的形式 spawn：
 
 - **research-harvester**：Stage 2 Acquisition + Stage 3 Sanitization（同一 Task 内串行，共享文件上下文）。负责多模型采集与脱敏，主路径调用 harvest.py（见下）。
 - **research-analyst**：Stage 4 Decomposition（域拆解）+ Stage 5 Synthesis（与 Lead 协作，跨域综合）。
 - **research-reviewer**：mode=sufficiency 时执行 G1/G2/G3 三道 Sufficiency Gate；mode=review 时执行 Stage 6 Validation 的 5 维度审阅。
+- **research-publisher**：Stage 7 Delivery 末端执行者，Lead 在 Delivery 定稿后 spawn 此 subagent，把 report.md 渲染成自包含 `report.html`（VIEW 层，派生自 report.md，零新事实）。model 继承 frontmatter=sonnet。
 
-G0（需求门）不派 subagent——由 Lead 在主上下文与用户对齐 primary_job/Non-Goals，这是全程唯一引入"模型外信号"的环节。Stage 7 Delivery、Stage 8 Landing（experimental）同样由 Lead 在主上下文执行，不派 subagent。
+G0（需求门）不派 subagent——由 Lead 在主上下文与用户对齐 primary_job/Non-Goals，这是全程唯一引入"模型外信号"的环节。Stage 7 Delivery 主体（report.md/executive_summary.md 等落盘）、Stage 8 Landing（experimental）同样由 Lead 在主上下文执行，不派 subagent；Stage 7 末端的 report.html 渲染是例外，交给 research-publisher。
 
 详细的 Task 隔离判据（何时必须隔离、何时主上下文直接做）见 `references/context-economics.md`。
 
@@ -82,7 +83,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/create-research-project.sh "研究主题" --type d
 
 ## 模板（assets/）
 
-Gate 评分细则：`assets/review-rubric.md`（5 维度审阅）、`assets/sufficiency-rubric.md`（8 维度充分性，含假设审计/证伪审计）。项目初始化：`assets/project-claude-md.tmpl`、`assets/project-gitignore.tmpl`、`assets/research-goal.md.tmpl`。交付物：`assets/deliverable-matrix.md`、`assets/deliverables-index.md.tmpl`、`assets/fetch-report.md.tmpl`。数据处理：`assets/redact.py.tmpl`。落地回填（experimental）：`assets/landing-feedback.md.tmpl`。完整清单见 `assets/INDEX.md`。
+Gate 评分细则：`assets/review-rubric.md`（5 维度审阅）、`assets/sufficiency-rubric.md`（8 维度充分性，含假设审计/证伪审计）。项目初始化：`assets/project-claude-md.tmpl`、`assets/project-gitignore.tmpl`、`assets/research-goal.md.tmpl`。交付物：`assets/deliverable-matrix.md`、`assets/deliverables-index.md.tmpl`、`assets/fetch-report.md.tmpl`、`assets/report-shell.html.tmpl`（report.html house style 模板）、`assets/report-html-guide.md`（HTML 渲染设计规范，research-publisher 参照）。数据处理：`assets/redact.py.tmpl`。落地回填（experimental）：`assets/landing-feedback.md.tmpl`。完整清单见 `assets/INDEX.md`。
 
 ## 依赖前置
 

--- a/plugins/deep-research/skills/deep-research/assets/INDEX.md
+++ b/plugins/deep-research/skills/deep-research/assets/INDEX.md
@@ -22,4 +22,4 @@
 
 - Playbooks: `../references/playbooks-INDEX.md` -- 研究类型剧本
 - Framework: `../references/framework-INDEX.md` -- 管线、质量门控、上下文经济学
-- Agents: 见 deep-research 插件的 research-harvester / research-analyst / research-reviewer subagent
+- Agents: 见 deep-research 插件的 research-harvester / research-analyst / research-reviewer / research-publisher subagent

--- a/plugins/deep-research/skills/deep-research/assets/INDEX.md
+++ b/plugins/deep-research/skills/deep-research/assets/INDEX.md
@@ -15,6 +15,8 @@
 | `deliverable-matrix.md` | 报告交付物矩阵 | Lead 在 Delivery Stage 参照，确定最终输出结构 |
 | `deliverables-index.md.tmpl` | 交付物权威关系索引模板 | 多文档 deliverables 必备，声明 PRIMARY/CURRENT/HISTORICAL（见 principles.md 原则 5） |
 | `landing-feedback.md.tmpl` | Stage 8 Landing 回填模板（⚠ experimental） | Lead 在 Stage 8 落地实测后回写，五段结构（落地概览 / 四分类 Delta 表 / delta 分述 / 方法论边界声明 / 权威指针+补轨登记）。待 #11 字面复制验证后转 stable |
+| `report-shell.html.tmpl` | report.html house style 模板（暗色/亮色双主题、零 JS、自包含） | research-publisher agent 渲染 report.md 为 HTML 时填充占位符 |
+| `report-html-guide.md` | HTML 渲染设计规范（组件词汇表、内容→组件映射规则、渲染铁律） | research-publisher agent 渲染时参照，判断内容如何映射到 house style 组件 |
 
 ## 关联
 

--- a/plugins/deep-research/skills/deep-research/assets/deliverable-matrix.md
+++ b/plugins/deep-research/skills/deep-research/assets/deliverable-matrix.md
@@ -129,4 +129,10 @@
 
 ---
 
-**关联文件**：[pipeline.md](../references/pipeline.md) Stage 7 · [review-rubric.md](./review-rubric.md)
+## HTML 展示报告 (report.html)
+
+`report.html` 是 report.md 的 **VIEW 层**——自包含 HTML 展示视图，不是独立权威。由 `research-publisher` subagent 在 Delivery 定稿后渲染，契约是 `report.html = f(report.md)`：零新事实，只把已有内容映射进 house style 组件（verdict-bar / signal 染色表 / phase-timeline 等）。渲染规则、组件词汇表、内容映射见 [report-html-guide.md](./report-html-guide.md)；模板结构见 [report-shell.html.tmpl](./report-shell.html.tmpl)。渲染后须过 `scripts/verify_report_html.py` 机械门（链接守恒 + 章节守恒 + 自包含）。
+
+---
+
+**关联文件**：[pipeline.md](../references/pipeline.md) Stage 7 · [review-rubric.md](./review-rubric.md) · [report-html-guide.md](./report-html-guide.md)

--- a/plugins/deep-research/skills/deep-research/assets/deliverables-index.md.tmpl
+++ b/plugins/deep-research/skills/deep-research/assets/deliverables-index.md.tmpl
@@ -12,6 +12,7 @@
 | `report.md` | {主报告主题} | active | PRIMARY | — |
 | `executive_summary.md` | 执行摘要 | active | CURRENT | 配合 report.md 读 |
 | `{slug}.md` | {子主题} | superseded | HISTORICAL | 被 `correction-YYYYMMDD-{slug}.md` 取代 |
+| `report.html` | HTML 展示视图 | active | VIEW | derived from report.md |
 
 ## 字段说明
 
@@ -22,6 +23,7 @@
 - **PRIMARY**：唯一权威入口，读者从此进入。
 - **CURRENT**：有效但非唯一，需配合 PRIMARY 一起读。
 - **HISTORICAL**：已被推翻，保留作推理底稿，不作为当前结论。
+- **VIEW**：展示视图（如 report.html），派生自 PRIMARY，随 PRIMARY 重算，非独立权威，不参与 supersede 链。读者读 PRIMARY 获取权威结论，VIEW 仅作阅读体验增强。
 
 **替代关系**：若被 Correction Record 修正，指向取代它的文档（`correction-YYYYMMDD-{slug}.md`），形成双向链接。
 

--- a/plugins/deep-research/skills/deep-research/assets/project-claude-md.tmpl
+++ b/plugins/deep-research/skills/deep-research/assets/project-claude-md.tmpl
@@ -11,7 +11,7 @@
 > - 核心原则（含元原则 0 举证责任锚定）：references/principles.md
 > - 管线定义：references/pipeline.md
 > - 适用剧本：references/{PLAYBOOK}.md
-> - 角色定义：见 deep-research 插件的 research-harvester / research-analyst / research-reviewer subagent
+> - 角色定义：见 deep-research 插件的 research-harvester / research-analyst / research-reviewer / research-publisher subagent
 > - 质量门控：references/quality-gates.md
 
 ## 根本目标

--- a/plugins/deep-research/skills/deep-research/assets/report-html-guide.md
+++ b/plugins/deep-research/skills/deep-research/assets/report-html-guide.md
@@ -61,7 +61,7 @@
 - **双语术语原样保留**：report.md 中的中英文术语对照（如「Contextual Thompson Sampling」）渲染时不做增删改写。
 - **零新事实**：HTML 只能包含 report.md（+ executive_summary.md / references.md）已有的信息。不得新增数据、不得编造示例、不得"合理推测"补全空白。
 - **hero 区同样受「零新事实」约束**：TITLE/EYEBROW/H1/SUB/META 都是 HTML 内容，不是可另取数的"元信息区"。这些字段只能提炼自渲染源本身——report.md 头部（标题、撰写日期、研究类型、执行摘要）、references.md（可数出的来源条数）。严禁从项目 CLAUDE.md、pipeline 中间产物、MEMORY 或任何 report.md 之外的地方取数填进 hero。hero-meta 的每一项都应能在 report.md/executive_summary/references 里 grep 到出处；report.md 头部没有的数字（如候选数）就不放，宁缺毋滥。
-- **Correction Record / 多文档场景如实呈现**：若 report.md 头部有 SUPERSEDED/部分修正声明，或 `deliverables-index.md` 标注了权威关系（PRIMARY/CURRENT/HISTORICAL），HTML 必须用 `.callout` 显著标出「本节已被 Correction Record 修订」。**不得抹平已修正、已下调的结论**——渲染层没有权限替原始判断"美化"。
+- **Correction Record / 多文档场景如实呈现**：若 report.md 头部有 SUPERSEDED/部分修正声明，或 `deliverables/final/INDEX.md`（权威关系索引，模板资产名是 `deliverables-index.md.tmpl`，渲染落盘后即 `INDEX.md`）标注了权威关系（PRIMARY/CURRENT/HISTORICAL/VIEW），HTML 必须用 `.callout` 显著标出「本节已被 Correction Record 修订」。**不得抹平已修正、已下调的结论**——渲染层没有权限替原始判断"美化"。
 
 ---
 

--- a/plugins/deep-research/skills/deep-research/assets/report-html-guide.md
+++ b/plugins/deep-research/skills/deep-research/assets/report-html-guide.md
@@ -1,0 +1,84 @@
+# HTML 渲染设计规范
+
+契约：`report.html = f(report.md)`，零新事实。HTML 是 report.md 的派生展示层（VIEW），report.md 永远是 PRIMARY 权威。research-publisher agent 用 `report-shell.html.tmpl`（house style 模板）渲染 report.md 为单文件 HTML 时，本文档是渲染判断的依据。
+
+---
+
+## ① 组件词汇表
+
+| 组件类 | 内容语义 |
+|---|---|
+| `.hero` | 标题区：eyebrow 标签、主标题、副标题、元信息（日期/范围） |
+| `.verdict-bar` | 执行摘要的核心结论条，2-3 格并列展示「结论/推荐方案/关键限制」 |
+| `.section` | 正文默认容器，每个一级/二级标题对应一个 section |
+| 染色表（`table` + `td.good/warn/bad` + `tr.rec`） | 多方案对比矩阵，用颜色编码优劣，推荐行高亮 |
+| `.card-grid` | 并列要点/风险/tradeoff，无顺序语义 |
+| `.callout` | 关键提示、核心矛盾、强调性论断 |
+| `.phase-timeline` | 分阶段路线图，有顺序语义（Phase 0→N，可含可选阶段） |
+| `.data-grid` | 数据/维度就绪度盘点，三态标注 |
+| `.pain-list` | 并列问题/盲区清单 |
+| `.arch-diagram` | ASCII 架构图/流程图，保留字符画排版 + 局部染色 |
+| `.tag` | 内联状态标注（推荐/现状/风险等短词） |
+
+---
+
+## ② 内容→组件映射规则
+
+这是 publisher 做渲染判断的依据，**映射是判断，不是机械转换**。
+
+| report.md 内容形态 | 渲染成 | 识别信号 |
+|---|---|---|
+| 执行摘要的核心结论/推荐方案 | verdict-bar（2-3 格） | 「结论」/「推荐方案」/「核心发现」标题 |
+| N 方案对比矩阵 | signal 染色表（✅→good/⚠️→warn/❌→bad，推荐方案行加 `tr.rec`） | markdown 表格含 ✅/⚠️/❌ 或明显对比语义 |
+| 分层建议 / 阶段路线图 | phase-timeline | 「Phase N」/「层 1/2/3」/「短期/中期/长期」 |
+| 数据/维度就绪度 | data-grid（ready/partial/missing） | 「已就绪」/「缺失」/「数据空白」 |
+| 并列风险/tradeoff/要点 | card-grid | 「风险」/「tradeoff」等并列要点 |
+| 关键提示/核心矛盾 | callout | 「核心原因」/「关键」强调段 |
+| ASCII 架构图/流程图 | arch-diagram（pre + 染色 span） | 代码块含框线/箭头字符 |
+| 并列问题清单 | pain-list | 「盲区」/「痛点」/「问题」并列 |
+| 内联状态词 | tag | 状态标注 |
+| 普通段落/列表 | 常规 `section p` / `ul` | 不满足以上任何识别信号 |
+
+拿不准就用最朴素的 `section` + `p`，不要硬套组件。组件是为了让高信息密度的内容形态更易读，不是为了给每一段都找个盒子装。
+
+---
+
+## ③ 主题变体选择规则
+
+默认 **midnight**（暗色），除非报告性质明显偏亮色场景：
+
+- **midnight**（默认）：技术/工程类报告，适合大多数深度研究产出
+- **daylight**：偏商业/评审场景，或用户明确偏好打印/亮色阅读
+
+渲染时在 `<html data-theme="...">` 写入选定主题，两套 CSS 变量已在模板里定义好，无需额外改动。
+
+---
+
+## ④ 硬约束（渲染铁律）
+
+- **自包含**：零外部资源。字体用 `local()`，CSS 全部内联在 `<style>` 中，不引用外部 JS/CSS/图片。产出单个 `.html` 文件必须能离线打开。
+- **引用链接零丢失**：report.md 中所有 `[文字](url)` 形式的引用链接，渲染时全部转成 `<a href="url">文字</a>`，一个不漏。
+- **双语术语原样保留**：report.md 中的中英文术语对照（如「Contextual Thompson Sampling」）渲染时不做增删改写。
+- **零新事实**：HTML 只能包含 report.md（+ executive_summary.md / references.md）已有的信息。不得新增数据、不得编造示例、不得"合理推测"补全空白。
+- **hero 区同样受「零新事实」约束**：TITLE/EYEBROW/H1/SUB/META 都是 HTML 内容，不是可另取数的"元信息区"。这些字段只能提炼自渲染源本身——report.md 头部（标题、撰写日期、研究类型、执行摘要）、references.md（可数出的来源条数）。严禁从项目 CLAUDE.md、pipeline 中间产物、MEMORY 或任何 report.md 之外的地方取数填进 hero。hero-meta 的每一项都应能在 report.md/executive_summary/references 里 grep 到出处；report.md 头部没有的数字（如候选数）就不放，宁缺毋滥。
+- **Correction Record / 多文档场景如实呈现**：若 report.md 头部有 SUPERSEDED/部分修正声明，或 `deliverables-index.md` 标注了权威关系（PRIMARY/CURRENT/HISTORICAL），HTML 必须用 `.callout` 显著标出「本节已被 Correction Record 修订」。**不得抹平已修正、已下调的结论**——渲染层没有权限替原始判断"美化"。
+
+---
+
+## ⑤ AI 味弱文案规约
+
+规约只作用于展示层的组织性文案（标题、eyebrow、标签），**不用于重写正文事实**——渲染时不改写 report.md 的措辞与结论。
+
+- **去营销腔**：不用「unbelievable」/「best-ever」/超级形容词/感叹号堆砌
+- **主动语态、句子式大小写**：标题用句子式大小写，不用 Title Case 也不用全部大写（`.section-label` 的 uppercase 是 CSS text-transform 效果，不是文案本身要求）
+- **具体优于聪明**：show don't tell，eyebrow/标签用具体信息（如「Feasibility Research」「Phase 0 · 增强指标采集」）而非抽象修辞
+- **结构装置必须编码真实语义**：编号（Phase N）、eyebrow、分隔线不做纯装饰，只在内容真是序列/分类时使用；没有顺序语义的并列内容不要硬套编号
+- **Chanel 原则（出门前减一件配饰）**：克制。删掉不服务内容理解的装饰性组件——如果一段内容用 `section p` 就说得清楚，不要为了"好看"硬套 card-grid 或 tag
+
+---
+
+## ⑥ 关联
+
+- `report-shell.html.tmpl` — house style HTML 模板（本规范的实现载体）
+- `deliverable-matrix.md` — 交付物矩阵（report.md 的结构定义，report.html 的内容来源）
+- research-publisher subagent — 本规范的执行者

--- a/plugins/deep-research/skills/deep-research/assets/report-html-guide.md
+++ b/plugins/deep-research/skills/deep-research/assets/report-html-guide.md
@@ -57,7 +57,7 @@
 ## ④ 硬约束（渲染铁律）
 
 - **自包含**：零外部资源。字体用 `local()`，CSS 全部内联在 `<style>` 中，不引用外部 JS/CSS/图片。产出单个 `.html` 文件必须能离线打开。
-- **引用链接零丢失**：report.md 中所有 `[文字](url)` 形式的引用链接，渲染时全部转成 `<a href="url">文字</a>`，一个不漏。
+- **引用链接零丢失**：report.md 正文中所有链接都要转成 `<a href="url">…</a>`，一个不漏——既包括 `[文字](url)` 形式，也包括**裸 URL**（正文里直接出现的 `https://…`，无 markdown 语法）。机械门对两种形式都校验。例外：fenced code block 与 inline code span 内的 URL 是示例/标识符（如 curl 命令、config 片段），渲染成 `<pre>`/`<code>` 纯文本、**不** linkify，机械门也不校验它们。
 - **双语术语原样保留**：report.md 中的中英文术语对照（如「Contextual Thompson Sampling」）渲染时不做增删改写。
 - **零新事实**：HTML 只能包含 report.md（+ executive_summary.md / references.md）已有的信息。不得新增数据、不得编造示例、不得"合理推测"补全空白。
 - **hero 区同样受「零新事实」约束**：TITLE/EYEBROW/H1/SUB/META 都是 HTML 内容，不是可另取数的"元信息区"。这些字段只能提炼自渲染源本身——report.md 头部（标题、撰写日期、研究类型、执行摘要）、references.md（可数出的来源条数）。严禁从项目 CLAUDE.md、pipeline 中间产物、MEMORY 或任何 report.md 之外的地方取数填进 hero。hero-meta 的每一项都应能在 report.md/executive_summary/references 里 grep 到出处；report.md 头部没有的数字（如候选数）就不放，宁缺毋滥。

--- a/plugins/deep-research/skills/deep-research/assets/report-shell.html.tmpl
+++ b/plugins/deep-research/skills/deep-research/assets/report-shell.html.tmpl
@@ -1,0 +1,663 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="{{THEME}}">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{TITLE}}</title>
+<style>
+/* ============================================================
+   deep-research house style — report-shell
+   report.html = f(report.md)，零新事实。本文件是渲染层模板，
+   由 research-publisher agent 填充 {{...}} 占位符与 CONTENT。
+   ============================================================ */
+
+@font-face {
+  font-family: 'Display';
+  src: local('SF Pro Display'), local('PingFang SC'), local('Helvetica Neue'), local('Arial');
+  font-weight: 100 900;
+}
+@font-face {
+  font-family: 'Body';
+  src: local('SF Pro Text'), local('PingFang SC'), local('Helvetica Neue'), local('Arial');
+  font-weight: 100 900;
+}
+@font-face {
+  font-family: 'Mono';
+  src: local('SF Mono'), local('Menlo'), local('Consolas'), local('monospace');
+  font-weight: 400 700;
+}
+
+/* --- Theme tokens: midnight (default) --- */
+:root {
+  --bg: #0c0e12;
+  --bg-elevated: #13161c;
+  --bg-surface: #1a1e26;
+  --bg-hover: #222730;
+  --border: #2a2f3a;
+  --border-subtle: #1e222b;
+  --text-primary: #e8eaf0;
+  --text-secondary: #8b90a0;
+  --text-tertiary: #5c6070;
+  --accent: #3b82f6;
+  --accent-dim: #2563eb;
+  --accent-glow: rgba(59, 130, 246, 0.12);
+  --signal-green: #34d399;
+  --signal-amber: #fbbf24;
+  --signal-red: #f87171;
+  --signal-green-dim: rgba(52, 211, 153, 0.15);
+  --signal-amber-dim: rgba(251, 191, 36, 0.15);
+  --signal-red-dim: rgba(248, 113, 113, 0.15);
+}
+/* --- Theme tokens: daylight (light variant, opt-in via data-theme) --- */
+[data-theme="daylight"] {
+  --bg: #fafafa;
+  --bg-elevated: #ffffff;
+  --bg-surface: #f4f5f7;
+  --bg-hover: #eef0f3;
+  --border: #e2e5ea;
+  --border-subtle: #eef0f3;
+  --text-primary: #1a1d24;
+  --text-secondary: #5c6270;
+  --text-tertiary: #9099a8;
+  --accent: #3b82f6;
+  --accent-dim: #2563eb;
+  --accent-glow: rgba(59, 130, 246, 0.10);
+  --signal-green: #059669;
+  --signal-amber: #d97706;
+  --signal-red: #dc2626;
+  --signal-green-dim: rgba(5, 150, 105, 0.12);
+  --signal-amber-dim: rgba(217, 119, 6, 0.12);
+  --signal-red-dim: rgba(220, 38, 38, 0.12);
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: 'Body', system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text-primary);
+  line-height: 1.7;
+}
+
+.page {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 6rem;
+}
+
+/* --- Hero --- */
+.hero {
+  padding: 4rem 0 3rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 3rem;
+}
+
+.hero-eyebrow {
+  font-family: 'Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 1.25rem;
+}
+.hero h1 {
+  font-family: 'Display', system-ui, sans-serif;
+  font-size: 2.2rem;
+  font-weight: 600;
+  line-height: 1.25;
+  text-wrap: balance;
+  color: var(--text-primary);
+  margin-bottom: 1rem;
+}
+
+.hero-sub {
+  font-size: 1.05rem;
+  color: var(--text-secondary);
+  max-width: 640px;
+  line-height: 1.75;
+}
+
+.hero-meta {
+  display: flex;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  font-family: 'Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--text-tertiary);
+  letter-spacing: 0.04em;
+}
+
+/* --- Verdict bar --- */
+.verdict-bar {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 3.5rem;
+}
+
+.verdict-cell {
+  background: var(--bg-elevated);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.verdict-label {
+  font-family: 'Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.verdict-value {
+  font-family: 'Display', system-ui, sans-serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.verdict-value.green { color: var(--signal-green); }
+.verdict-value.amber { color: var(--signal-amber); }
+
+/* --- Sections --- */
+.section {
+  margin-bottom: 3.5rem;
+}
+
+.section-label {
+  font-family: 'Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: 0.75rem;
+}
+.section h2 {
+  font-family: 'Display', system-ui, sans-serif;
+  font-size: 1.35rem;
+  font-weight: 600;
+  line-height: 1.35;
+  text-wrap: balance;
+  margin-bottom: 1rem;
+  color: var(--text-primary);
+}
+
+.section h3 {
+  font-family: 'Display', system-ui, sans-serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  margin-top: 2rem;
+  color: var(--text-primary);
+}
+
+.section p {
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
+}
+
+.section p strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.section ul, .section ol {
+  color: var(--text-secondary);
+  margin: 0 0 1rem 1.25rem;
+}
+
+.section li {
+  margin-bottom: 0.4rem;
+  line-height: 1.65;
+}
+
+.section a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent-dim);
+}
+
+.section a:hover {
+  border-bottom-color: var(--accent);
+}
+
+/* --- Architecture diagram --- */
+.arch-diagram {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 2rem;
+  margin: 1.5rem 0;
+  overflow-x: auto;
+}
+
+.arch-diagram pre {
+  font-family: 'Mono', monospace;
+  font-size: 0.78rem;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  white-space: pre;
+}
+
+.arch-diagram pre .hl { color: var(--accent); font-weight: 600; }
+.arch-diagram pre .green { color: var(--signal-green); }
+.arch-diagram pre .amber { color: var(--signal-amber); }
+.arch-diagram pre .dim { color: var(--text-tertiary); }
+
+/* --- Comparison tables --- */
+.table-wrap {
+  overflow-x: auto;
+  margin: 1.5rem 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  font-variant-numeric: tabular-nums;
+}
+thead th {
+  font-family: 'Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  text-align: left;
+  padding: 0.75rem 1rem;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+tbody td {
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  vertical-align: top;
+}
+
+tbody tr:last-child td { border-bottom: none; }
+
+tbody td:first-child {
+  color: var(--text-primary);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+tbody td.good { color: var(--signal-green); }
+tbody td.warn { color: var(--signal-amber); }
+tbody td.bad { color: var(--signal-red); }
+
+tr.rec {
+  background: var(--accent-glow);
+}
+
+tr.rec td:first-child {
+  color: var(--accent);
+}
+
+/* --- Cards --- */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1px;
+  background: var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 1.5rem 0;
+}
+
+.card {
+  background: var(--bg-elevated);
+  padding: 1.25rem 1.5rem;
+}
+
+.card-title {
+  font-family: 'Display', system-ui, sans-serif;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.card p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 0;
+}
+/* --- Phase timeline --- */
+.phase-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 1.5rem 0;
+}
+
+.phase {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 0;
+  min-height: 0;
+}
+
+.phase-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+
+.phase-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+  margin-top: 0.2rem;
+  z-index: 1;
+}
+
+.phase-dot.optional {
+  background: transparent;
+  border: 2px solid var(--text-tertiary);
+}
+
+.phase-line {
+  width: 1px;
+  flex: 1;
+  background: var(--border);
+}
+
+.phase-content {
+  padding: 0 0 2rem 0;
+}
+
+.phase:last-child .phase-line { display: none; }
+.phase:last-child .phase-content { padding-bottom: 0; }
+
+.phase-name {
+  font-family: 'Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.35rem;
+}
+
+.phase-name.optional-label { color: var(--text-tertiary); }
+
+.phase-desc {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.phase-desc strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* --- Callout --- */
+.callout {
+  background: var(--accent-glow);
+  border-left: 3px solid var(--accent);
+  padding: 1rem 1.25rem;
+  margin: 1.5rem 0;
+  border-radius: 0 6px 6px 0;
+}
+
+.callout p {
+  color: var(--text-secondary);
+  margin-bottom: 0;
+  font-size: 0.9rem;
+}
+
+.callout strong {
+  color: var(--text-primary);
+}
+/* --- Pain point list --- */
+.pain-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background: var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 1.5rem 0;
+}
+
+.pain-item {
+  background: var(--bg-elevated);
+  padding: 1rem 1.5rem;
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 1rem;
+  align-items: baseline;
+}
+
+.pain-item .pain-name {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--signal-amber);
+}
+
+.pain-item .pain-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* --- Data readiness --- */
+.data-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1px;
+  background: var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 1.5rem 0;
+}
+
+.data-cell {
+  background: var(--bg-elevated);
+  padding: 1rem 1.25rem;
+}
+
+.data-cell .data-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.25rem;
+}
+
+.data-cell .data-source {
+  font-family: 'Mono', monospace;
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  margin-bottom: 0.35rem;
+}
+
+.data-cell .data-status {
+  font-family: 'Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+}
+
+.data-cell .data-status.ready { color: var(--signal-green); }
+.data-cell .data-status.partial { color: var(--signal-amber); }
+.data-cell .data-status.missing { color: var(--signal-red); }
+
+/* --- Tag/badge --- */
+.tag {
+  display: inline-block;
+  font-family: 'Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.15em 0.5em;
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+.tag-green { background: var(--signal-green-dim); color: var(--signal-green); }
+.tag-amber { background: var(--signal-amber-dim); color: var(--signal-amber); }
+.tag-red { background: var(--signal-red-dim); color: var(--signal-red); }
+
+/* --- Responsive --- */
+@media (max-width: 640px) {
+  .hero h1 { font-size: 1.6rem; }
+  .verdict-bar { grid-template-columns: 1fr; }
+  .pain-item { grid-template-columns: 1fr; gap: 0.25rem; }
+  .hero-meta { flex-direction: column; gap: 0.5rem; }
+  .page { padding: 2rem 1rem 4rem; }
+}
+</style>
+</head>
+<body>
+<div class="page">
+  <!-- Hero: 报告标题区。THEME 由 publisher 决定 midnight/daylight，见 report-html-guide.md ③ -->
+  <header class="hero">
+    <div class="hero-eyebrow">{{HERO_EYEBROW}}</div>
+    <h1>{{HERO_H1}}</h1>
+    <p class="hero-sub">{{HERO_SUB}}</p>
+    <div class="hero-meta">{{HERO_META}}</div>
+  </header>
+
+  <!--
+    verdict-bar 用法（执行摘要核心结论，2-3 格）：
+    <div class="verdict-bar">
+      <div class="verdict-cell">
+        <span class="verdict-label">结论</span>
+        <span class="verdict-value green">可行，值得推进</span>
+      </div>
+      <div class="verdict-cell">
+        <span class="verdict-label">推荐方案</span>
+        <span class="verdict-value">方案名称</span>
+      </div>
+    </div>
+    verdict-value 可加 .green（正向）或 .amber（有保留），不加则为中性色。
+  -->
+
+  <!--
+    section 用法（正文默认容器，未匹配任何语义组件的内容落这里）：
+    <section class="section">
+      <div class="section-label">阶段/主题标签</div>
+      <h2>小节标题</h2>
+      <p>正文段落，<strong>加粗关键结论</strong>。</p>
+    </section>
+  -->
+
+  <!--
+    table_wrap + signal 染色表用法（方案对比矩阵）：
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>维度</th><th>方案A</th><th>方案B</th></tr></thead>
+        <tbody>
+          <tr><td>指标</td><td class="good">达标</td><td class="bad">不达标</td></tr>
+          <tr class="rec"><td>推荐方案行</td><td class="good">...</td><td>...</td></tr>
+        </tbody>
+      </table>
+    </div>
+    td 加 .good/.warn/.bad 对应 ✅/⚠️/❌；推荐方案整行加 tr.rec。
+  -->
+
+  <!--
+    card-grid 用法（并列风险/tradeoff/要点，无顺序语义）：
+    <div class="card-grid">
+      <div class="card">
+        <div class="card-title">要点标题</div>
+        <p>要点说明。</p>
+      </div>
+    </div>
+  -->
+
+  <!--
+    callout 用法（关键提示/核心矛盾，强调段）：
+    <div class="callout">
+      <p><strong>核心原因：</strong>说明文字。</p>
+    </div>
+    需要 amber/red 强调时内联覆盖边框色：
+    <div class="callout" style="border-left-color: var(--signal-amber);">
+  -->
+
+  <!--
+    phase-timeline 用法（分阶段路线图/Phase N/短中长期）：
+    <div class="phase-timeline">
+      <div class="phase">
+        <div class="phase-rail"><div class="phase-dot"></div><div class="phase-line"></div></div>
+        <div class="phase-content">
+          <div class="phase-name">Phase 0 · 阶段名</div>
+          <div class="phase-desc">阶段说明，<strong>关键动作加粗</strong>。</div>
+        </div>
+      </div>
+      <div class="phase">
+        <div class="phase-rail"><div class="phase-dot optional"></div></div>
+        <div class="phase-content">
+          <div class="phase-name optional-label">Phase N · 可选阶段</div>
+          <div class="phase-desc">可选阶段说明。</div>
+        </div>
+      </div>
+    </div>
+    最后一个 phase 不需要 phase-line（末尾自动隐藏）；可选阶段用 .optional / .optional-label。
+  -->
+
+  <!--
+    data-grid 用法（数据/维度就绪度盘点）：
+    <div class="data-grid">
+      <div class="data-cell">
+        <div class="data-name">数据项名称</div>
+        <div class="data-source">来源</div>
+        <div class="data-status ready">● 已就绪 · 说明</div>
+      </div>
+    </div>
+    data-status 三态：ready（●已就绪）/ partial（◐部分可得）/ missing（○缺失）。
+  -->
+
+  <!--
+    pain-list 用法（并列问题/盲区清单）：
+    <div class="pain-list">
+      <div class="pain-item">
+        <span class="pain-name">问题名</span>
+        <span class="pain-desc">问题描述。</span>
+      </div>
+    </div>
+  -->
+
+  <!--
+    arch-diagram 用法（ASCII 架构图/流程图，保留原始字符画排版）：
+    <div class="arch-diagram">
+      <pre>
+<span class="hl">关键节点高亮</span>
+<span class="green">正向状态</span>  <span class="amber">警示状态</span>
+<span class="dim">次要说明文字</span>
+</pre>
+    </div>
+  -->
+
+  <!--
+    tag 用法（内联状态标注）：
+    <span class="tag tag-green">推荐</span>
+    <span class="tag tag-amber">现状</span>
+    <span class="tag tag-red">风险</span>
+  -->
+
+  {{CONTENT}}
+
+</div>
+</body>
+</html>

--- a/plugins/deep-research/skills/deep-research/references/context-economics.md
+++ b/plugins/deep-research/skills/deep-research/references/context-economics.md
@@ -91,4 +91,4 @@ fetch 后端链同理降级：curl-cffi（本地免费直连，软依赖）→ t
 
 ---
 
-**关联文件**：[pipeline.md](./pipeline.md) · [principles.md](./principles.md) · 角色定义见 deep-research 插件的 research-harvester / research-analyst / research-reviewer subagent
+**关联文件**：[pipeline.md](./pipeline.md) · [principles.md](./principles.md) · 角色定义见 deep-research 插件的 research-harvester / research-analyst / research-reviewer / research-publisher subagent

--- a/plugins/deep-research/skills/deep-research/references/framework-INDEX.md
+++ b/plugins/deep-research/skills/deep-research/references/framework-INDEX.md
@@ -19,6 +19,6 @@
 
 | 项 | 说明 |
 |------|------|
-| research-harvester / research-analyst / research-reviewer | 3 个专业角色，已成为 deep-research 插件的原生 subagent（用 Task 工具以 `deep-research:research-harvester` 等 spawn），不再是可链接的文件 |
+| research-harvester / research-analyst / research-reviewer / research-publisher | 4 个专业角色，已成为 deep-research 插件的原生 subagent（用 Task 工具以 `deep-research:research-harvester` 等 spawn），不再是可链接的文件 |
 | [playbooks-INDEX.md](./playbooks-INDEX.md) | 按研究类型的执行手册（提供默认源列表和流程变体） |
 | `../assets/` | 报告模板和项目初始化模板 |

--- a/plugins/deep-research/skills/deep-research/references/pipeline.md
+++ b/plugins/deep-research/skills/deep-research/references/pipeline.md
@@ -12,7 +12,7 @@ Sources → ❰G0❱ → [harvester] Acquisition → ❰G1❱
   → [analyst] Decomposition → ❰G2❱
   → [analyst+Lead] Synthesis → ❰G3❱
   → [reviewer] Validation
-  → [Lead] Delivery
+  → [Lead] Delivery → [publisher] report.html
   ⋯⋯ → [Lead] Landing & Feedback（Stage 8, experimental, 仅落地后触发）
 ```
 
@@ -126,7 +126,9 @@ Lead 参与综合分析中不可委托的连贯思考和战略判断。
 | 执行者 | Lead session |
 | 输入 | 审阅通过的产物 |
 | 输出目录 | `deliverables/final/` |
-| 产物 | report.md + executive_summary.md + 附录 |
+| 产物 | report.md + executive_summary.md + 附录 + report.html（见下 HTML 渲染子步骤） |
+
+**HTML 渲染子步骤**：Delivery 定稿（report.md 等已落盘 `deliverables/final/`）后，Lead spawn `deep-research:research-publisher`（Task subagent），把 report.md 渲染成 `report.html`——自包含 HTML 展示视图（VIEW 层，见 [principles.md](./principles.md) 原则 5），零新事实。publisher 渲染完成后自调 `scripts/verify_report_html.py` 机械门自校验（三态 exit：`0`=PASS/`1`=FAIL/`2`=N/A，校验链接守恒 + 章节守恒 + 自包含），不 PASS 须修正后复渲。
 
 ### Stage 8: Landing & Feedback（Lead 执行，experimental）
 
@@ -165,4 +167,4 @@ Lead 参与综合分析中不可委托的连贯思考和战略判断。
 6. **Gate 阻塞**：G0/G1/G2/G3 未通过时，后续 Stage 禁止启动
 7. **回退权限**：只有 Lead 可以决定 Stage 回退。G3 裁决 RECYCLE 时强制回退到 G0 重校准问题定义（区别于 FAIL 的原阶段补充）
 
-**关联文件**：[principles.md](./principles.md) · [quality-gates.md](./quality-gates.md) · 角色定义见 deep-research 插件的 research-harvester / research-analyst / research-reviewer subagent
+**关联文件**：[principles.md](./principles.md) · [quality-gates.md](./quality-gates.md) · 角色定义见 deep-research 插件的 research-harvester / research-analyst / research-reviewer / research-publisher subagent

--- a/plugins/deep-research/skills/deep-research/references/principles.md
+++ b/plugins/deep-research/skills/deep-research/references/principles.md
@@ -152,11 +152,12 @@ INDEX.md 权威关系表必含列：
 
 | 文件 | 主题 | 状态 | 权威级别 | 替代关系 |
 
-权威级别三态（与上方 front matter `authority` 字段一致）：
+权威级别四态（与上方 front matter `authority` 字段一致）：
 
 - **PRIMARY**：唯一权威入口，读者从此进入。
 - **CURRENT**：有效但非唯一，需配合 PRIMARY 一起读。
 - **HISTORICAL**：已被推翻，保留作推理底稿，不作为当前结论。
+- **VIEW**：展示视图（如 report.html），派生自 PRIMARY，随 PRIMARY 重算，非独立权威，不参与 supersede 链。读者读 PRIMARY 获取权威结论，VIEW 仅作阅读体验增强。
 
 模板见 [deliverables-index.md.tmpl](../assets/deliverables-index.md.tmpl)。
 

--- a/plugins/deep-research/tests/test_verify_report_html.py
+++ b/plugins/deep-research/tests/test_verify_report_html.py
@@ -1,0 +1,303 @@
+"""BDD coverage for verify_report_html.py -- the mechanical gate that checks
+report.html = f(report.md) structurally (link conservation, section
+conservation, self-containment). See scripts/verify_report_html.py module
+docstring for the full contract; this file exercises it via subprocess, the
+same way a real research-publisher self-check invocation would run it, so a
+regression in the CLI wiring (argparse, exit codes, stdout format) is caught
+too -- not just the underlying functions.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "verify_report_html.py"
+
+_SAMPLE_MD = """# Sample Report
+
+## Overview
+
+Some intro text with a link to [Example Source](https://example.com/a?b=1).
+
+## Findings
+
+Findings text.
+
+### Sub-finding detail
+
+More detail here.
+"""
+
+_SAMPLE_HTML_GOOD = """<!DOCTYPE html>
+<html lang="zh-CN" data-theme="midnight">
+<head><meta charset="UTF-8"><title>Sample Report</title>
+<style>body { color: #000; }</style>
+</head>
+<body>
+<div class="page">
+  <header class="hero"><h1>Sample Report</h1></header>
+  <section class="section">
+    <h2>Overview</h2>
+    <p>Some intro text with a link to <a href="https://example.com/a?b=1">Example Source</a>.</p>
+  </section>
+  <section class="section">
+    <h2>Findings</h2>
+    <p>Findings text.</p>
+    <h3>Sub-finding detail</h3>
+    <p>More detail here.</p>
+  </section>
+</div>
+</body>
+</html>
+"""
+
+
+def run_verify(path_arg):
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), str(path_arg)],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def _write(dir_path: Path, name: str, content: str) -> Path:
+    p = dir_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestCleanHtmlPasses:
+    """A correctly rendered report.html (all links present, all sections
+    present, no external resources) must PASS with exit code 0."""
+
+    def test_clean_html_exits_zero(self, tmp_path):
+        _write(tmp_path, "report.md", _SAMPLE_MD)
+        _write(tmp_path, "report.html", _SAMPLE_HTML_GOOD)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 0
+        assert "PASS" in stdout
+
+    def test_clean_html_via_direct_report_html_path(self, tmp_path):
+        _write(tmp_path, "report.md", _SAMPLE_MD)
+        html_path = _write(tmp_path, "report.html", _SAMPLE_HTML_GOOD)
+
+        code, stdout, _ = run_verify(html_path)
+
+        assert code == 0
+        assert "PASS" in stdout
+
+
+class TestMissingLinkFails:
+    """If report.html drops one of report.md's URLs, that's a structural
+    loss of a citation -- must FAIL with exit code 1 and name the URL."""
+
+    def test_dropped_url_fails_and_is_named(self, tmp_path):
+        _write(tmp_path, "report.md", _SAMPLE_MD)
+        html_without_link = _SAMPLE_HTML_GOOD.replace(
+            '<a href="https://example.com/a?b=1">Example Source</a>',
+            "Example Source",
+        )
+        _write(tmp_path, "report.html", html_without_link)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 1
+        assert "FAIL" in stdout
+        assert "example.com/a?b=1" in stdout
+
+
+class TestMissingSectionFails:
+    """If report.html drops one of report.md's ## headings, that's a
+    structural loss of a whole section -- must FAIL with exit code 1."""
+
+    def test_dropped_heading_fails(self, tmp_path):
+        _write(tmp_path, "report.md", _SAMPLE_MD)
+        html_without_section = _SAMPLE_HTML_GOOD.replace(
+            "<h3>Sub-finding detail</h3>\n    <p>More detail here.</p>\n  ",
+            "",
+        )
+        _write(tmp_path, "report.html", html_without_section)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 1
+        assert "FAIL" in stdout
+        assert "Sub-finding detail" in stdout
+
+
+class TestExternalResourceFails:
+    """Self-containment is a hard rule: no <script src="http...">, no
+    <link href="http...">. Must FAIL with exit code 1. A content-level
+    <a href="http...```"> citation link must NOT trigger this (that's
+    covered by TestCleanHtmlPasses, which already has such a link)."""
+
+    def test_external_script_src_fails(self, tmp_path):
+        _write(tmp_path, "report.md", _SAMPLE_MD)
+        html_with_external_script = _SAMPLE_HTML_GOOD.replace(
+            "</head>",
+            '<script src="https://cdn.example.com/lib.js"></script></head>',
+        )
+        _write(tmp_path, "report.html", html_with_external_script)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 1
+        assert "FAIL" in stdout
+
+    def test_external_link_href_fails(self, tmp_path):
+        _write(tmp_path, "report.md", _SAMPLE_MD)
+        html_with_external_link = _SAMPLE_HTML_GOOD.replace(
+            "</head>",
+            '<link rel="stylesheet" href="https://cdn.example.com/style.css"></head>',
+        )
+        _write(tmp_path, "report.html", html_with_external_link)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 1
+        assert "FAIL" in stdout
+
+
+class TestAmpersandEscapingDoesNotFalsePositive:
+    """The crux regression case: markdown URLs containing '&' render as
+    '&amp;' in HTML attributes. Without html.unescape() before comparison,
+    every such URL would false-positive as "missing". Must PASS."""
+
+    def test_ampersand_url_escaped_in_html_still_passes(self, tmp_path):
+        md = """# Report
+
+## Section One
+
+See [data source](https://x.com/a?b=1&c=2) for details.
+"""
+        html_content = """<!DOCTYPE html>
+<html><head><title>Report</title><style></style></head>
+<body>
+<section class="section">
+<h2>Section One</h2>
+<p>See <a href="https://x.com/a?b=1&amp;c=2">data source</a> for details.</p>
+</section>
+</body></html>
+"""
+        _write(tmp_path, "report.md", md)
+        _write(tmp_path, "report.html", html_content)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 0
+        assert "PASS" in stdout
+
+
+class TestHeadingNormalizationNoFalsePositive:
+    """Dogfooding regression: section conservation must compare semantic
+    content, not exact bytes. Two lossless display-layer rewrites of a
+    heading that IS present must still PASS -- underscore identifiers and
+    separator swaps both bit real reports."""
+
+    def test_underscore_identifier_heading_passes(self, tmp_path):
+        # Bug 1: heading contains a code identifier ("primary_job"); the
+        # underscore is a literal part of the token, not markdown emphasis.
+        # HTML keeps the underscore -> must match, not be flagged missing.
+        md = """# Report
+
+## 关于 primary_job 与 non_goals 的分析
+
+Body text.
+"""
+        html_content = """<!DOCTYPE html>
+<html><head><title>Report</title><style></style></head>
+<body>
+<section class="section">
+<h2>关于 primary_job 与 non_goals 的分析</h2>
+<p>Body text.</p>
+</section>
+</body></html>
+"""
+        _write(tmp_path, "report.md", md)
+        _write(tmp_path, "report.html", html_content)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 0, stdout
+        assert "PASS" in stdout
+
+    def test_em_dash_rendered_as_middle_dot_passes(self, tmp_path):
+        # Bug 2: md heading uses em dash " — "; publisher typesets it as
+        # " · " (middle dot) in HTML. Heading body is intact -> must match.
+        md = """# Report
+
+### 层 1 — 纯 markdown skill（轻量方案）
+
+Body text.
+"""
+        html_content = """<!DOCTYPE html>
+<html><head><title>Report</title><style></style></head>
+<body>
+<section class="section">
+<h3>层 1 · 纯 markdown skill（轻量方案）</h3>
+<p>Body text.</p>
+</section>
+</body></html>
+"""
+        _write(tmp_path, "report.md", md)
+        _write(tmp_path, "report.html", html_content)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 0, stdout
+        assert "PASS" in stdout
+
+    def test_genuinely_dropped_section_still_fails(self, tmp_path):
+        # Guardrail: normalization must NOT weaken real-loss detection. A
+        # section whose substantive text is entirely absent from the HTML
+        # must still FAIL even under the relaxed normalized comparison.
+        md = """# Report
+
+## 存在的章节
+
+Present.
+
+## 被整段删除的章节标题
+
+Dropped.
+"""
+        html_content = """<!DOCTYPE html>
+<html><head><title>Report</title><style></style></head>
+<body>
+<section class="section">
+<h2>存在的章节</h2>
+<p>Present.</p>
+</section>
+</body></html>
+"""
+        _write(tmp_path, "report.md", md)
+        _write(tmp_path, "report.html", html_content)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 1
+        assert "FAIL" in stdout
+        assert "被整段删除的章节标题" in stdout
+
+
+class TestNoReportHtmlIsNotApplicable:
+    """Before publisher has rendered anything, there's no report.html to
+    check -- this is N/A (exit 2), not FAIL. Distinguishing "not done yet"
+    from "done wrong" matters: N/A must never block a pipeline that simply
+    hasn't reached Stage 7 Delivery yet."""
+
+    def test_missing_report_html_exits_two(self, tmp_path):
+        _write(tmp_path, "report.md", _SAMPLE_MD)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 2
+        assert "N_A" in stdout or "N/A" in stdout
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/plugins/deep-research/tests/test_verify_report_html.py
+++ b/plugins/deep-research/tests/test_verify_report_html.py
@@ -284,6 +284,84 @@ Dropped.
         assert "被整段删除的章节标题" in stdout
 
 
+class TestCodeFenceUrlsAreNotMustConserveLinks:
+    """Copilot review regression: a URL inside a fenced code block (example
+    curl command, repo URL in a config snippet) is not a citation. The
+    publisher renders code blocks as <pre> plain text and MUST NOT linkify
+    them, so such URLs have no href/src in the HTML. Counting them as
+    must-conserve links would false-positive a correctly rendered report
+    into an unsatisfiable FAIL. Only prose-level links must survive."""
+
+    def test_code_block_url_not_required_prose_link_is(self, tmp_path):
+        md = """# Report
+
+## Setup
+
+Install per the [official guide](https://example.com/docs), then run:
+
+```bash
+curl https://example.com/api/v1/install | sh
+```
+
+Done.
+"""
+        # HTML keeps the prose link as <a href>, but the code-block URL is
+        # rendered as <pre> plain text -- deliberately NOT an <a href>.
+        html_content = """<!DOCTYPE html>
+<html><head><title>Report</title><style></style></head>
+<body>
+<section class="section">
+<h2>Setup</h2>
+<p>Install per the <a href="https://example.com/docs">official guide</a>, then run:</p>
+<div class="arch-diagram"><pre>curl https://example.com/api/v1/install | sh</pre></div>
+<p>Done.</p>
+</section>
+</body></html>
+"""
+        _write(tmp_path, "report.md", md)
+        _write(tmp_path, "report.html", html_content)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 0, stdout
+        assert "PASS" in stdout
+
+    def test_prose_link_still_required_even_with_code_block_present(self, tmp_path):
+        # Guardrail: stripping code fences must not weaken detection of a
+        # genuinely dropped prose link. Same md, but HTML omits the prose
+        # link's <a href> -> must still FAIL and name the missing URL.
+        md = """# Report
+
+## Setup
+
+Install per the [official guide](https://example.com/docs), then run:
+
+```bash
+curl https://example.com/api/v1/install | sh
+```
+
+Done.
+"""
+        html_content = """<!DOCTYPE html>
+<html><head><title>Report</title><style></style></head>
+<body>
+<section class="section">
+<h2>Setup</h2>
+<p>Install per the official guide, then run:</p>
+<div class="arch-diagram"><pre>curl https://example.com/api/v1/install | sh</pre></div>
+<p>Done.</p>
+</section>
+</body></html>
+"""
+        _write(tmp_path, "report.md", md)
+        _write(tmp_path, "report.html", html_content)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 1
+        assert "example.com/docs" in stdout
+
+
 class TestNoReportHtmlIsNotApplicable:
     """Before publisher has rendered anything, there's no report.html to
     check -- this is N/A (exit 2), not FAIL. Distinguishing "not done yet"

--- a/plugins/deep-research/tests/test_verify_report_html.py
+++ b/plugins/deep-research/tests/test_verify_report_html.py
@@ -362,6 +362,103 @@ Done.
         assert "example.com/docs" in stdout
 
 
+class TestInlineCodeSpanUrlsAreNotMustConserveLinks:
+    """Copilot review round 3: same deadlock as fenced blocks, but for inline
+    code spans (`...`). A URL written as `https://api.example/v1` renders to
+    <code> plain text with no href, so it must not be a must-conserve link."""
+
+    def test_inline_code_url_not_required_prose_link_is(self, tmp_path):
+        md = """# Report
+
+## API
+
+Call the [public docs](https://example.com/docs) endpoint at `https://api.example.com/v1` directly.
+"""
+        # Prose link kept as <a href>; the inline-code URL rendered as <code>
+        # plain text (no href) -- must not be flagged missing.
+        html_content = """<!DOCTYPE html>
+<html><head><title>Report</title><style></style></head>
+<body>
+<section class="section">
+<h2>API</h2>
+<p>Call the <a href="https://example.com/docs">public docs</a> endpoint at <code>https://api.example.com/v1</code> directly.</p>
+</section>
+</body></html>
+"""
+        _write(tmp_path, "report.md", md)
+        _write(tmp_path, "report.html", html_content)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 0, stdout
+        assert "PASS" in stdout
+
+    def test_prose_link_still_required_with_inline_code_url_present(self, tmp_path):
+        # Guardrail: stripping inline code must not weaken detection of a
+        # genuinely dropped prose link.
+        md = """# Report
+
+## API
+
+Call the [public docs](https://example.com/docs) endpoint at `https://api.example.com/v1` directly.
+"""
+        html_content = """<!DOCTYPE html>
+<html><head><title>Report</title><style></style></head>
+<body>
+<section class="section">
+<h2>API</h2>
+<p>Call the public docs endpoint at <code>https://api.example.com/v1</code> directly.</p>
+</section>
+</body></html>
+"""
+        _write(tmp_path, "report.md", md)
+        _write(tmp_path, "report.html", html_content)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 1
+        assert "example.com/docs" in stdout
+
+
+class TestReferencesMdNotInMustConserveSet:
+    """Copilot review round 3 + user decision: link conservation is scoped to
+    report.md ONLY. references.md is an independent deliverable (the full
+    bibliography) the publisher does not render into the HTML, so its URLs
+    must NOT be required to survive -- otherwise every report FAILs
+    unsatisfiably. HTML is strictly f(report.md)."""
+
+    def test_references_only_url_absent_from_html_still_passes(self, tmp_path):
+        md = """# Report
+
+## Overview
+
+See [main source](https://example.com/main) for the core finding.
+"""
+        # references.md has an extra URL that never appears in the HTML.
+        references = """# References
+
+1. https://example.com/main
+2. https://extra.example.com/only-in-references
+"""
+        html_content = """<!DOCTYPE html>
+<html><head><title>Report</title><style></style></head>
+<body>
+<section class="section">
+<h2>Overview</h2>
+<p>See <a href="https://example.com/main">main source</a> for the core finding.</p>
+</section>
+</body></html>
+"""
+        _write(tmp_path, "report.md", md)
+        _write(tmp_path, "references.md", references)
+        _write(tmp_path, "report.html", html_content)
+
+        code, stdout, _ = run_verify(tmp_path)
+
+        assert code == 0, stdout
+        assert "PASS" in stdout
+
+
 class TestNoReportHtmlIsNotApplicable:
     """Before publisher has rendered anything, there's no report.html to
     check -- this is N/A (exit 2), not FAIL. Distinguishing "not done yet"

--- a/plugins/deep-research/tests/test_verify_report_html.py
+++ b/plugins/deep-research/tests/test_verify_report_html.py
@@ -132,7 +132,7 @@ class TestMissingSectionFails:
 class TestExternalResourceFails:
     """Self-containment is a hard rule: no <script src="http...">, no
     <link href="http...">. Must FAIL with exit code 1. A content-level
-    <a href="http...```"> citation link must NOT trigger this (that's
+    <a href="http..."> citation link must NOT trigger this (that's
     covered by TestCleanHtmlPasses, which already has such a link)."""
 
     def test_external_script_src_fails(self, tmp_path):


### PR DESCRIPTION
## 变更概述

为 deep-research 插件的 Stage 7 Delivery 增加 `report.html` 产出：把已审阅通过的 `report.md` 渲染成精美、AI 味弱、自包含的 HTML 展示视图。

**核心契约**：`report.html = f(report.md)`，零新事实——HTML 是 report.md 的派生展示视图（VIEW），report.md 永远是 PRIMARY 权威。

**设计策略**：抽取一次、冻结复用。把参考报告的设计语言（暗色 token 板 + signal 三色 + 语义组件 + 零 JS 自包含）+ frontend-design 的 AI-味弱 写作方法论固化进 house style 资产，运行时不依赖外部 skill。理由：报告库受益于一致可学习的版式，而非每次不同的设计。

## 主要改动

**新增**
- `assets/report-shell.html.tmpl` — house style 模板（设计 token + 语义组件 CSS：verdict-bar / signal 染色表 / card-grid / callout / phase-timeline / data-grid / pain-list / arch-diagram / tag；响应式；local() 字体栈；零 JS；midnight/daylight 两套主题）
- `assets/report-html-guide.md` — 组件词汇表 + 内容→组件映射规则 + 硬约束 + AI-味弱 文案规约
- `agents/research-publisher.md` — 第 4 个 subagent（model=sonnet, color=cyan）
- `scripts/verify_report_html.py` — 确定性机械门（链接守恒 + 章节守恒 + 自包含，三态 exit code，stdlib-only）
- `tests/test_verify_report_html.py` — 机械门测试

**修改（契约同步）**
- `plugin.json` + `marketplace.json` — 注册 agent + 版本双同步 1.2.1→1.3.0
- `pipeline.md` — Stage 7 增 HTML 渲染子步骤
- `SKILL.md` / `framework-INDEX.md` / `context-economics.md` / `project-claude-md.tmpl` — subagent 3→4
- `deliverable-matrix.md` — 交付物加 report.html（VIEW 层）
- `principles.md` + `deliverables-index.md.tmpl` — 权威级别新增 VIEW 态
- `INDEX.md` — 模板索引补两项

## 架构决策

- **保留 LLM 渲染，不用 markdown parser**：MD→HTML 在本用例不是确定性问题，价值全在语义组件映射（结论→verdict-bar、✅/⚠️/❌ 对比表→signal 染色表、路线图→phase-timeline）。parser 只能吐通用丑 HTML。用确定性机械门消灭 LLM 的真实失败模式（截断/丢链接/漏章节），而非因噎废食换 parser。机械门覆盖结构性丢失（可机读）；语义性捏造由人工核验兜底。
- **零新事实契约**：包括 hero 区。dogfooding 中发现并修正了一处 hero 越界取数（从项目 CLAUDE.md 取了 report.md 没有的候选数），并回填 guide 堵住漏洞。

## 兼容性

- 纯新增 Delivery 末端派生视图，不触碰 harvest.py / gate_check.py / G0-G3 门控 / pipeline 数据流分层
- 不引入运行时外部 skill 依赖；verify 脚本 stdlib-only

## 验证

- 机械门测试 11 passed；全套插件测试 280 passed 无回归
- dogfooding 渲染真实报告（skills_管理系统选型，205 行、带 Correction Record + INDEX）：机械门 PASS（34 链接 / 26 章节守恒 / 自包含）
- 代码级核验：组件映射合理（td.good×15/warn×7/bad×8、推荐行 tr.rec、分层 phase-timeline）、Correction Record 权威关系如实呈现未抹平、零新事实
- 人工视觉裁决：统一 section 宽度（移除正文 680px 限制，与表格/banner 右边缘对齐）

close #68
