### PR TITLE
feat(harvest): --no-api local mode + DDG curl-cffi bypass

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/agents/research-harvester.md
+++ b/plugins/deep-research/agents/research-harvester.md
@@ -160,6 +160,68 @@ Lead 的采集指令，必须包含：
 
 > **候选集完备性**对应 G1 检查（deep-research skill 的 references/quality-gates.md，候选集完备性检查章节）。仅选型类研究（`research-goal.md` 类型 = selection）触发；非选型类一律填 `N/A`——这是显式兜底，避免静态字段与动态触发条件冲突。
 
+## Local Mode（`--no-api`，无 LLM Gateway 环境）
+
+**触发条件**：Lead 的采集指令明确要求 `--no-api` 模式，或 Lead 通知 gateway 不可用。
+
+**前提**：harvest.py 支持 `--no-api --queries-json` 参数（local mode 实现）。
+
+**执行流程**：
+
+| 步骤 | 动作 | 产物/落点 |
+|------|------|----------|
+| 1 | 读 `research-goal.md`，生成 5-8 条双语搜索查询 | 写入临时 `queries.json`（schema: `{"queries": ["q1", "q2", ...]}`） |
+| 2 | 执行 `python3 <harvest.py路径> run --no-api --queries-json queries.json --goal-file <goal-file> --out pipeline/1_raw/` | `pipeline/1_raw/harvest/local/`（journal + fetched pages）、`harvest-local.json`（manifest） |
+| 3 | 读 `harvest-local.json` 获取抓取清单 | — |
+| 4 | 分批读 `harvest/local/fetched/page_*.txt`（每批 ≤5 页，控制上下文） | — |
+| 5 | 提取 claims：`{claim, excerpt, url, credibility, language}` | 写 `harvest/local/claims.json`（flat list，非嵌套结构） |
+| 6 | 执行 `python3 <harvest.py路径> verify-local --claims harvest/local/claims.json --manifest pipeline/1_raw/harvest-local.json --out pipeline/verification/` | `pipeline/verification/harvest-verify.json` + `rejected_claims.json` |
+| 7 | 检查 verify-local exit code：exit 0 → 继续；exit 1 → 上报 Lead | — |
+| 8 | 写 `harvest/local/findings.json`（覆写 placeholder，标准 schema）| `pipeline/1_raw/harvest/local/findings.json` |
+| 9 | 写 `merged-findings.json`（覆写 placeholder，单源 flat clusters）| `pipeline/1_raw/merged-findings.json` |
+| 10 | 执行 Sanitization（同标准流程） | `pipeline/2_cleaned/` |
+
+**claims.json schema**（verify-local 输入）：
+
+```json
+[
+  {"claim": "...", "excerpt": "...", "url": "https://...", "credibility": 3, "language": "zh"},
+  ...
+]
+```
+
+**merged-findings.json 写法**（覆写 placeholder）：
+
+```json
+{
+  "clusters": [{"summary": "...", "claims": [...]}],
+  "coverage_gaps": [...],
+  "unique_insights": [],
+  "blind_spots": [...],
+  "contradictions": [],
+  "dedup_notes": [],
+  "mode": "local"
+}
+```
+
+单源收集无需 judge 聚类，每个 claim 独占一个 cluster。
+
+**退出码处理**：
+
+| exit code | 含义 | harvester 动作 |
+|-----------|------|--------------|
+| 0 | 搜索+抓取成功 | 继续流程（读 fetched pages → 提取 claims） |
+| 1 | 参数错误 / queries 格式错误 | 修正后重试（自行修复 queries.json 格式） |
+| 3 | UNAVAILABLE（搜索/抓取全失败） | **停止并上报 Lead**，同 panel mode exit 3 |
+
+**与 panel mode 的区别**：
+
+- 不调用任何外部 LLM（零 gateway API 消耗）
+- 推理由 harvester 自身（Claude Code session）完成
+- 无多模型交叉验证（单源）；reviewer 的 G1 Sufficiency Gate 会看到 `mode: "local"` 标记
+- citation verification 由 `verify-local` 子命令执行（确定性代码，非 LLM）
+- 脱敏按标准 post-acquisition 流程（local mode 不外发内容到第三方 LLM，无前置脱敏需求）
+
 ---
 
 **关联文件**：deep-research skill 的 references/pipeline.md（Stages 1-3） · references/principles.md（可追溯性） · references/context-economics.md（搜索工具链）

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -2235,6 +2235,8 @@ def cmd_run_local(args, config):
     cleanup_stale_state(pipeline_dir, verify_dir, raw_dir)
     write_tombstone(verify_dir, goal_hash)
 
+    install_ssrf_guard()
+
     queries = _read_queries_json(args.queries_json)
     search_backends, fetch_backends = build_backends(config)
 

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -33,6 +33,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -560,20 +561,33 @@ def _ddg_extract_target_url(href):
 
 
 def _search_duckduckgo(cfg, query, timeout):
-    # Zero-key, zero-dependency fallback: html.duckduckgo.com is a fixed,
-    # trusted host -- same SSRF posture as the other search backends.
     url = "https://html.duckduckgo.com/html/?q=" + urllib.parse.quote(query)
-    headers = {"User-Agent": "Mozilla/5.0 (compatible; harvest.py/1.0)", "Accept-Encoding": "identity"}
-    req = urllib.request.Request(url, headers=headers)
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            raw = _maybe_decompress(resp.read(), resp)
-    except (urllib.error.URLError, OSError) as e:
-        return None, f"duckduckgo: request failed: {e}"
-    try:
-        page = raw.decode("utf-8", errors="replace")
-    except Exception as e:
-        return None, f"duckduckgo: failed to decode response body: {e}"
+
+    if _HAS_CURL_CFFI:
+        try:
+            resp = curl_cffi_requests.get(
+                url, impersonate=(cfg or {}).get("impersonate", "chrome"),
+                timeout=timeout, allow_redirects=True,
+            )
+            if resp.status_code != 200:
+                return None, f"duckduckgo: HTTP {resp.status_code}"
+            page = resp.text
+        except Exception as e:
+            return None, f"duckduckgo: curl-cffi request failed: {e}"
+    else:
+        headers = {"User-Agent": "Mozilla/5.0 (compatible; harvest.py/1.0)",
+                   "Accept-Encoding": "identity"}
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                raw = _maybe_decompress(resp.read(), resp)
+        except (urllib.error.URLError, OSError) as e:
+            return None, f"duckduckgo: request failed: {e}"
+        try:
+            page = raw.decode("utf-8", errors="replace")
+        except Exception as e:
+            return None, f"duckduckgo: failed to decode response body: {e}"
+
     results = []
     for attrs, inner in _DDG_ANCHOR_RE.findall(page):
         if "result__a" not in attrs:
@@ -1978,6 +1992,8 @@ def check_project(project_dir):
     verdict = data.get("verdict")
     if verdict == "UNAVAILABLE":
         return "FAIL", "multi-model harvest UNAVAILABLE: retry / fix config / or request user exemption to legacy"
+    if verdict == "LOCAL":
+        return "N_A", "local mode: citation verification delegated to caller"
     if verdict != "OK":
         return "FAIL", f"unknown or incomplete verdict: {verdict!r}"
 
@@ -2113,6 +2129,36 @@ def write_fetch_report(raw_dir, results, alive, invalid_total, invalid_rate, loc
     (raw_dir / "fetch-report.md").write_text("\n".join(lines), encoding="utf-8")
 
 
+def write_fetch_report_local(raw_dir, queries, fetched_pages, journal, goal_text):
+    """Local-mode counterpart of write_fetch_report(): no panel/judge/
+    citation-verification stats exist yet in this mode (verify-local runs
+    later, out-of-process), so the report only records what search+fetch
+    actually did."""
+    lines = [
+        "# Fetch Report (Local Mode)\n",
+        "## 采集统计",
+        f"- 搜索查询数: {len(queries)}",
+        f"- 成功抓取页面: {len(fetched_pages)}",
+        f"- 总内容字符数: {sum(p['chars'] for p in fetched_pages)}",
+        "",
+        "## 多模型参与情况",
+        "- N/A (local mode, single-agent)",
+        "",
+        "## 引用校验统计",
+        "- delegated to caller (verify-local subcommand)",
+        "",
+        "## 搜索查询",
+    ]
+    for q in queries:
+        lines.append(f"- {q}")
+    lines.append("")
+    lines.append("## 抓取页面")
+    for p in fetched_pages:
+        lines.append(f"- [{p['title'] or p['url']}]({p['url']}) ({p['chars']} chars)")
+
+    (raw_dir / "fetch-report.md").write_text("\n".join(lines), encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -2122,9 +2168,190 @@ def load_config(path):
         return json.load(f)
 
 
+def _read_queries_json(path):
+    """Read and validate queries from a JSON file or stdin ("-") for local
+    mode. The caller (not an LLM panel) supplies the queries directly, so
+    this is the only place that shapes/validates that input."""
+    try:
+        if path == "-":
+            raw = sys.stdin.read()
+        else:
+            raw = Path(path).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"error: queries file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as e:
+        print(f"error: cannot read queries file: {e}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"error: invalid JSON in queries file: {e}", file=sys.stderr)
+        sys.exit(1)
+    queries = data.get("queries") if isinstance(data, dict) else None
+    if not isinstance(queries, list) or not queries:
+        print('error: queries file must contain a non-empty list in {"queries": [...]}', file=sys.stderr)
+        sys.exit(1)
+    return queries
+
+
+def cmd_run_local(args, config):
+    """Local mode: search + fetch only, no LLM gateway calls at all -- the
+    caller (e.g. an interactive agent) supplies queries directly and does
+    its own reasoning/citation over the fetched pages. Reuses the same
+    project/goal/state-file plumbing as cmd_run() so check_project() and the
+    on-disk layout stay uniform between the two modes; citation
+    verification is deferred to the separate `verify-local` subcommand
+    since there are no panel-produced claims to verify here."""
+    raw_dir = Path(args.out)
+    project_dir_arg = getattr(args, "project_dir", None)
+    if project_dir_arg:
+        project_dir = Path(project_dir_arg).resolve()
+        pipeline_dir = project_dir / "pipeline"
+        verify_dir = pipeline_dir / "verification"
+    else:
+        pipeline_dir = raw_dir.parent
+        project_dir = pipeline_dir.parent
+        verify_dir = pipeline_dir / "verification"
+
+    canonical_goal_file = resolve_goal_file(project_dir)
+    if canonical_goal_file is None:
+        print(f"error: no goal file found under {project_dir} "
+              f"(checked {GOAL_FILE_CONVENTIONAL_DIR}/{GOAL_FILE_NAME} and {GOAL_FILE_NAME}); "
+              "a goal file is required before running harvest", file=sys.stderr)
+        sys.exit(1)
+
+    goal_path = Path(args.goal_file).resolve()
+    canonical_goal_file = canonical_goal_file.resolve()
+    if goal_path != canonical_goal_file:
+        print(f"error: --goal-file {goal_path} does not match the conventionally-resolved "
+              f"goal file {canonical_goal_file} for this project; pass the canonical path so "
+              "goal_file_sha256 is anchored to the text harvest actually runs on", file=sys.stderr)
+        sys.exit(1)
+
+    goal_text = canonical_goal_file.read_text(encoding="utf-8")
+    goal_hash = hashlib.sha256(canonical_goal_file.read_bytes()).hexdigest()
+
+    cleanup_stale_state(pipeline_dir, verify_dir, raw_dir)
+    write_tombstone(verify_dir, goal_hash)
+
+    queries = _read_queries_json(args.queries_json)
+    search_backends, fetch_backends = build_backends(config)
+
+    journal = []
+    all_urls = []
+    for query in queries:
+        result_json = do_search(query, "auto", search_backends, journal, config)
+        results = json.loads(result_json).get("results", [])
+        for r in results:
+            all_urls.append((r["url"], r.get("title", "")))
+
+    url_counts = Counter(url for url, _ in all_urls)
+    seen = set()
+    ranked = []
+    for url, title in all_urls:
+        if url not in seen:
+            seen.add(url)
+            ranked.append({"url": url, "title": title, "count": url_counts[url]})
+    ranked.sort(key=lambda x: x["count"], reverse=True)
+
+    max_fetch = config.get("limits", {}).get("max_fetch_urls", 15)
+    top_urls = ranked[:max_fetch]
+    if not top_urls:
+        print("error: all searches returned no usable URLs", file=sys.stderr)
+        abort_unavailable(verify_dir, goal_hash, "no usable URLs from search")
+
+    fetched_pages = []
+    harvest_dir = raw_dir / HARVEST_SUBDIR / "local"
+    fetched_dir = harvest_dir / "fetched"
+    fetched_dir.mkdir(parents=True, exist_ok=True)
+
+    for i, item in enumerate(top_urls):
+        # do_fetch returns the raw truncated content string on success, or a
+        # json.dumps({"error": ...}) string on failure -- sniffing the return
+        # value itself is ambiguous (fetched prose can legitimately start
+        # with "{"), so read the journal entry do_fetch just appended
+        # instead; its "content" field uses the same None-on-failure
+        # convention build_fetch_index() already relies on elsewhere.
+        do_fetch(item["url"], fetch_backends, journal, config)
+        content = journal[-1].get("content")
+        if content:
+            page_file = fetched_dir / f"page_{i + 1:03d}.txt"
+            page_file.write_text(content, encoding="utf-8")
+            fetched_pages.append({
+                "url": item["url"],
+                "title": item["title"],
+                "content_path": str(page_file.relative_to(raw_dir)),
+                "chars": len(content),
+            })
+
+    if not fetched_pages:
+        print("error: all fetches failed", file=sys.stderr)
+        abort_unavailable(verify_dir, goal_hash, "all fetches failed")
+
+    harvest_dir.mkdir(parents=True, exist_ok=True)
+
+    with (harvest_dir / "journal_local.jsonl").open("w", encoding="utf-8") as f:
+        for entry in journal:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    (harvest_dir / "findings.json").write_text(
+        json.dumps({"claims": [], "status": "LOCAL_DELEGATE", "mode": "local"}, indent=2),
+        encoding="utf-8")
+
+    manifest = {
+        "mode": "local",
+        "timestamp": time.time(),
+        "goal_hash": goal_hash,
+        "queries": queries,
+        "fetched_pages": fetched_pages,
+        "stats": {
+            "queries_executed": len(queries),
+            "pages_fetched": len(fetched_pages),
+            "total_content_chars": sum(p["chars"] for p in fetched_pages),
+        },
+    }
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "harvest-local.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    (raw_dir / MERGED_FINDINGS_FILE).write_text(
+        json.dumps({"clusters": [], "coverage_gaps": [], "mode": "local", "delegate": True},
+                   ensure_ascii=False, indent=2), encoding="utf-8")
+
+    write_fetch_report_local(raw_dir, queries, fetched_pages, journal, goal_text)
+
+    write_verify_json(verify_dir, goal_hash, "LOCAL", {
+        "mode": "local",
+        "pages_fetched": len(fetched_pages),
+        "queries_executed": len(queries),
+    })
+
+    print(f"harvest local mode complete: {len(fetched_pages)} pages fetched")
+
+
 def cmd_run(args):
     config = load_config(args.config)
     _check_curl_cffi_available(config)
+
+    # getattr(...) rather than args.no_api/args.queries_json: same
+    # back-compat rationale as args.project_dir above -- older test/caller
+    # code building an args namespace without these new attributes must
+    # keep working, taking the normal-mode path unchanged.
+    no_api = getattr(args, "no_api", False)
+    queries_json = getattr(args, "queries_json", None)
+    if no_api:
+        if not queries_json:
+            print("error: local mode requires --queries-json", file=sys.stderr)
+            sys.exit(1)
+        cmd_run_local(args, config)
+        return
+    gw_api_key_env = config.get("gateway", {}).get("api_key_env", "")
+    has_gateway_key = bool(os.environ.get(gw_api_key_env, ""))
+    if not has_gateway_key:
+        print("error: Gateway API key missing. To run in local mode, pass "
+              "--no-api --queries-json <file>.", file=sys.stderr)
+        sys.exit(3)
 
     raw_dir = Path(args.out)
     # getattr(...) rather than args.project_dir: keeps this importable by
@@ -2305,6 +2532,97 @@ def cmd_check(args):
     sys.exit(_VERDICT_EXIT_CODES[verdict])
 
 
+def cmd_verify_local(args):
+    """Deterministic citation verification for local-mode claims: no LLM
+    judgment, just a set-membership check of each claim's URL (normalized)
+    against the manifest's fetched_pages -- the same URL-level trust model
+    validate_claims() applies to panel-produced claims, just running
+    out-of-process against caller-supplied claims instead of a journal."""
+    try:
+        claims_raw = Path(args.claims).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"error: claims file not found: {args.claims}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as e:
+        print(f"error: cannot read claims file: {e}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        claims = json.loads(claims_raw)
+    except json.JSONDecodeError as e:
+        print(f"error: invalid JSON in claims file: {e}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(claims, list):
+        print("error: claims must be a list of objects with 'url' field", file=sys.stderr)
+        sys.exit(1)
+    for i, c in enumerate(claims):
+        if not isinstance(c, dict) or not isinstance(c.get("url"), str):
+            print(f"error: claims[{i}] must be an object with a string 'url' field", file=sys.stderr)
+            sys.exit(1)
+
+    try:
+        manifest_raw = Path(args.manifest).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"error: manifest file not found: {args.manifest}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as e:
+        print(f"error: cannot read manifest file: {e}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        manifest = json.loads(manifest_raw)
+    except json.JSONDecodeError as e:
+        print(f"error: invalid JSON in manifest file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    fetched_urls = set()
+    for page in manifest.get("fetched_pages", []):
+        url = page.get("url", "")
+        if url:
+            fetched_urls.add(normalize_url(url))
+
+    valid, invalid = [], []
+    for c in claims:
+        normalized = normalize_url(c["url"])
+        if normalized in fetched_urls:
+            valid.append(c)
+        else:
+            invalid.append({"claim": c.get("claim", ""), "url": c["url"],
+                             "reject_reason": "url_not_in_fetched_pages"})
+
+    total = len(valid) + len(invalid)
+    invalid_rate = len(invalid) / total if total > 0 else 0.0
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    (out_dir / "rejected_claims.json").write_text(
+        json.dumps(invalid, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    if len(valid) == 0 or invalid_rate > 0.05:
+        verdict = "UNAVAILABLE"
+        reason = f"invalid_rate={invalid_rate:.2%}, valid={len(valid)}, invalid={len(invalid)}"
+    else:
+        verdict = "OK"
+        reason = None
+
+    goal_hash = manifest.get("goal_hash", "")
+    payload = {
+        "mode": "local",
+        "invalid_citation_rate": invalid_rate,
+        "invalid_claim_count": len(invalid),
+        "total_claims": total,
+    }
+    if reason:
+        payload["reason"] = reason
+    write_verify_json(out_dir, goal_hash, verdict, payload)
+
+    if verdict == "OK":
+        print(f"verify-local: PASS (valid={len(valid)}, invalid={len(invalid)}, rate={invalid_rate:.2%})")
+        sys.exit(0)
+    else:
+        print(f"verify-local: FAIL ({reason})", file=sys.stderr)
+        sys.exit(1)
+
+
 def build_arg_parser():
     parser = argparse.ArgumentParser(prog="harvest.py")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -2320,11 +2638,24 @@ def build_arg_parser():
                              "for a supplementary/backfill run where --out is a subdirectory of "
                              "the primary pipeline/1_raw (otherwise the old raw_dir.parent.parent "
                              "derivation miscomputes the project root).")
+    run_p.add_argument("--no-api", action="store_true",
+                        help="Local mode: search+fetch only via this script's backends, no LLM "
+                             "gateway calls. Requires --queries-json; citation verification is "
+                             "deferred to the separate verify-local subcommand.")
+    run_p.add_argument("--queries-json", default=None,
+                        help="Path to a JSON file (or '-' for stdin) with {\"queries\": [...]}, "
+                             "required when --no-api is set.")
     run_p.set_defaults(func=cmd_run)
 
     check_p = sub.add_parser("check")
     check_p.add_argument("project_dir")
     check_p.set_defaults(func=cmd_check)
+
+    verify_local_p = sub.add_parser("verify-local")
+    verify_local_p.add_argument("--claims", required=True)
+    verify_local_p.add_argument("--manifest", required=True)
+    verify_local_p.add_argument("--out", required=True)
+    verify_local_p.set_defaults(func=cmd_verify_local)
 
     return parser
 

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -681,7 +681,49 @@ class TestDuckDuckGoSearch(unittest.TestCase):
         self.assertIn("IP-reputation block", reason)
 
 
-class TestAgyCliSearch(unittest.TestCase):
+class TestDuckDuckGoSearchCurlCffi(unittest.TestCase):
+    """Tests for the curl-cffi path of _search_duckduckgo (when _HAS_CURL_CFFI=True)."""
+
+    def test_curl_cffi_success_parses_results(self):
+        fake_resp = mock.Mock()
+        fake_resp.status_code = 200
+        fake_resp.text = _DDG_SAMPLE_HTML
+        with mock.patch.object(harvest, "_HAS_CURL_CFFI", True), \
+             mock.patch("harvest.curl_cffi_requests") as mock_curl:
+            mock_curl.get.return_value = fake_resp
+            results, reason = harvest._search_duckduckgo({}, "query", 5)
+        self.assertIsNone(reason)
+        self.assertTrue(len(results) > 0)
+        mock_curl.get.assert_called_once()
+
+    def test_curl_cffi_non_200_returns_error(self):
+        fake_resp = mock.Mock()
+        fake_resp.status_code = 403
+        with mock.patch.object(harvest, "_HAS_CURL_CFFI", True), \
+             mock.patch("harvest.curl_cffi_requests") as mock_curl:
+            mock_curl.get.return_value = fake_resp
+            result, reason = harvest._search_duckduckgo({}, "query", 5)
+        self.assertIsNone(result)
+        self.assertIn("HTTP 403", reason)
+
+    def test_curl_cffi_exception_returns_error(self):
+        with mock.patch.object(harvest, "_HAS_CURL_CFFI", True), \
+             mock.patch("harvest.curl_cffi_requests") as mock_curl:
+            mock_curl.get.side_effect = RuntimeError("connection reset")
+            result, reason = harvest._search_duckduckgo({}, "query", 5)
+        self.assertIsNone(result)
+        self.assertIn("curl-cffi request failed", reason)
+
+    def test_curl_cffi_uses_impersonate_from_cfg(self):
+        fake_resp = mock.Mock()
+        fake_resp.status_code = 200
+        fake_resp.text = "<html></html>"
+        with mock.patch.object(harvest, "_HAS_CURL_CFFI", True), \
+             mock.patch("harvest.curl_cffi_requests") as mock_curl:
+            mock_curl.get.return_value = fake_resp
+            harvest._search_duckduckgo({"impersonate": "safari"}, "q", 5)
+        call_kwargs = mock_curl.get.call_args[1]
+        self.assertEqual(call_kwargs["impersonate"], "safari")
     def _fake_proc(self, stdout="", returncode=0, stderr=""):
         proc = mock.Mock()
         proc.returncode = returncode

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -572,6 +572,14 @@ _DDG_SAMPLE_HTML = """
 
 
 class TestDuckDuckGoSearch(unittest.TestCase):
+    def setUp(self):
+        # Force urllib path so HTML-parsing tests stay isolated from curl-cffi.
+        self._patch = mock.patch.object(harvest, "_HAS_CURL_CFFI", False)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+
     def test_parses_result_links_and_unwraps_uddg_redirect(self):
         with mock.patch("harvest.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
@@ -1170,7 +1178,8 @@ class TestBackendDegradation(unittest.TestCase):
             ({"type": "tavily", "api_key_env": "NONEXISTENT_TAVILY_KEY_VAR"}, harvest.RateLimiter(0)),
             ({"type": "duckduckgo"}, harvest.RateLimiter(0)),
         ]
-        with mock.patch("harvest.urllib.request.urlopen", side_effect=OSError("network down")):
+        with mock.patch.object(harvest, "_HAS_CURL_CFFI", False), \
+             mock.patch("harvest.urllib.request.urlopen", side_effect=OSError("network down")):
             harvest.do_search("q", "en", backends, journal, self.config)
         attempts = journal[0]["attempts"]
         self.assertEqual(len(attempts), 2)
@@ -2237,7 +2246,16 @@ class TestCmdRunEndToEnd(unittest.TestCase):
         self._orig_getaddrinfo = socket.getaddrinfo
         harvest._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))]
 
+        # cmd_run's new gateway-key gate (--no-api local mode) fires before
+        # any of the normal-mode logic these tests exercise -- fake key
+        # present, same TEST_GATEWAY_KEY name base_config()'s api_key_env
+        # already points at, keeps every existing normal-mode test on the
+        # gated path it always ran.
+        self._env_patch = mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"})
+        self._env_patch.start()
+
     def tearDown(self):
+        self._env_patch.stop()
         harvest._real_getaddrinfo = self._orig_real
         socket.getaddrinfo = self._orig_getaddrinfo
         self.tmpdir.cleanup()
@@ -2523,7 +2541,12 @@ class TestCmdRunGoalFileResolution(unittest.TestCase):
         self.raw_dir = self.pipeline_dir / "1_raw"
         self.raw_dir.mkdir(parents=True)
 
+        # Same gateway-key gate rationale as TestCmdRunEndToEnd.setUp.
+        self._env_patch = mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"})
+        self._env_patch.start()
+
     def tearDown(self):
+        self._env_patch.stop()
         self.tmpdir.cleanup()
 
     def test_no_resolvable_goal_file_aborts_before_any_state_write(self):
@@ -2612,7 +2635,12 @@ class TestSupplementaryRunIsolation(unittest.TestCase):
         self.goal_file.write_text("why is the sky blue?", encoding="utf-8")
         self.config = base_config()
 
+        # Same gateway-key gate rationale as TestCmdRunEndToEnd.setUp.
+        self._env_patch = mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"})
+        self._env_patch.start()
+
     def tearDown(self):
+        self._env_patch.stop()
         self.tmpdir.cleanup()
 
     def _run(self, raw_dir, project_dir_arg, goal_file_arg=None):
@@ -3363,6 +3391,407 @@ class TestBudgetNudgeAndForcedSynthesisConvergence(unittest.TestCase):
 class argparse_ns:
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
+
+
+# ---------------------------------------------------------------------------
+# --no-api local mode: dispatch gating in cmd_run
+# ---------------------------------------------------------------------------
+
+class TestCmdRunLocalModeDispatch(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.project_dir = Path(self.tmpdir.name)
+        self.pipeline_dir = self.project_dir / "pipeline"
+        self.raw_dir = self.pipeline_dir / "1_raw"
+        self.raw_dir.mkdir(parents=True)
+        self.goal_file = self.project_dir / harvest.GOAL_FILE_NAME
+        self.goal_file.write_text("why is the sky blue?", encoding="utf-8")
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_no_api_without_queries_json_exits_1(self):
+        config = base_config()
+        args = argparse_ns(goal_file=str(self.goal_file), out=str(self.raw_dir), config="unused",
+                            local_dir=None, no_api=True, queries_json=None)
+        with mock.patch("harvest.load_config", return_value=config):
+            with self.assertRaises(SystemExit) as ctx:
+                harvest.cmd_run(args)
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_missing_gateway_key_without_no_api_exits_3(self):
+        # TEST_GATEWAY_KEY deliberately absent from the environment here --
+        # normal mode with no key and no --no-api must fail fast with a
+        # message pointing at the local-mode escape hatch, before any
+        # cleanup/tombstone/network activity.
+        config = base_config()
+        args = argparse_ns(goal_file=str(self.goal_file), out=str(self.raw_dir), config="unused",
+                            local_dir=None, no_api=False, queries_json=None)
+        with mock.patch.dict(os.environ, {}, clear=False), \
+             mock.patch("harvest.load_config", return_value=config):
+            os.environ.pop("TEST_GATEWAY_KEY", None)
+            with self.assertRaises(SystemExit) as ctx:
+                harvest.cmd_run(args)
+        self.assertEqual(ctx.exception.code, 3)
+        verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
+        self.assertFalse(verify_file.exists())
+
+    def test_no_api_dispatches_to_local_mode_not_normal_mode(self):
+        # With --no-api set, cmd_run must never touch make_client_factory /
+        # run_panel (the normal-mode LLM path) even when a gateway key is
+        # present -- local mode is a hard fork, not a fallback.
+        config = base_config()
+        queries_file = self.project_dir / "queries.json"
+        queries_file.write_text(json.dumps({"queries": ["why is the sky blue"]}), encoding="utf-8")
+        args = argparse_ns(goal_file=str(self.goal_file), out=str(self.raw_dir), config="unused",
+                            local_dir=None, no_api=True, queries_json=str(queries_file))
+        with mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"}), \
+             mock.patch("harvest.load_config", return_value=config), \
+             mock.patch("harvest.make_client_factory", side_effect=AssertionError("must not call normal-mode factory")), \
+             mock.patch("harvest.do_search", return_value=json.dumps({"results": [{"url": "https://a.com/1", "title": "t"}]})), \
+             mock.patch("harvest.do_fetch") as mock_do_fetch:
+            def fake_fetch(url, fetch_backends, journal, config):
+                journal.append({"tool": "fetch", "url": url, "backend": "urllib-ua", "content": "fetched body"})
+                return "fetched body"
+            mock_do_fetch.side_effect = fake_fetch
+            harvest.cmd_run(args)
+
+        verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
+        self.assertTrue(verify_file.exists())
+        data = json.loads(verify_file.read_text(encoding="utf-8"))
+        self.assertEqual(data["verdict"], "LOCAL")
+
+
+# ---------------------------------------------------------------------------
+# cmd_run_local: search + fetch only, no LLM, writes manifest/report/verify
+# ---------------------------------------------------------------------------
+
+class TestCmdRunLocalEndToEnd(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.project_dir = Path(self.tmpdir.name)
+        self.pipeline_dir = self.project_dir / "pipeline"
+        self.raw_dir = self.pipeline_dir / "1_raw"
+        self.raw_dir.mkdir(parents=True)
+        self.goal_file = self.project_dir / harvest.GOAL_FILE_NAME
+        self.goal_file.write_text("why is the sky blue?", encoding="utf-8")
+        self.config = base_config()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _args(self, queries_json_path):
+        return argparse_ns(goal_file=str(self.goal_file), out=str(self.raw_dir), config="unused",
+                            local_dir=None, no_api=True, queries_json=str(queries_json_path))
+
+    def test_happy_path_writes_manifest_report_and_local_verdict(self):
+        queries_file = self.project_dir / "queries.json"
+        queries_file.write_text(json.dumps({"queries": ["q1", "q2"]}), encoding="utf-8")
+
+        search_results = json.dumps({"results": [
+            {"url": "https://example.com/a", "title": "A"},
+            {"url": "https://example.com/b", "title": "B"},
+        ]})
+
+        def fake_fetch(url, fetch_backends, journal, config):
+            content = f"content for {url}"
+            journal.append({"tool": "fetch", "url": url, "backend": "urllib-ua", "content": content})
+            return content
+
+        with mock.patch("harvest.do_search", return_value=search_results), \
+             mock.patch("harvest.do_fetch", side_effect=fake_fetch):
+            harvest.cmd_run_local(self._args(queries_file), self.config)
+
+        verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
+        self.assertTrue(verify_file.exists())
+        data = json.loads(verify_file.read_text(encoding="utf-8"))
+        self.assertEqual(data["verdict"], "LOCAL")
+        self.assertEqual(data["pages_fetched"], 2)
+        self.assertEqual(data["queries_executed"], 2)
+
+        manifest_file = self.raw_dir / "harvest-local.json"
+        self.assertTrue(manifest_file.exists())
+        manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+        self.assertEqual(manifest["mode"], "local")
+        self.assertEqual(len(manifest["fetched_pages"]), 2)
+        self.assertEqual(manifest["goal_hash"], data["goal_file_sha256"])
+
+        for page in manifest["fetched_pages"]:
+            page_path = self.raw_dir / page["content_path"]
+            self.assertTrue(page_path.exists())
+
+        self.assertTrue((self.raw_dir / "fetch-report.md").exists())
+        self.assertTrue((self.raw_dir / harvest.MERGED_FINDINGS_FILE).exists())
+
+        # check_project must treat a LOCAL verdict as N_A (delegated), not
+        # PASS/FAIL -- gate is deferred to verify-local + caller judgment.
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "N_A")
+
+    def test_no_search_results_aborts_unavailable(self):
+        queries_file = self.project_dir / "queries.json"
+        queries_file.write_text(json.dumps({"queries": ["q1"]}), encoding="utf-8")
+        empty_results = json.dumps({"results": []})
+        with mock.patch("harvest.do_search", return_value=empty_results):
+            with self.assertRaises(SystemExit) as ctx:
+                harvest.cmd_run_local(self._args(queries_file), self.config)
+        self.assertEqual(ctx.exception.code, 3)
+        verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
+        data = json.loads(verify_file.read_text(encoding="utf-8"))
+        self.assertEqual(data["verdict"], "UNAVAILABLE")
+
+    def test_all_fetches_fail_aborts_unavailable(self):
+        queries_file = self.project_dir / "queries.json"
+        queries_file.write_text(json.dumps({"queries": ["q1"]}), encoding="utf-8")
+        search_results = json.dumps({"results": [{"url": "https://example.com/a", "title": "A"}]})
+
+        def fake_fetch_fail(url, fetch_backends, journal, config):
+            journal.append({"tool": "fetch", "url": url, "backend": None, "content": None})
+            return json.dumps({"error": "all fetch backends failed"})
+
+        with mock.patch("harvest.do_search", return_value=search_results), \
+             mock.patch("harvest.do_fetch", side_effect=fake_fetch_fail):
+            with self.assertRaises(SystemExit) as ctx:
+                harvest.cmd_run_local(self._args(queries_file), self.config)
+        self.assertEqual(ctx.exception.code, 3)
+        verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
+        data = json.loads(verify_file.read_text(encoding="utf-8"))
+        self.assertEqual(data["verdict"], "UNAVAILABLE")
+
+    def test_ranks_urls_by_search_result_frequency(self):
+        # url "b" appears in both query results, "a" only once -- ranked
+        # (and therefore fetch-ordered) output must put "b" first.
+        queries_file = self.project_dir / "queries.json"
+        queries_file.write_text(json.dumps({"queries": ["q1", "q2"]}), encoding="utf-8")
+
+        def fake_search(query, lang, search_backends, journal, config):
+            if query == "q1":
+                return json.dumps({"results": [{"url": "https://x.com/a", "title": "A"},
+                                                 {"url": "https://x.com/b", "title": "B"}]})
+            return json.dumps({"results": [{"url": "https://x.com/b", "title": "B"}]})
+
+        fetch_order = []
+
+        def fake_fetch(url, fetch_backends, journal, config):
+            fetch_order.append(url)
+            journal.append({"tool": "fetch", "url": url, "backend": "urllib-ua", "content": "c"})
+            return "c"
+
+        with mock.patch("harvest.do_search", side_effect=fake_search), \
+             mock.patch("harvest.do_fetch", side_effect=fake_fetch):
+            harvest.cmd_run_local(self._args(queries_file), self.config)
+
+        self.assertEqual(fetch_order[0], "https://x.com/b")
+
+    def test_respects_max_fetch_urls_limit(self):
+        queries_file = self.project_dir / "queries.json"
+        queries_file.write_text(json.dumps({"queries": ["q1"]}), encoding="utf-8")
+        many_results = json.dumps({"results": [
+            {"url": f"https://x.com/{i}", "title": str(i)} for i in range(5)
+        ]})
+        cfg = base_config()
+        cfg["limits"]["max_fetch_urls"] = 2
+
+        fetched = []
+
+        def fake_fetch(url, fetch_backends, journal, config):
+            fetched.append(url)
+            journal.append({"tool": "fetch", "url": url, "backend": "urllib-ua", "content": "c"})
+            return "c"
+
+        with mock.patch("harvest.do_search", return_value=many_results), \
+             mock.patch("harvest.do_fetch", side_effect=fake_fetch):
+            harvest.cmd_run_local(self._args(queries_file), cfg)
+
+        self.assertEqual(len(fetched), 2)
+
+
+# ---------------------------------------------------------------------------
+# _read_queries_json helper
+# ---------------------------------------------------------------------------
+
+class TestReadQueriesJson(unittest.TestCase):
+    def test_missing_file_exits_1(self):
+        with self.assertRaises(SystemExit) as ctx:
+            harvest._read_queries_json("/nonexistent-queries-file-xyz.json")
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_invalid_json_exits_1(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "q.json"
+            p.write_text("not json", encoding="utf-8")
+            with self.assertRaises(SystemExit) as ctx:
+                harvest._read_queries_json(str(p))
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_missing_queries_key_exits_1(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "q.json"
+            p.write_text(json.dumps({"not_queries": []}), encoding="utf-8")
+            with self.assertRaises(SystemExit) as ctx:
+                harvest._read_queries_json(str(p))
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_empty_queries_list_exits_1(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "q.json"
+            p.write_text(json.dumps({"queries": []}), encoding="utf-8")
+            with self.assertRaises(SystemExit) as ctx:
+                harvest._read_queries_json(str(p))
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_valid_file_returns_queries_list(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "q.json"
+            p.write_text(json.dumps({"queries": ["a", "b"]}), encoding="utf-8")
+            self.assertEqual(harvest._read_queries_json(str(p)), ["a", "b"])
+
+    def test_stdin_dash_reads_from_stdin(self):
+        with mock.patch("sys.stdin", io.StringIO(json.dumps({"queries": ["a"]}))):
+            self.assertEqual(harvest._read_queries_json("-"), ["a"])
+
+
+# ---------------------------------------------------------------------------
+# cmd_verify_local: deterministic citation check for caller-supplied claims
+# ---------------------------------------------------------------------------
+
+class TestCmdVerifyLocal(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmpdir.name)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _write(self, name, data):
+        p = self.dir / name
+        p.write_text(json.dumps(data), encoding="utf-8")
+        return p
+
+    def test_all_claims_valid_yields_ok_and_exit_0(self):
+        manifest_path = self._write("manifest.json", {
+            "goal_hash": "abc123",
+            "fetched_pages": [{"url": "https://example.com/a"}, {"url": "https://example.com/b"}],
+        })
+        claims_path = self._write("claims.json", [
+            {"claim": "c1", "url": "https://example.com/a"},
+            {"claim": "c2", "url": "https://example.com/b"},
+        ])
+        out_dir = self.dir / "out"
+        args = argparse_ns(claims=str(claims_path), manifest=str(manifest_path), out=str(out_dir))
+        with self.assertRaises(SystemExit) as ctx:
+            harvest.cmd_verify_local(args)
+        self.assertEqual(ctx.exception.code, 0)
+
+        verify_file = out_dir / harvest.VERIFY_FILE
+        data = json.loads(verify_file.read_text(encoding="utf-8"))
+        self.assertEqual(data["verdict"], "OK")
+        self.assertEqual(data["goal_file_sha256"], "abc123")
+        self.assertEqual(data["total_claims"], 2)
+        self.assertEqual(data["invalid_claim_count"], 0)
+
+        rejected = json.loads((out_dir / "rejected_claims.json").read_text(encoding="utf-8"))
+        self.assertEqual(rejected, [])
+
+    def test_claim_citing_unfetched_url_is_rejected(self):
+        manifest_path = self._write("manifest.json", {
+            "fetched_pages": [{"url": "https://example.com/a"}],
+        })
+        claims_path = self._write("claims.json", [
+            {"claim": "c1", "url": "https://example.com/a"},
+            {"claim": "c2", "url": "https://example.com/never-fetched"},
+        ])
+        out_dir = self.dir / "out"
+        args = argparse_ns(claims=str(claims_path), manifest=str(manifest_path), out=str(out_dir))
+        with self.assertRaises(SystemExit) as ctx:
+            harvest.cmd_verify_local(args)
+        # 1/2 invalid == 50% > 5% threshold -> UNAVAILABLE, exit 1.
+        self.assertEqual(ctx.exception.code, 1)
+
+        data = json.loads((out_dir / harvest.VERIFY_FILE).read_text(encoding="utf-8"))
+        self.assertEqual(data["verdict"], "UNAVAILABLE")
+
+        rejected = json.loads((out_dir / "rejected_claims.json").read_text(encoding="utf-8"))
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0]["reject_reason"], "url_not_in_fetched_pages")
+
+    def test_url_normalization_matches_trailing_slash_variants(self):
+        # normalize_url() strips trailing slashes -- a claim citing the
+        # slash-terminated form of a fetched URL must still match.
+        manifest_path = self._write("manifest.json", {
+            "fetched_pages": [{"url": "https://example.com/a/"}],
+        })
+        claims_path = self._write("claims.json", [
+            {"claim": "c1", "url": "https://example.com/a"},
+        ])
+        out_dir = self.dir / "out"
+        args = argparse_ns(claims=str(claims_path), manifest=str(manifest_path), out=str(out_dir))
+        with self.assertRaises(SystemExit) as ctx:
+            harvest.cmd_verify_local(args)
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_zero_claims_yields_unavailable(self):
+        manifest_path = self._write("manifest.json", {"fetched_pages": []})
+        claims_path = self._write("claims.json", [])
+        out_dir = self.dir / "out"
+        args = argparse_ns(claims=str(claims_path), manifest=str(manifest_path), out=str(out_dir))
+        with self.assertRaises(SystemExit) as ctx:
+            harvest.cmd_verify_local(args)
+        self.assertEqual(ctx.exception.code, 1)
+        data = json.loads((out_dir / harvest.VERIFY_FILE).read_text(encoding="utf-8"))
+        self.assertEqual(data["verdict"], "UNAVAILABLE")
+
+    def test_malformed_claim_missing_url_field_exits_1(self):
+        manifest_path = self._write("manifest.json", {"fetched_pages": []})
+        claims_path = self._write("claims.json", [{"claim": "c1"}])
+        out_dir = self.dir / "out"
+        args = argparse_ns(claims=str(claims_path), manifest=str(manifest_path), out=str(out_dir))
+        with self.assertRaises(SystemExit) as ctx:
+            harvest.cmd_verify_local(args)
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertFalse((out_dir / harvest.VERIFY_FILE).exists())
+
+    def test_claims_file_not_a_list_exits_1(self):
+        manifest_path = self._write("manifest.json", {"fetched_pages": []})
+        claims_path = self._write("claims.json", {"claims": []})
+        out_dir = self.dir / "out"
+        args = argparse_ns(claims=str(claims_path), manifest=str(manifest_path), out=str(out_dir))
+        with self.assertRaises(SystemExit) as ctx:
+            harvest.cmd_verify_local(args)
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_missing_claims_file_exits_1(self):
+        manifest_path = self._write("manifest.json", {"fetched_pages": []})
+        out_dir = self.dir / "out"
+        args = argparse_ns(claims="/nonexistent-claims.json", manifest=str(manifest_path), out=str(out_dir))
+        with self.assertRaises(SystemExit) as ctx:
+            harvest.cmd_verify_local(args)
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_missing_manifest_file_exits_1(self):
+        claims_path = self._write("claims.json", [])
+        out_dir = self.dir / "out"
+        args = argparse_ns(claims=str(claims_path), manifest="/nonexistent-manifest.json", out=str(out_dir))
+        with self.assertRaises(SystemExit) as ctx:
+            harvest.cmd_verify_local(args)
+        self.assertEqual(ctx.exception.code, 1)
+
+
+# ---------------------------------------------------------------------------
+# check_project: LOCAL verdict handling
+# ---------------------------------------------------------------------------
+
+class TestCheckProjectLocalVerdict(unittest.TestCase):
+    def test_local_verdict_yields_n_a(self):
+        with tempfile.TemporaryDirectory() as d:
+            project_dir = Path(d)
+            verify_dir = project_dir / "pipeline" / "verification"
+            verify_dir.mkdir(parents=True)
+            (verify_dir / harvest.VERIFY_FILE).write_text(
+                json.dumps({"verdict": "LOCAL", "goal_file_sha256": "x"}), encoding="utf-8")
+            verdict, reason = harvest.check_project(project_dir)
+        self.assertEqual(verdict, "N_A")
+        self.assertIn("local mode", reason)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- harvest.py 新增 `--no-api` 本地模式：无 LLM gateway 时作为搜索/抓取工具箱，推理由 harvester subagent 承担
- `_search_duckduckgo` 优先走 curl-cffi Chrome TLS 模拟，绕过 bot-check（此前 urllib 裸 UA 被拦）
- 新增 `verify-local` 子命令：确定性 citation 校验（URL 归一化 + 集合匹配 + 5% 阈值）
- research-harvester agent 协议补充 local mode 10 步流程

## Key design decisions

- `--no-api` 是显式 flag，无 key 时不自动降级（向后兼容，旧调用方仍看到 exit 3）
- 搜索/抓取照常走网络，只是不调 LLM gateway（panel + judge = 0 次）
- citation verification 由 Python 代码执行（不让 LLM 做数学）
- DDG curl-cffi 路径不需要 SSRF guard（固定可信 host）

## Test plan

- [x] 284 existing tests pass (0 regressions)
- [x] 27 new local-mode tests pass
- [x] DDG search via curl-cffi live test (previously bot-checked IP now gets results)
- [x] `--no-api` e2e: 2 queries → 5 pages fetched, 24k chars
- [x] `verify-local` e2e: valid claims → PASS; invalid claims → FAIL with rejected_claims.json