### PR TITLE
feat(harvest): fetch 抗慢速拖延 + jina 直连兜底重排

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest.config.json
+++ b/plugins/deep-research/scripts/harvest.config.json
@@ -25,18 +25,22 @@
   "fetch_backends": [
     {
       "type": "curl-cffi",
-      "impersonate": "chrome"
-    },
-    {
-      "type": "tavily-extract",
-      "api_key_env": "TAVILY_API_KEY"
+      "impersonate": "chrome",
+      "timeout_s": 25
     },
     {
       "type": "jina-reader",
-      "api_key_env": "JINA_API_KEY"
+      "api_key_env": "JINA_API_KEY",
+      "timeout_s": 60
     },
     {
-      "type": "urllib-ua"
+      "type": "tavily-extract",
+      "api_key_env": "TAVILY_API_KEY",
+      "timeout_s": 60
+    },
+    {
+      "type": "urllib-ua",
+      "timeout_s": 25
     }
   ],
   "local_sources": {
@@ -52,7 +56,10 @@
     "quorum": 2,
     "search_min_interval_s": 2,
     "fetch_min_interval_s": 0.5,
-    "fetch_max_chars": 20000
+    "fetch_max_chars": 20000,
+    "fetch_connect_timeout_s": 5,
+    "fetch_low_speed_bytes_s": 512,
+    "fetch_low_speed_window_s": 10
   },
   "blacklist_domains": [
     "blog.csdn.net",

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -861,10 +861,32 @@ def _fetch_curl_cffi(cfg, url, timeout, max_chars, config):
     # already fail-fast-exits cmd_run() before any fetch happens if this
     # backend is configured but curl_cffi isn't importable, so by the time
     # this function runs, _HAS_CURL_CFFI is guaranteed True.
+    #
+    # `timeout` is the total budget for this call *across all redirect
+    # hops*, not per-hop -- without this, a tarpit (slow-drip response)
+    # combined with a redirect chain could burn hops * timeout wall clock.
+    # `.get(key, default)` (not `config["limits"][key]`) is deliberate:
+    # these three keys are new, and a config that predates them must keep
+    # working with these defaults rather than KeyError -> get swallowed by
+    # call_fetch_backend's broad except into a silent, permanent
+    # "unexpected error" that takes curl-cffi out of rotation for good.
+    limits = config.get("limits", {})
+    connect_timeout_s = limits.get("fetch_connect_timeout_s", 5)
+    low_speed_bytes_s = limits.get("fetch_low_speed_bytes_s", 512)
+    low_speed_window_s = limits.get("fetch_low_speed_window_s", 10)
     blacklist = config.get("blacklist_domains", [])
     impersonate = cfg.get("impersonate", "chrome")
     current_url = url
+    deadline = time.monotonic() + timeout
     for hop in range(_CURL_CFFI_MAX_REDIRECT_HOPS + 1):
+        # < 1, not <= 0: curl_cffi converts seconds to milliseconds via
+        # int(x * 1000), and libcurl treats a 0ms timeout as *no limit*.
+        # A remaining budget inside that sub-millisecond window would
+        # otherwise round down to 0 and silently reopen the hang this
+        # deadline exists to close.
+        remaining = deadline - time.monotonic()
+        if remaining < 1:
+            return None, "curl-cffi: total fetch deadline exceeded across redirects"
         if is_blacklisted(current_url, blacklist):
             return None, f"curl-cffi: redirect target domain blacklisted: {current_url}"
         try:
@@ -872,11 +894,23 @@ def _fetch_curl_cffi(cfg, url, timeout, max_chars, config):
         except (socket.gaierror, OSError) as e:
             return None, f"curl-cffi: DNS resolution failed: {e}"
         pin = f"{host}:{port}:{ip}"
+        # curl_cffi 0.15.0 sets CURLOPT_TIMEOUT_MS = connect + read for a
+        # tuple timeout (it sums the two components, it doesn't treat
+        # `read` as the total) -- so to cap this hop's total at exactly
+        # `remaining`, the read component must be `remaining - conn`, not
+        # `remaining` itself. `- 0.1` keeps a strictly positive read
+        # component even when remaining is barely above the connect cap.
+        conn = min(connect_timeout_s, remaining - 0.1)
         try:
             resp = curl_cffi_requests.get(
-                current_url, timeout=timeout, impersonate=impersonate,
+                current_url, timeout=(conn, remaining - conn), impersonate=impersonate,
                 allow_redirects=False, headers={"Accept-Encoding": "identity"},
-                curl_options={CurlCffiOpt.RESOLVE: [pin], CurlCffiOpt.MAXFILESIZE_LARGE: max_chars * 4},
+                curl_options={
+                    CurlCffiOpt.RESOLVE: [pin],
+                    CurlCffiOpt.MAXFILESIZE_LARGE: max_chars * 4,
+                    CurlCffiOpt.LOW_SPEED_LIMIT: low_speed_bytes_s,
+                    CurlCffiOpt.LOW_SPEED_TIME: low_speed_window_s,
+                },
             )
         except Exception as e:
             return None, f"curl-cffi: request failed: {e}"
@@ -929,7 +963,10 @@ def _fetch_urllib_ua(cfg, url, timeout, max_chars):
 
 def call_fetch_backend(backend_cfg, limiter, url, config, attempts=None):
     limiter.acquire()
-    timeout = config["limits"]["call_timeout_s"]
+    # Per-backend timeout_s override, falling back to the shared
+    # call_timeout_s -- .get() means backends that don't declare timeout_s
+    # (or a config predating this field) keep the old 180s behavior.
+    timeout = backend_cfg.get("timeout_s", config["limits"]["call_timeout_s"])
     max_chars = config["limits"]["fetch_max_chars"]
     btype = backend_cfg["type"]
     try:

--- a/plugins/deep-research/skills/deep-research/SKILL.md
+++ b/plugins/deep-research/skills/deep-research/SKILL.md
@@ -56,6 +56,11 @@ G0 与用户完成 primary_job / Non-Goals 对齐后、进入 Acquisition 前，
      > 2. 使用 `--no-api` 模式（零外部 LLM 消耗，由我直接搜索+分析，质量略低于多模型交叉验证）"
    - 用户选 1 → Lead 指引用户 export key 或写入 `.env`，确认后走 panel mode
    - 用户选 2 → Lead 在 spawn harvester 的 Task 指令中加 `--no-api` 标记
+3. **检测 `JINA_API_KEY`**（fetch 兜底链 jina-reader 的可选加速 key）：
+   ```bash
+   [ -n "$JINA_API_KEY" ] && echo set || echo unset
+   ```
+   若 `unset`，向用户提示一句（如"ℹ️ JINA_API_KEY 未配置：fetch 兜底 jina 走免费限流档，速率较低、并发受限；配置后可提速。不阻塞，继续。"），**不阻塞管线，继续 G0**——jina 无 key 也能工作，这只是速率提示，不是需求门。
 
 **`--no-api` 模式说明**（供 Lead 告知用户）：
 - harvest.py 只负责搜索+抓取，不调 LLM gateway（零 API 成本）

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -30,7 +30,9 @@ def base_config(**overrides):
         "fetch_backends": [{"type": "urllib-ua"}],
         "local_sources": {"enabled": False, "dir": "intake/local_sources"},
         "limits": {"max_steps_per_model": 6, "call_timeout_s": 5, "wall_clock_s": 60,
-                   "quorum": 2, "search_min_interval_s": 0, "fetch_max_chars": 20000},
+                   "quorum": 2, "search_min_interval_s": 0, "fetch_max_chars": 20000,
+                   "fetch_connect_timeout_s": 5, "fetch_low_speed_bytes_s": 512,
+                   "fetch_low_speed_window_s": 10},
         "blacklist_domains": ["blog.csdn.net", "cloud.baidu.com", "aliyun.com"],
     }
     cfg.update(overrides)
@@ -1367,6 +1369,57 @@ class TestCurlCffiFetch(unittest.TestCase):
         self.assertEqual(content, "clean text")
         m.assert_called_once()
 
+    def test_low_speed_options_set_from_config(self):
+        cfg = base_config()
+        cfg["limits"]["fetch_low_speed_bytes_s"] = 999
+        cfg["limits"]["fetch_low_speed_window_s"] = 7
+        with mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(200, "<p>ok</p>")) as m:
+            self._fetch("https://a.com/x", config=cfg)
+        curl_options = m.call_args.kwargs["curl_options"]
+        self.assertEqual(curl_options[harvest.CurlCffiOpt.LOW_SPEED_LIMIT], 999)
+        self.assertEqual(curl_options[harvest.CurlCffiOpt.LOW_SPEED_TIME], 7)
+
+    def test_timeout_tuple_connect_plus_read_equals_remaining_budget(self):
+        # curl_cffi 0.15.0 sums (connect, read) into CURLOPT_TIMEOUT_MS for
+        # non-stream calls -- so the read component must be
+        # `remaining - connect`, not `remaining`, or the effective total
+        # would be connect + remaining (over budget).
+        with mock.patch("harvest.time.monotonic", side_effect=[0.0, 0.0]), \
+             mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(200, "<p>ok</p>")) as m:
+            self._fetch("https://a.com/x", timeout=20)
+        conn, read = m.call_args.kwargs["timeout"]
+        self.assertAlmostEqual(conn + read, 20, places=3)
+        self.assertEqual(conn, 5)  # default fetch_connect_timeout_s
+
+    def test_cross_hop_deadline_exceeded_aborts_before_next_hop(self):
+        # First hop resolves within budget and redirects; by the time the
+        # second hop would fire, the shared deadline has less than 1s left
+        # -- it must abort there instead of issuing another curl call.
+        with mock.patch("harvest.time.monotonic", side_effect=[0.0, 0.0, 4.5]), \
+             mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(302, location="/next")) as m:
+            result, reason = self._fetch("https://a.com/start", timeout=5)
+        self.assertIsNone(result)
+        self.assertIn("deadline exceeded", reason)
+        m.assert_called_once()
+
+    def test_unmigrated_config_missing_new_limit_keys_still_works(self):
+        # A config predating this change has none of the 3 new limits keys.
+        # .get()+default must keep curl-cffi working rather than KeyError
+        # -> swallowed by call_fetch_backend's broad except into a silent,
+        # permanent "unexpected error".
+        cfg = base_config()
+        cfg["limits"] = {k: v for k, v in cfg["limits"].items()
+                          if k not in ("fetch_connect_timeout_s", "fetch_low_speed_bytes_s",
+                                       "fetch_low_speed_window_s")}
+        with mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(200, "<p>legacy ok</p>")):
+            result, reason = self._fetch("https://a.com/x", config=cfg)
+        self.assertIsNone(reason)
+        self.assertIn("legacy ok", result)
+
 
 class TestCurlCffiStartupCheck(unittest.TestCase):
     """_check_curl_cffi_available() is the fail-fast gate: if the backend is
@@ -1398,6 +1451,90 @@ class TestCurlCffiStartupCheck(unittest.TestCase):
         harvest._HAS_CURL_CFFI = False
         cfg = base_config(fetch_backends=[{"type": "urllib-ua"}])
         harvest._check_curl_cffi_available(cfg)  # must not raise
+
+
+class TestCallFetchBackendPerBackendTimeout(unittest.TestCase):
+    """call_fetch_backend must read a per-backend `timeout_s` override before
+    falling back to the shared call_timeout_s -- raw fetch (curl-cffi/
+    urllib-ua) should be capped fast, while server-side renderers (jina/
+    tavily) get more slack, without a one-size-fits-all timeout misjudging
+    either."""
+
+    def test_backend_with_timeout_s_uses_its_own_value(self):
+        cfg = base_config()
+        with mock.patch("harvest._fetch_curl_cffi", return_value=("text", None)) as m:
+            harvest.call_fetch_backend({"type": "curl-cffi", "timeout_s": 25},
+                                        harvest.RateLimiter(0), "https://a.com/x", cfg)
+        self.assertEqual(m.call_args.args[2], 25)
+
+    def test_jina_backend_with_timeout_s_uses_its_own_value(self):
+        cfg = base_config()
+        with mock.patch("harvest._fetch_jina_reader", return_value=("text", None)) as m:
+            harvest.call_fetch_backend({"type": "jina-reader", "timeout_s": 60},
+                                        harvest.RateLimiter(0), "https://a.com/x", cfg)
+        self.assertEqual(m.call_args.args[2], 60)
+
+    def test_backend_without_timeout_s_falls_back_to_call_timeout_s(self):
+        cfg = base_config()  # call_timeout_s: 5, from base_config()
+        with mock.patch("harvest._fetch_urllib_ua", return_value=("text", None)) as m:
+            harvest.call_fetch_backend({"type": "urllib-ua"},
+                                        harvest.RateLimiter(0), "https://a.com/x", cfg)
+        self.assertEqual(m.call_args.args[2], cfg["limits"]["call_timeout_s"])
+
+
+class TestFetchBackendsRealConfigChain(unittest.TestCase):
+    """The shipped harvest.config.json is the actual chain used in
+    production -- assert its shape directly so a future edit to the file
+    can't silently break the curl-cffi -> jina-reader fallback order or
+    drop the per-backend timeout_s fields these tests exercise elsewhere."""
+
+    def setUp(self):
+        config_path = Path(__file__).resolve().parent.parent / "scripts" / "harvest.config.json"
+        self.config = harvest.load_config(config_path)
+
+    def test_jina_reader_is_first_fallback_after_curl_cffi(self):
+        types = [b["type"] for b in self.config["fetch_backends"]]
+        self.assertEqual(types[0], "curl-cffi")
+        self.assertEqual(types[1], "jina-reader")
+
+    def test_all_backends_declare_timeout_s(self):
+        for backend in self.config["fetch_backends"]:
+            self.assertIn("timeout_s", backend, backend["type"])
+
+    def test_raw_fetch_backends_capped_shorter_than_server_side_renderers(self):
+        by_type = {b["type"]: b["timeout_s"] for b in self.config["fetch_backends"]}
+        self.assertLess(by_type["curl-cffi"], by_type["jina-reader"])
+        self.assertLess(by_type["urllib-ua"], by_type["tavily-extract"])
+
+    def test_new_low_speed_limits_present_with_expected_defaults(self):
+        limits = self.config["limits"]
+        self.assertEqual(limits["fetch_connect_timeout_s"], 5)
+        self.assertEqual(limits["fetch_low_speed_bytes_s"], 512)
+        self.assertEqual(limits["fetch_low_speed_window_s"], 10)
+        self.assertEqual(limits["call_timeout_s"], 180)  # unchanged, still used by LLM/search calls
+
+
+class TestJinaReaderAuthHeader(unittest.TestCase):
+    """_fetch_jina_reader's Authorization header must track JINA_API_KEY
+    presence/absence -- guards against a regression when the fetch chain
+    reorder (variant 2) promotes jina to the first fallback slot."""
+
+    def _fetch(self, env):
+        with mock.patch.dict(os.environ, env, clear=False), \
+             mock.patch("harvest.urllib.request.urlopen",
+                         return_value=FakeHTTPResponse(b"page text")) as m:
+            harvest._fetch_jina_reader({"api_key_env": "JINA_API_KEY"}, "https://a.com/x", 5, 20000)
+        return m.call_args.args[0]
+
+    def test_authorization_header_present_when_key_set(self):
+        req = self._fetch({"JINA_API_KEY": "secret-key"})
+        self.assertEqual(req.headers.get("Authorization"), "Bearer secret-key")
+
+    def test_authorization_header_absent_when_key_unset(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JINA_API_KEY", None)
+            req = self._fetch({})
+        self.assertNotIn("Authorization", req.headers)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -1393,6 +1393,22 @@ class TestCurlCffiFetch(unittest.TestCase):
         self.assertAlmostEqual(conn + read, 20, places=3)
         self.assertEqual(conn, 5)  # default fetch_connect_timeout_s
 
+    def test_timeout_tuple_small_budget_selects_remaining_minus_epsilon(self):
+        # When remaining < fetch_connect_timeout_s (here remaining=2 vs the
+        # default connect cap of 5), `min(connect_timeout_s, remaining-0.1)`
+        # must pick the second operand -- conn = remaining - 0.1, read =
+        # 0.1. This locks down the epsilon fallback so it can't be
+        # "simplified" to conn = remaining (which would zero out the read
+        # component and reintroduce the libcurl 0ms-means-infinite hang).
+        with mock.patch("harvest.time.monotonic", side_effect=[0.0, 0.0]), \
+             mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(200, "<p>ok</p>")) as m:
+            self._fetch("https://a.com/x", timeout=2)
+        conn, read = m.call_args.kwargs["timeout"]
+        self.assertAlmostEqual(conn, 1.9, places=3)
+        self.assertAlmostEqual(read, 0.1, places=3)
+        self.assertAlmostEqual(conn + read, 2, places=3)
+
     def test_cross_hop_deadline_exceeded_aborts_before_next_hop(self):
         # First hop resolves within budget and redirects; by the time the
         # second hop would fire, the shared deadline has less than 1s left


### PR DESCRIPTION
## Summary

- `_fetch_curl_cffi` 新增跨跳 deadline（单 URL 总预算,而非每跳都用完整 timeout）+ curl 原生 `LOW_SPEED_LIMIT`/`LOW_SPEED_TIME`，主动中断持续低速连接（tarpit/慢速拖延防御），不再只靠总超时硬顶。
- tuple timeout 语义修正：curl_cffi 0.15.0 对 `(connect, read)` 求和进 `CURLOPT_TIMEOUT_MS`，故 read 分量 = `remaining - connect`，避免单跳总上限超预算。
- `fetch_backends` 重排为 `curl-cffi → jina-reader → tavily-extract → urllib-ua`：jina 在服务端完成抓取渲染，对反爬天然有韧性且无 key 也能用，比原排在其后的付费 tavily-extract 更适合做 curl-cffi 的直接兜底。
- per-backend `timeout_s`：raw fetch（curl-cffi/urllib-ua）25s，服务端渲染型（jina/tavily）60s，不再用单一超时一刀切。
- 3 个新 `limits` 键与 per-backend `timeout_s` 一律 `.get()+默认值` 读取，存量 config 缺键不会 KeyError（避免被宽 catch 吞成永久 unexpected error，导致 curl-cffi 静默失效）。
- G0 采集模式决策段落补一条：Lead 检测 `JINA_API_KEY` 是否配置，未配置时非阻塞提示（走免费限流档，速率较低），不 gate、不阻塞管线。
- 版本号 1.5.1 → 1.5.2（`plugin.json` + `marketplace.json` 双同步）。

## Test plan

- [x] `python3 -m unittest tests.test_harvest`：296 tests, OK（原 282 + 新增 14）
- [x] 新增测试覆盖：low-speed curl_options 值、tuple timeout 求和语义（含小预算边界分支：`remaining < connect_timeout_s` 时 `min()` 选中 `remaining-0.1`）、跨跳 deadline 中止、**向后兼容回归**（缺 3 个新 limits 键的未迁移 config 仍可正常 fetch）、per-backend timeout 分发（curl-cffi/jina 各自取值，缺省回退 `call_timeout_s`）、真实 `harvest.config.json` 的 fetch_backends 链序与超时值、jina `Authorization` 头随 key 有无而增减
- [x] `harvest.config.json` / `marketplace.json` JSON 语法校验通过
- [x] curl_cffi 0.15.0 实机验证 tuple timeout 求和语义（源码 `requests/utils.py` L546-549）与实现一致