### PR TITLE
feat(deep-research): 主 session 成本根治 — 绝对规则+生成卸载+reviewer scoped-Write (v1.7.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/agents/research-analyst.md
+++ b/plugins/deep-research/agents/research-analyst.md
@@ -24,7 +24,10 @@ color: blue
 |------|------|------|
 | 脱敏后数据 | `pipeline/2_cleaned/` | **只读** |
 | 域拆解产物（Synthesis 阶段） | `pipeline/3_structured/` | 只读（自己写的也不改） |
-| Lead 的分析指令 | Task prompt | — |
+| 自己第一轮草稿（Synthesis 第二轮） | `deliverables/draft/` | 读（第二轮改稿基准，不重读 3_structured） |
+| 洞察提取产物（Stage 7 生成） | `pipeline/4_extracted/` | 只读 |
+| 已交付结论（Stage 8 Landing） | `deliverables/final/` | 读（回填对照基准） |
+| Lead 的分析指令 / manifest 修正 / report-spec / delta 对比指令 | Task prompt | — |
 
 **铁律**：禁止读 `pipeline/1_raw/`，禁止修改 `pipeline/2_cleaned/`。
 
@@ -35,6 +38,10 @@ color: blue
 | 域拆解文件 | `pipeline/3_structured/` | Decomposition |
 | 洞察提取文件 | `pipeline/4_extracted/` | Synthesis |
 | deliverables 草稿 | `deliverables/draft/` | Synthesis |
+| report.md / executive_summary.md | `deliverables/final/` | Delivery（Stage 7 生成） |
+| landing 回填文档 / Correction Record / 补轨 handoff | `deliverables/final/` | Landing（Stage 8, experimental） |
+
+**回传纪律（绝对规则）**：回传 Lead 的一律是结构化 manifest/receipt（synthesis-manifest / `{落盘路径, 机械门 receipt}` / delta receipt），**永不回传生成内容或草稿全文**——全文落盘，Lead 按指针需要时派 subagent 读。
 
 ## 工作模式
 
@@ -58,16 +65,44 @@ color: blue
 
 跨域整合，提取洞察，产出报告草稿。
 
-**执行步骤**：
-1. 读取 `pipeline/3_structured/` 全部域文件
+**绝对规则约束**：Lead 禁读 `pipeline/3_structured`/`2_cleaned` 全文（见 pipeline.md「Stage 间契约」第 8 条）。Synthesis 分两轮执行，回传 Lead 的是 **synthesis-manifest**（几百 token），**不是**草稿全文——草稿落在盘上，Lead 只据 manifest 裁决。
+
+**第一轮执行步骤**：
+1. 读取 `pipeline/3_structured/` 全部域文件（+ 需要时 `2_cleaned/` 只读）
 2. 识别跨域模式、趋势和矛盾
 3. 生成洞察报告到 `pipeline/4_extracted/`
-4. 按报告模板产出 deliverables 草稿
+4. 按报告模板产出**完整** deliverables 草稿，落盘 `deliverables/draft/v{N}/`
+5. **回传 Lead 一份 synthesis-manifest**，每条洞察 = `{claim_id, 一句话结论, 支撑文件路径+行号指针, 冲突/取舍待决项}`（schema 见 pipeline.md「manifest / receipt / spec 产物定义」）。只回传 manifest，不回传草稿全文。
 
-**Synthesis 中 Lead 的角色**：
-- Lead 参与不可委托的连贯思考（如战略判断、跨域因果推理）
-- analyst 负责事实整理和初步分析
-- 最终综合结论由 Lead 在主上下文中确认
+**Lead 裁决**（主上下文，不读全文）：Lead 只读 manifest，在此基础上做不可委托的连贯思考和战略判断（战略取舍、跨域因果、冲突裁定），产出**定向修正指令**回传 analyst。
+
+**第二轮执行步骤**：
+1. **只读自己第一轮的 draft 草稿 + Lead 的定向修正指令**——**不重读** `pipeline/3_structured/`（消灭重读，这是替代 teammate 跨阶段保温的机制：第二轮作用在已蒸馏的小草稿上，不回溯大源头）
+2. 据修正指令改稿，更新 `deliverables/draft/` 与 `pipeline/4_extracted/`
+3. 回传 Lead 修订后的 manifest（仍不含全文）
+
+> **为何两轮不重读**：庞大的 3_structured 全文只在第一轮穿过 analyst 一次；第二轮的修正作用在第一轮已写下的草稿上。这样既保留 Lead 不可委托的连贯裁决（作用在 manifest 上），又杜绝把大源头反复读进上下文。
+
+### 模式 3: Stage 7 report 生成（Delivery writer）
+
+绝对规则下 Lead 不亲自落盘 `deliverables/final/` 文档。Stage 7 定稿生成由 analyst 承接：
+
+**执行步骤**：
+1. 接收 Lead 的 **report-spec**（`{报告大纲, 每节裁决要点, 引用指针}`，schema 见 pipeline.md）
+2. 按 spec + 盘上 `pipeline/4_extracted/`（只读）渲染 `deliverables/final/report.md`、`executive_summary.md`（及按需的 references.md / INDEX.md）
+3. 回传 Lead `{落盘路径, 机械门 receipt}`，**不回传生成内容全文**
+
+> report.html 仍归 research-publisher 生成（VIEW 层派生），analyst 只产 `.md` 终稿，不碰 HTML。生成落盘后 Lead 会 spawn 轻量 reviewer 做 no-new-facts 语义核验（见 pipeline.md Stage 7）。
+
+### 模式 4: Stage 8 Landing（experimental，落地回填执行者）
+
+> ⚠ **EXPERIMENTAL**：Stage 8 待 ≥1 真实项目验证后转 stable（见 #11）。归属复用 analyst——已具 Write、已读 deliverables 语义，landing 是「读 final + 落地反馈 → 产 delta 对比」的分析活，性质同 Synthesis。
+
+**执行步骤**：
+1. 接收 Lead 的 **delta 对比指令**（落地实测反馈 + 需对照的已交付结论）
+2. 读 `deliverables/final/` + 落地反馈，逐条对照「设计预期 vs 落地实际」，按四分类（①被验证正确 / ②被推翻 / ③暴露留白 / ④正向 emergent）归类
+3. 落盘 landing 回填文档（五段结构，见 `landing-feedback.md.tmpl`）到 `deliverables/final/`（追加不覆盖）；②被推翻走 Correction Record、③暴露留白注册补轨 handoff，均由 analyst 落盘
+4. 回传 Lead 一份 **delta receipt**（`{delta 四分类标签, 每 delta 一句话结论, 支撑指针, 触发的下游动作, 落盘路径}`，schema 见 pipeline.md）。Lead 只据 receipt 做四分类分流裁决，不亲读回填文档全文。
 
 ## 写作规范
 

--- a/plugins/deep-research/agents/research-publisher.md
+++ b/plugins/deep-research/agents/research-publisher.md
@@ -88,7 +88,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/verify_report_html.py <项目 deliverables
 
 三态 exit code：`0`=PASS（自包含 + 链接/章节守恒）/ `1`=FAIL（打印缺失清单，须修正后复渲）/ `2`=N/A（report.html 尚不存在）。
 
-**能力边界（如实声明，不夸大）**：机械门只覆盖**结构性丢失**——链接是否守恒、章节是否守恒、有无违规外部资源引用。它不能校验**语义性捏造**（凭空新增事实、扭曲原文含义），这部分由 Lead 的视觉核验兜底。verify 脚本 PASS 不等于内容零新事实，publisher 自己在渲染时就要守住这条线。
+**能力边界（如实声明，不夸大）**：机械门只覆盖**结构性丢失**——链接是否守恒、章节是否守恒、有无违规外部资源引用。它不能校验**语义性捏造**（凭空新增事实、扭曲原文含义）。绝对规则下 Lead 不再亲读 report.html/report.md 全文，语义核验由 Lead 在生成落盘后 spawn 的轻量 reviewer（mode=review）承担，回传 verdict receipt（见 pipeline.md Stage 7）——这替代了原「Lead 视觉核验兜底」在绝对规则下断裂的安全网。verify 脚本 PASS 不等于内容零新事实，publisher 自己在渲染时就要守住这条线。
 
 ## 主题选择
 

--- a/plugins/deep-research/agents/research-reviewer.md
+++ b/plugins/deep-research/agents/research-reviewer.md
@@ -8,7 +8,7 @@ description: |
   典型触发场景：Acquisition+Sanitization 完成后的 G1 评估、Decomposition
   完成后的 G2 评估、Synthesis 完成后的 G3 评估（含假设审计与证伪审计）、
   Stage 6 对最终产物的对抗审阅。不负责 G0 需求门（由 Lead 与用户对齐）。
-tools: Read, Grep
+tools: Read, Grep, Write
 model: opus
 color: yellow
 ---
@@ -34,6 +34,26 @@ color: yellow
 
 **输入**：`pipeline/4_extracted/` + deliverables 草稿 + playbook 约束
 **输出**：审阅报告（verdict + 维度评分 + 问题清单 + 修改建议）
+
+## 产物落盘
+
+reviewer 拿到 Write 权限只为一件事：让审阅内容不必穿过 Lead 主上下文（见
+`docs/adr-main-session-cost-fix.md` 绝对规则）。两种 mode 产出的审阅报告
+（Gate 评分报告 / 5 维度审阅报告）**必须写入磁盘**，路径与命名：
+
+- 目录：项目根下 `pipeline/verification/`（固定，唯一合法落盘目录）
+- 命名：带时间戳，只新建不覆盖——`YYYYMMDD_HHMMSS_G{N}-verdict.md`（mode=sufficiency）
+  / `YYYYMMDD_HHMMSS_stage6-validation.md`（mode=review）
+- 同一产物多轮审阅（对抗审阅的重审）各自新建一份，不覆盖前一轮，保留完整
+  审阅历史供追溯
+
+**铁律**：reviewer 只写 `verification/`，禁止写入其他任何目录（编号目录
+`1_raw`~`4_extracted`、`deliverables/`、`research-goal.md` 等一律禁写）。
+reviewer 是评估者不是生产者，写权限是 receipt 通道的必要开销，不是产出物
+写入权。
+
+审阅报告**全文只落盘**，不作为回传内容。回传 Lead 的只有下一节定义的
+receipt。
 
 ## Sufficiency Gate 触发点
 
@@ -104,13 +124,17 @@ color: yellow
 
 ## 对抗审阅流程
 
-1. reviewer 产出审阅报告
-2. 原作者（harvester/analyst）修订产物，可附辩护理由
+1. reviewer 产出审阅报告，落盘 `pipeline/verification/`，回传 Lead 一份
+   receipt（含报告路径）
+2. Lead 把 receipt 里的报告路径转给原作者（harvester/analyst）；原作者按
+   路径自行读取报告全文（不再依赖 Lead 转发全文——Lead 手上本就没有全文），
+   修订产物，可附辩护理由
 3. reviewer **必须**回应辩护内容：
    - 辩护成立 → 撤回该条意见
    - 辩护不成立 → 说明理由，维持意见
    - 部分成立 → 调整意见严重度
 4. 不回应辩护直接维持原判 → 违规（Lead 可介入）
+5. 重审产出新报告（新时间戳文件，不覆盖上一轮），回传新 receipt
 
 ## 审阅报告格式
 
@@ -134,6 +158,77 @@ color: yellow
 ### revision_count: {N}/3
 ```
 
+## 回传 Lead 的 receipt 契约
+
+审阅报告（Gate 评分报告 / 5 维度审阅报告）**全文只落盘**在
+`pipeline/verification/`（见「产物落盘」）。**回传 Lead 的只有 receipt**——
+结构化摘要，永不含报告全文。这是绝对规则「主 session 禁读 pipeline 全文」
+成立的前提：Lead 不读盘，只能靠 receipt 里的字段做裁决和驱动下一轮修正
+（详见 `docs/adr-main-session-cost-fix.md` 契约②）。
+
+receipt 必须包含以下字段，两种 mode 共用同一套结构，marker/verdict 标签
+按各自 mode 的既有格式：
+
+1. **裁决标记**（两种 mode 格式不同，缺一不可）：
+   - mode=sufficiency：`GATE_VERDICT: G{N} PASS|FAIL|RECYCLE` 独立成行、
+     原样输出，行内不得有任何尾随内容（含标点、括注）。这一行是
+     `gate_check.py`（`GATE_PASS_RE`）G1 引用校验机械门的触发锚——格式
+     必须与其正则逐字匹配，否则机械门失效、G1 补采检查静默跳过：
+     ```
+     GATE_VERDICT: G{N} PASS
+     ```
+     （G2/G3 同一格式，仅 G1 触发机械门，但格式统一不因不触发而放松）
+   - mode=review（Stage 6）：沿用既有 `<verdict>APPROVED|NEEDS REVISION|REJECTED</verdict>`
+     XML 标签，首行输出。gate_check.py 不监听此标签，Stage 6 不触发机械门，
+     但 receipt 结构与 FAIL 分支字段要求同样适用。
+2. **项目路径**：`projects/xxx/...`，与 `gate_check.py` 的 `PROJECT_PATH_RE`
+   同构，供 Lead/机械门定位项目。
+3. **verdict**：明文写出 `PASS / FAIL / RECYCLE`（mode=sufficiency）或
+   `APPROVED / NEEDS REVISION / REJECTED`（mode=review），与标记行/标签一致，
+   不矛盾。
+4. **维度评分表**：各维度分数 + 一句话说明（紧凑版，非报告原表格的展开版）。
+5. **报告路径**：审阅报告在 `pipeline/verification/` 下的完整落盘路径。
+   Lead 需要报告细节时，据此路径 spawn 一个 subagent 去读，Lead 自己不读。
+6. **FAIL 分支硬性字段**（verdict ≠ PASS/APPROVED 时必须携带，缺失即违规）：
+   - 问题/幻觉原文摘录
+   - 所在文件 + 段落指针（`pipeline/.../file.md` 第几节/第几段）
+   - 错误原因
+   - 达标所需具体改进
+
+   这四项不是锦上添花——**Lead 已被绝对规则物理禁读 pipeline 全文**，纠错
+   全靠 receipt 携带的定位信息驱动下一轮修正。verdict 字段本身只是一个
+   标签，干瘪的 verdict（只有 PASS/FAIL 三个字）会直接断掉纠错链：原作者
+   收不到具体问题定位，只能瞎猜重做。
+
+### receipt 示例（mode=sufficiency，FAIL 分支）
+
+```
+GATE_VERDICT: G1 FAIL
+projects/xxx-research/
+verdict: FAIL
+维度评分：覆盖度 2（一票否决）、时效性 4、可信度 3、双语平衡 3
+报告路径：pipeline/verification/20260707_153000_G1-verdict.md
+问题摘录："某产品 2024 年市占率达 47%"
+定位：pipeline/2_cleaned/source-07.md 第 3 段
+错误原因：原始来源未给出该数字，为综合推断，未标注置信度
+改进要求：补搜该市占率数据的一次来源，或删除该论断改为定性描述
+```
+
+### receipt 示例（mode=review，NEEDS REVISION 分支）
+
+```
+<verdict>NEEDS REVISION</verdict>
+projects/xxx-research/
+verdict: NEEDS REVISION
+维度评分：准确性 3、完整性 4、逻辑性 4、可操作性 3、可追溯性 2
+报告路径：pipeline/verification/20260707_161500_stage6-validation.md
+问题摘录："建议 A 与建议 B 相互矛盾（见结论第2节 vs 第4节）"
+定位：deliverables/draft/report.md 结论第2节 / 第4节
+错误原因：综合阶段未做交叉一致性检查，两条建议基于不同前提
+改进要求：明确两条建议的适用场景边界，或合并为条件分支表述
+```
+
 ---
 
 **关联文件**：deep-research skill 的 references/quality-gates.md · references/pipeline.md（Stages 6 + G1/G2/G3）
+· `docs/adr-main-session-cost-fix.md`（契约② receipt schema 唯一事实源）

--- a/plugins/deep-research/docs/adr-main-session-cost-fix.md
+++ b/plugins/deep-research/docs/adr-main-session-cost-fix.md
@@ -50,7 +50,8 @@ research 仓 #36/#37 两次实测坐实：deep-research 7-Stage 调研中，**�
   - Read 分支：`tool_input.file_path` 命中 → 拦截。
   - Bash 分支：命令解析出读取意图（`cat|head|tail|less|more|sed|awk`，及 `grep ""` 全量读、`echo "$(<file)"`）且目标指向受管路径 → 拦截。
 - **白名单放行**（小指针文件，主 session 合法持有）：文件名匹配 `research-goal.md`、`*-manifest.*`、`*-receipt.*`、`INDEX.md`、`*.verdict`、`*-verdict.md`；或文件体积 < 阈值（建议 8KB，指针/receipt 量级）。
-- **fail-open 硬约束**（任一成立即放行，never break userspace）：非 deep-research 项目（查不到 pipeline/）、拿不到 `agent_id`、路径解析异常、Bash 命令解析不出明确读大文件意图（不误伤 grep 检索/ls/find/git）。
+- **fail-open 硬约束**（任一成立即放行，never break userspace）：非 deep-research 项目（查不到 pipeline/）、目标非受管路径、命中白名单、路径解析异常、Bash 命令解析不出明确读大文件意图（不误伤 grep 检索/ls/find/git）。**fail-open 落在项目/路径/白名单层，不在 agent_id 层**。
+- **agent_id 语义**（对齐 `pre-edit-write.sh` 的 `.agent_id // ""`）：非空＝subagent→放行；空/None/缺失＝主 session→走路径判定。**不能**把「agent_id 缺失」当技术不确定去 fail-open——主 session 的 PreToolUse 事件本就携带空/缺失 agent_id，若对 None 放行则主 session 永远绕过门禁、绝对规则失效。误判风险的兜底是路径层（即便某 subagent 的 agent_id 丢失被当成主 session，也只在「研究项目内+受管路径+大文件」才拦，带明确 stderr 指引，代价远小于主 session 整体绕过）。
 - **拦截 stderr 指导语**（强制，防盲目重试）：
   ```
   [read_guard] Action blocked: Lead 主 session 禁读 pipeline/deliverables 全文（绝对规则，见 adr-main-session-cost-fix）。

--- a/plugins/deep-research/docs/adr-main-session-cost-fix.md
+++ b/plugins/deep-research/docs/adr-main-session-cost-fix.md
@@ -1,0 +1,111 @@
+# ADR: 主 session 成本根治 — 绝对规则 + 生成卸载 + reviewer scoped-Write
+
+**状态**：Accepted（Step 0 契约冻结，供后续实现步骤引用）
+**日期**：2026-07-07
+**关联**：research 仓 #36/#37（成本复盘 n=2）、#38（承接方案，C 段单列）
+
+---
+
+## 背景与纠偏
+
+research 仓 #36/#37 两次实测坐实：deep-research 7-Stage 调研中，**主 session（Lead，全程 opus）独占 ~90% 成本**（$379/$422、$217/$242）。
+
+按 opus list price 拆解主 session 账单（#36 数据：input 1940万 / cache_read 1386万 / cache_write 287万 / output 10万）：
+
+| 项 | token | 单价 | 金额 | 占比 |
+|---|--:|--:|--:|--:|
+| **uncached input** | 1940万 | $15/M | **$291** | **78%** |
+| cache_write | 287万 | $18.75/M | $54 | 14% |
+| cache_read | 1386万 | $1.5/M | $21 | 6% |
+| output | 10万 | $75/M | $7.5 | 2% |
+
+**关键纠偏**：成本核心是 **uncached input（$291/78%）**，不是 cache_read（$21/6%）。根因＝**全文穿过主上下文按全价计 input**。#38-C 原归因「cache_read 雪球」归错方向。1h cache 是补丁（只保温已缓存的，管不到全文第一次穿过上下文；且被本方案架构解法抽掉），**已砍除**。
+
+## 决策
+
+### 唯一绝对规则
+
+> **主 session（`agent_id` 为空）对 `pipeline/**` 和 `deliverables/**` 下的文件，只允许持有路径指针，禁止读取其内容（Read 工具 + Bash cat 类读取）。所有内容读取 / 生成 / 审阅由 subagent 在隔离上下文完成，回传 Lead 的只有 receipt（路径 + 结构化裁决摘要），永不含全文。**
+
+绝对规则 > 软规则：消除所有「这次就读一下」的边界情况。物理焊死靠 PreToolUse hook 按 `agent_id` 空/非空区分主/子（`pre-edit-write.sh` 已验证此机制）。
+
+### 为何不用 teammates 分阶段持有上下文
+
+- Claude prompt cache 仅 5min TTL：停泊的 teammate 回访即全价重载，不省钱；且它自己变成新雪球。
+- teammate 核心价值＝保留跨阶段隐性上下文，**恰好捅穿框架反偏见护栏**（reviewer 与主 session 共享偏见会重演病灶，principles 元原则 0）。
+- pipeline 是 DAG 单向漏斗，无「同一大 blob 反复重读」模式，无状态磁盘传递天生最优。
+
+### 为何 reviewer 必须加 Write（非可选）
+
+纯 Task 模型下 subagent 输出只能回 spawner（Lead）。reviewer 只读→审阅报告靠回传→内容穿过 Lead（正是要消灭的）。**内容不经 Lead 的唯一 inter-agent 通道是磁盘 → 产出者必须能落盘 → reviewer 必须 Write。** 作用域锁 `verification/`（非编号目录、gate 裁决既有归宿），不违反 pipeline 不可变。
+
+---
+
+## 冻结契约（Step 0 交付，实现步骤逐字对齐，唯一事实源）
+
+### 契约① read_guard 判定规格（Step 1 实现）
+
+- **触发**：PreToolUse，matcher `Read` 与 `Bash`。
+- **拦截条件**（全部满足）：`agent_id` 为空（主 session）AND 项目已启用 deep-research（向上查到 `pipeline/` 目录）AND 目标命中 `pipeline/**` 或 `deliverables/**` 下非白名单文件。
+  - Read 分支：`tool_input.file_path` 命中 → 拦截。
+  - Bash 分支：命令解析出读取意图（`cat|head|tail|less|more|sed|awk`，及 `grep ""` 全量读、`echo "$(<file)"`）且目标指向受管路径 → 拦截。
+- **白名单放行**（小指针文件，主 session 合法持有）：文件名匹配 `research-goal.md`、`*-manifest.*`、`*-receipt.*`、`INDEX.md`、`*.verdict`、`*-verdict.md`；或文件体积 < 阈值（建议 8KB，指针/receipt 量级）。
+- **fail-open 硬约束**（任一成立即放行，never break userspace）：非 deep-research 项目（查不到 pipeline/）、拿不到 `agent_id`、路径解析异常、Bash 命令解析不出明确读大文件意图（不误伤 grep 检索/ls/find/git）。
+- **拦截 stderr 指导语**（强制，防盲目重试）：
+  ```
+  [read_guard] Action blocked: Lead 主 session 禁读 pipeline/deliverables 全文（绝对规则，见 adr-main-session-cost-fix）。
+  你必须 spawn 一个 subagent 读该文件并回传结构化 receipt（含所需字段），而不是重试本次读取。
+  Blocked path: <path>
+  ```
+  参照 `gate_check.py` block 带 reason 的既有范式。
+- **威胁模型分层（诚实分级，不 overclaim）**：Read 工具＝硬拦截（物理焊死，Lead 读文件默认主路径）；Bash＝尽力护栏（拦意外/习惯性读取模式，非对抗性沙盒——Lead 是协作方非攻击者，无动机 `python -c open().read()` 越狱）；根因层＝receipt 已含所需一切，消除「非读不可」场景。**不做 chmod/容器级隔离**（会同时禁掉同 UID 的 subagent，且对协作威胁模型是过度工程）。
+
+### 契约② receipt schema（Step 2 实现，reviewer 回传）
+
+所有 Gate/Validation reviewer 回传 Lead 的 receipt，永不含审阅报告全文，字段如下：
+
+- `GATE_VERDICT: G{N} PASS|FAIL|RECYCLE`（**独立成行、原样文本**，风险1 硬约束——`gate_check.py` 靠此行触发 G1 引用校验机械门；行内不得有尾随内容，见 test_gate_check 既有断言）
+- `projects/xxx/...` 项目路径（`gate_check.py` PROJECT_PATH_RE 靠此定位项目）
+- `verdict`：APPROVED | NEEDS REVISION | REJECTED（mode=review）/ PASS | FAIL | RECYCLE（mode=sufficiency）
+- `维度评分表`：各维度分数 + 一句话
+- `报告路径`：落盘的完整审阅报告在 `pipeline/verification/` 的路径（Lead 需细节时派 subagent 按此路径读）
+- **FAIL 分支硬性字段（风险2、red team R3#2，最关键）**：verdict≠PASS/APPROVED 时，receipt **必须**含 `{问题/幻觉原文摘录, 所在文件+段落指针, 错误原因, 达标所需具体改进}`——Lead 已物理禁读全文，纠错全靠 receipt 携带的定位信息驱动下一轮修正；干瘪 verdict 会断掉纠错链。
+
+### 契约③ manifest / spec schema（Step 4/5 实现）
+
+- **synthesis-manifest**（analyst Synthesis 第一轮回传 Lead）：每条洞察 = `{claim_id, 一句话结论, 支撑文件路径+行号指针, 冲突/取舍待决项}`。几百 token。第一轮同时产出完整草稿落盘 `deliverables/draft/`。Lead 裁决作用在 manifest 上，产出决策指令。**第二轮 analyst 只读自己草稿 + Lead 定向修正，不重读 `3_structured`**（消灭重读，替代 teammate 保温）。
+- **report-spec**（Lead → Stage7 writer=analyst）：`{report 大纲, 每节裁决要点, 引用指针}`。全在主上下文，不含 4_extracted 全文。writer 按 spec + 盘上 `4_extracted` 渲染 `deliverables/final/report.md`、`executive_summary.md`，回传 `{路径, 机械门 receipt}`。
+
+### 契约④ landing delta receipt schema + 执行者归属（Step 5b 实现）
+
+- **归属拍板：复用 analyst**（已具 Write、已读 deliverables 语义；landing 是「读 final + 落地反馈 → 产 delta 对比」的分析活，性质同 Synthesis）。**不新增角色**。
+- **delta receipt schema**：`{delta 四分类标签(①被验证正确/②被推翻/③暴露留白/④正向emergent), 每 delta 一句话结论, 支撑指针, 触发的下游动作(Correction Record/补轨 handoff/无), 落盘路径}`。Correction Record/补轨 handoff 由 analyst 落盘，Lead 只持 receipt 做四分类分流。
+
+### 契约⑤ 绝对规则条款 + Stage 契约最终措辞（Step 3 落进 4 份 reference）
+
+Step 3 把以下措辞落进 reference/skill，逐处消除自相矛盾软条款（风险5 清单）：
+
+- **context-economics.md:29**「deliverables 最终整合→主上下文」→ 改为「Lead 出 spec，生成/整合由 subagent 执行，Lead 只持 receipt」。新增「Task 隔离 vs 主上下文」表顶部绝对规则条款。
+- **pipeline.md:99**（Synthesis 输入 3_structured 全文）→ 改为 analyst 读全文、回传 manifest；Lead 裁 manifest 不读全文。
+- **pipeline.md:129**（Stage7 执行者 Lead）→ 改为 Lead 出 spec、analyst 生成 final、reviewer 语义核验（风险2）。
+- **pipeline.md:139**（Stage8 执行者 Lead）→ 改为 analyst subagent（契约④）。
+- **principles.md:46**（4_extracted「analyst + Lead 写入」）→ 删「+ Lead」，Lead 不写 pipeline。
+- **SKILL.md:42**（Stage7 主体 Lead 主上下文执行）→ 对齐 spec/生成卸载。
+- 新增 manifest/receipt/spec/delta-receipt 定义章节，长在现有 PRIMARY/VIEW/派生层概念上。
+
+### 风险2 缓解落点（Step 5）
+
+Stage7 生成后，Lead spawn 轻量 reviewer（mode=review 既有能力）做 report.md/report.html 的 no-new-facts 语义核验，回传 verdict receipt（含契约② FAIL 字段）。Lead 不亲读。补上 publisher.md:91「Lead 视觉核验兜底」在绝对规则下断裂的安全网。
+
+---
+
+## 预期收益（量级估算，非承诺，BDD 实测校准）
+
+主 session uncached input 1940万→~300万量级，主 session $379→~$60-80，全局 $422→~$130-160。真实收益取决于 manifest/spec 压缩率，以 Step 6 BDD「主 session input 降 ≥60% 且 G0-G3 质量门不退化」为验收基准。
+
+## 零破坏性保证
+
+- hook 全程 fail-open（非研究项目/无 agent_id/解析失败→放行）。
+- reviewer Write 锁 `verification/`，不碰编号目录，不违反 pipeline 不可变（principles.md:52 管 1_raw→4_extracted）。
+- 存量已交付项目不受影响（规则只约束新研究运行时 Lead 行为）。
+- harvest.py `--no-api` local mode 兼容：门禁只管 Lead 读取，不改 harvester 采集路径；receipt 契约对 local/panel 两模式同构（G1 marker 不变）。

--- a/plugins/deep-research/hooks/hooks.json
+++ b/plugins/deep-research/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Deep research G1 gate: mechanically verifies GATE_VERDICT: G1 PASS claims against harvest.py's citation-verification tombstone (fail-open on any technical uncertainty, block only on a genuine business-level FAIL/UNAVAILABLE)",
+  "description": "Deep research hooks: (1) SubagentStop G1 gate — mechanically verifies GATE_VERDICT: G1 PASS claims against harvest.py's citation-verification tombstone; (2) PreToolUse read_guard — enforces the absolute rule that the Lead main session (agent_id empty) may hold only pointers to pipeline/deliverables files, never read their contents (Read + Bash cat-class). Both fail-open on any technical uncertainty (never break userspace).",
   "hooks": {
     "SubagentStop": [
       {
@@ -8,6 +8,18 @@
           {
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/gate_check.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Read|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/read_guard.py\"",
             "timeout": 10
           }
         ]

--- a/plugins/deep-research/hooks/read_guard.py
+++ b/plugins/deep-research/hooks/read_guard.py
@@ -182,8 +182,21 @@ def _extract_bash_read_targets(command: str):
 def _should_block(agent_id, tool_name, tool_input, cwd):
     """核心判定纯函数。返回 (should_block: bool, blocked_path: str|None)。
 
-    任何不确定 → (False, None)（fail-open）。
+    fail-open 保护落在**项目/路径/白名单层**（非研究项目、非受管路径、白名单文件
+    一律放行），不在 agent_id 层——这一点很关键，见下。
+
+    agent_id 语义（对齐 pre-edit-write.sh 的既有判据 `.agent_id // ""`）：
+      - **非空** → 确定是 subagent → 放行。
+      - **空字符串 / None / 缺失** → 视作主 session（Lead 的 PreToolUse 事件本就
+        携带空/缺失 agent_id）→ 继续走路径判定。**不能**把 None 当技术不确定去
+        fail-open——若那样，主 session 的事件（agent_id 恰恰为空/缺失）将永远
+        绕过门禁，绝对规则彻底失效。真正的 fail-open 由后续「非研究项目/非受管
+        路径/白名单」三道路径层放行提供：即便把某个 agent_id 丢失的 subagent 误
+        判为主 session，也只有在「研究项目内 + 受管路径 + 大文件」时才会拦，且带
+        明确 stderr 指引，代价远小于让主 session 整体绕过。
     """
+    # None / 缺失归一化为空字符串，与主 session 同路径处理（见上 docstring）。
+    agent_id = agent_id or ""
     # subagent（agent_id 非空）不受限
     if agent_id:
         return False, None

--- a/plugins/deep-research/hooks/read_guard.py
+++ b/plugins/deep-research/hooks/read_guard.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""PreToolUse(Read|Bash) hook: 主 session 绝对规则门禁。
+
+绝对规则（见 docs/adr-main-session-cost-fix.md 契约①）：主 session（agent_id
+为空）对 pipeline/** 与 deliverables/** 下的文件只能持路径指针，禁止读取内容
+（Read 工具 + Bash cat 类读取）。subagent（agent_id 非空）不受限——它们必须读
+pipeline 才能干活。
+
+威胁模型分层（诚实分级）：Read 工具＝硬拦截（Lead 读文件默认主路径）；Bash＝
+尽力护栏（拦意外/习惯性读取模式，非对抗性沙盒——Lead 是协作方非攻击者）；不做
+chmod/容器级隔离（会同时禁掉同 UID 的 subagent，且对协作威胁模型是过度工程）。
+
+fail-open 是硬约束（never break userspace）：非 deep-research 项目、拿不到
+agent_id、路径解析异常、Bash 命令解析不出明确读大文件意图——一律放行。宁可漏检
+不可误伤。判定逻辑集中在纯函数 _should_block()，便于单测；main() 只负责 IO。
+"""
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+
+# 受管路径：项目内这两个目录下的文件是主 session 禁读对象。
+_MANAGED_DIRS = ("pipeline", "deliverables")
+
+# 向上查 pipeline/ 定位项目根的层数上限（与 gate_check.py 同款，防无限上溯）。
+_MAX_WALKUP_LEVELS = 30
+
+# 小指针文件白名单：主 session 合法持有（receipt/manifest/goal/index/verdict）。
+_WHITELIST_BASENAMES = ("research-goal.md", "INDEX.md")
+_WHITELIST_PATTERNS = (
+    re.compile(r"-manifest\.[^/]+$"),
+    re.compile(r"-receipt\.[^/]+$"),
+    re.compile(r"\.verdict$"),
+    re.compile(r"-verdict\.md$"),
+)
+# 体积阈值：低于此值视为指针/receipt 量级，放行。
+_SIZE_THRESHOLD_BYTES = 8 * 1024
+
+# Bash 读取命令：命中这些且参数指向受管路径 → 拦截。
+_READ_COMMANDS = frozenset(
+    {"cat", "head", "tail", "less", "more", "sed", "awk"}
+)
+
+# stderr 指导语（拦截时输出，防协作 agent 盲目重试）。
+_BLOCK_MESSAGE = (
+    "[read_guard] Action blocked: Lead 主 session 禁读 pipeline/deliverables "
+    "全文（绝对规则，见 adr-main-session-cost-fix）。\n"
+    "你必须 spawn 一个 subagent 读该文件并回传结构化 receipt（含所需字段），"
+    "而不是重试本次读取。\n"
+    "Blocked path: {path}"
+)
+
+
+def _locate_project_root(start: Path):
+    """从 start 向上查含 pipeline/ 的祖先目录（即研究项目根）。
+
+    复用 gate_check._locate_project_dir 的核心逻辑：设层数上限，到文件系统根
+    自然停止。查不到返回 None（调用方据此 fail-open 放行——非 deep-research 项目
+    不该被门禁误伤）。
+    """
+    try:
+        node = start.resolve()
+    except OSError:
+        return None
+    for _ in range(_MAX_WALKUP_LEVELS):
+        if (node / "pipeline").is_dir():
+            return node
+        parent = node.parent
+        if parent == node:  # 文件系统根
+            break
+        node = parent
+    return None
+
+
+def _is_whitelisted(abs_path: str) -> bool:
+    """小指针文件放行判定：文件名匹配白名单，或体积低于阈值。"""
+    base = os.path.basename(abs_path)
+    if base in _WHITELIST_BASENAMES:
+        return True
+    for pat in _WHITELIST_PATTERNS:
+        if pat.search(base):
+            return True
+    # 体积检查：读不到大小（文件不存在等）不作为放行依据，交给路径判定。
+    try:
+        if os.path.getsize(abs_path) < _SIZE_THRESHOLD_BYTES:
+            return True
+    except OSError:
+        pass
+    return False
+
+
+def _under_managed_dir(abs_path: str, project_root: Path) -> bool:
+    """abs_path 是否落在 project_root 下的 pipeline/ 或 deliverables/ 内。"""
+    try:
+        real = os.path.realpath(abs_path)
+    except OSError:
+        return False
+    for d in _MANAGED_DIRS:
+        prefix = os.path.realpath(str(project_root / d)) + os.sep
+        if real.startswith(prefix):
+            return True
+    return False
+
+
+def _resolve(path: str, cwd: str) -> str:
+    """相对路径按 cwd 解析为绝对路径。"""
+    if os.path.isabs(path):
+        return path
+    return os.path.join(cwd or os.getcwd(), path)
+
+
+def _managed_target(path: str, cwd: str):
+    """给定一个候选文件路径，返回它是否受管且非白名单（即应拦截）。
+
+    返回 (should_block, abs_path)。非受管 / 白名单 / 定位不到项目 → (False, _)。
+    """
+    abs_path = _resolve(path, cwd)
+    project_root = _locate_project_root(Path(os.path.dirname(abs_path) or cwd or "."))
+    if project_root is None:
+        return False, abs_path  # 非研究项目 → fail-open
+    if not _under_managed_dir(abs_path, project_root):
+        return False, abs_path
+    if _is_whitelisted(abs_path):
+        return False, abs_path
+    return True, abs_path
+
+
+def _extract_bash_read_targets(command: str):
+    """从 Bash 命令解析出「读取大文件」意图的目标路径列表。
+
+    只认明确的读取模式，不确定一律返回空（fail-open）：
+      - cat/head/tail/less/more/sed/awk <file>
+      - grep 空 pattern 全量读（grep "" file / grep '' file）
+      - echo "$(<file)" 进程替换读取
+    grep 带真实 pattern 的检索、ls、find、git 等 → 不视为读大文件，返回空。
+    """
+    targets = []
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return targets  # 引号不闭合等 → 解析不出意图，fail-open
+    if not tokens:
+        return targets
+
+    # 处理管道/多命令：按 | && ; 粗分段，逐段判首命令。
+    segments = re.split(r"[|;]|&&|\|\|", command)
+    for seg in segments:
+        try:
+            seg_tokens = shlex.split(seg)
+        except ValueError:
+            continue
+        if not seg_tokens:
+            continue
+        cmd = os.path.basename(seg_tokens[0])
+        args = seg_tokens[1:]
+
+        if cmd in _READ_COMMANDS:
+            # 取非选项参数作为文件目标（sed/awk 首个非选项可能是脚本，保守全收——
+            # 命中受管路径才拦，误收无害路径不会拦）。
+            for a in args:
+                if a.startswith("-"):
+                    continue
+                targets.append(a)
+        elif cmd == "grep":
+            # 仅「空 pattern 全量读」视为读大文件；带 pattern 的检索放行。
+            non_opt = [a for a in args if not a.startswith("-")]
+            if non_opt and non_opt[0] == "":
+                targets.extend(non_opt[1:])
+
+    # echo "$(<file)" 或裸 "$(<file)" 进程替换读取
+    for m in re.finditer(r"\$\(\s*<\s*([^\s)]+)\s*\)", command):
+        targets.append(m.group(1))
+    for m in re.finditer(r"<\s*([^\s;|&<>]+)", command):
+        # 输入重定向 `< file`（排除 <<here-doc，已被 [^<] 挡掉部分）
+        targets.append(m.group(1))
+
+    return targets
+
+
+def _should_block(agent_id, tool_name, tool_input, cwd):
+    """核心判定纯函数。返回 (should_block: bool, blocked_path: str|None)。
+
+    任何不确定 → (False, None)（fail-open）。
+    """
+    # subagent（agent_id 非空）不受限
+    if agent_id:
+        return False, None
+
+    tool_input = tool_input or {}
+
+    if tool_name == "Read":
+        path = tool_input.get("file_path")
+        if not path:
+            return False, None
+        blocked, abs_path = _managed_target(path, cwd)
+        return (blocked, abs_path) if blocked else (False, None)
+
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        if not command:
+            return False, None
+        for target in _extract_bash_read_targets(command):
+            blocked, abs_path = _managed_target(target, cwd)
+            if blocked:
+                return True, abs_path
+        return False, None
+
+    return False, None
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+        agent_id = event.get("agent_id") or ""
+        tool_name = event.get("tool_name") or ""
+        tool_input = event.get("tool_input") or {}
+        cwd = event.get("cwd") or ""
+
+        should_block, blocked_path = _should_block(
+            agent_id, tool_name, tool_input, cwd
+        )
+        if should_block:
+            # PreToolUse 阻断：stderr 指导语 + exit 2（与 pre-edit-write.sh 同款
+            # deny 契约——exit 2 使 stderr 反馈给模型）。
+            print(_BLOCK_MESSAGE.format(path=blocked_path), file=sys.stderr)
+            sys.exit(2)
+    except SystemExit:
+        raise
+    except Exception:
+        # fail-open：技术性不确定一律放行（never break userspace）
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/deep-research/skills/deep-research/SKILL.md
+++ b/plugins/deep-research/skills/deep-research/SKILL.md
@@ -39,7 +39,7 @@ description: 结构化深度研究框架，7-Stage 管线 + 角色专业化 suba
 - **research-reviewer**：mode=sufficiency 时执行 G1/G2/G3 三道 Sufficiency Gate；mode=review 时执行 Stage 6 Validation 的 5 维度审阅。
 - **research-publisher**：Stage 7 Delivery 末端执行者，Lead 在 Delivery 定稿后 spawn 此 subagent，把 report.md 渲染成自包含 `report.html`（VIEW 层，派生自 report.md，零新事实）。model 继承 frontmatter=sonnet。
 
-G0（需求门）不派 subagent——由 Lead 在主上下文与用户对齐 primary_job/Non-Goals，这是全程唯一引入"模型外信号"的环节。Stage 7 Delivery 主体（report.md/executive_summary.md 等落盘）、Stage 8 Landing（experimental）同样由 Lead 在主上下文执行，不派 subagent；Stage 7 末端的 report.html 渲染是例外，交给 research-publisher。
+G0（需求门）不派 subagent——由 Lead 在主上下文与用户对齐 primary_job/Non-Goals，这是全程唯一引入"模型外信号"的环节。**绝对规则**：Lead（主 session）对 `pipeline/**`、`deliverables/**` 下的文件只允许持有路径指针，禁止读取其内容，物理焊死靠 PreToolUse `read_guard` hook（详见 `references/context-economics.md`）。Stage 7 Delivery 主体（report.md/executive_summary.md 等落盘）不再由 Lead 在主上下文生成——Lead 只出 report-spec（大纲+要点+引用指针），交由 research-analyst 按 spec 生成落盘，生成后再 spawn research-reviewer 做 no-new-facts 语义核验，Lead 只据 receipt 裁决；末端的 report.html 渲染交给 research-publisher。Stage 8 Landing（experimental）同理由 Lead 出对比指令、research-analyst 执行落地回填，Lead 只持 delta receipt。
 
 详细的 Task 隔离判据（何时必须隔离、何时主上下文直接做）见 `references/context-economics.md`。
 

--- a/plugins/deep-research/skills/deep-research/references/context-economics.md
+++ b/plugins/deep-research/skills/deep-research/references/context-economics.md
@@ -4,6 +4,12 @@
 
 ---
 
+## 唯一绝对规则
+
+> **主 session（`agent_id` 为空）对 `pipeline/**` 和 `deliverables/**` 下的文件，只允许持有路径指针，禁止读取其内容（Read 工具 + Bash cat 类读取）。所有内容读取 / 生成 / 审阅由 subagent 在隔离上下文完成，回传 Lead 的只有 receipt（路径 + 结构化裁决摘要），永不含全文。**
+
+绝对规则 > 软规则：消除所有「这次就读一下」的边界情况。物理焊死靠 PreToolUse `read_guard` hook 按 `agent_id` 空/非空区分主/子 session（fail-open：非 deep-research 项目/拿不到 agent_id/解析异常时放行，不误伤主 session 正常操作）。下表「Task 隔离 vs 主上下文」的划分全部服从此绝对规则——主上下文执行的场景只意味着调度/裁决在主上下文，不意味着 Lead 可读 pipeline/deliverables 全文。
+
 ## Task 隔离 vs 主上下文
 
 ### 必须 Task 隔离的场景
@@ -26,7 +32,9 @@
 | 1-2 次可完成的简单搜索 | 不值得隔离开销 |
 | Lead 的战略决策和综合判断 | 需要完整上下文连贯思考 |
 | Stage 间调度和 Gate 裁决 | 调度逻辑必须在主上下文 |
-| deliverables 最终整合 | 需要跨 Stage 的全局视野 |
+| deliverables 最终整合：Lead 出 spec，生成/整合由 subagent 执行，Lead 只持 receipt | 绝对规则——Lead 禁读 pipeline/deliverables 全文，整合决策与整合执行分离 |
+
+> **补充**：Lead 只持指针 / receipt / manifest，禁读 `pipeline/**`、`deliverables/**` 全文；需要内容时必须派 subagent 读取并提炼回传结构化摘要，不得自行 Read/cat。
 
 ### 反模式（禁止）
 

--- a/plugins/deep-research/skills/deep-research/references/pipeline.md
+++ b/plugins/deep-research/skills/deep-research/references/pipeline.md
@@ -10,10 +10,10 @@
 Sources → ❰G0❱ → [harvester] Acquisition → ❰G1❱
   → [harvester] Sanitization
   → [analyst] Decomposition → ❰G2❱
-  → [analyst+Lead] Synthesis → ❰G3❱
+  → [analyst+Lead(manifest 裁决)] Synthesis → ❰G3❱
   → [reviewer] Validation
-  → [Lead] Delivery → [publisher] report.html
-  ⋯⋯ → [Lead] Landing & Feedback（Stage 8, experimental, 仅落地后触发）
+  → [Lead(spec)+analyst(生成)+reviewer(语义核验)] Delivery → [publisher] report.html
+  ⋯⋯ → [Lead(对比指令)+analyst(执行)] Landing & Feedback（Stage 8, experimental, 仅落地后触发）
 ```
 
 > **G0 需求门**（Sources 后、Acquisition 前）：Lead 与用户对齐问题正确性 + 根本目标，输出 Go / Recycle。区别于 G1/G2/G3 审「执行充分性」，G0 审「问题正确性 + 根本目标对齐」，在源头拦截「解决错问题」。G0 产出 `intake/requirements/research-goal.md`（primary_job + Non-Goals + 用户 sign-off），是举证责任锚定（[principles.md](./principles.md) 元原则 0）的物理入口。定义见 [quality-gates.md](./quality-gates.md)。
@@ -96,11 +96,15 @@ fetch-report 必填字段：tier 分层（T1/T2/T3）、翻页统计、错误汇
 | 项 | 说明 |
 |---|---|
 | 执行者 | research-analyst + Lead session |
-| 输入目录 | `pipeline/3_structured/` + `pipeline/2_cleaned/`（只读） |
+| 输入目录 | `pipeline/3_structured/` + `pipeline/2_cleaned/`（只读，analyst 读取） |
 | 输出目录 | `pipeline/4_extracted/` |
 | 产物 | 洞察报告 + deliverables 草稿 |
 
-Lead 参与综合分析中不可委托的连贯思考和战略判断。
+绝对规则下 Lead 禁读 `pipeline/3_structured`/`2_cleaned` 全文。执行分两轮：
+
+- **第一轮**：analyst 读 `3_structured` 全文，同时产出完整草稿落盘 `deliverables/draft/`，并回传 Lead 一份 **synthesis-manifest**（每条洞察 = `{claim_id, 一句话结论, 支撑文件路径+行号指针, 冲突/取舍待决项}`，schema 见下「Stage 间契约」）。
+- **Lead 裁决**：Lead 只读 manifest（几百 token），不读全文，在此基础上做不可委托的连贯思考和战略判断，产出定向修正指令。
+- **第二轮**：analyst 只读**自己的草稿 + Lead 的定向修正指令**，不重读 `3_structured`（消灭重读，替代 teammate 保温机制），据此改稿。
 
 ### ❰G3❱ Sufficiency Gate: 综合充分性
 
@@ -119,28 +123,36 @@ Lead 参与综合分析中不可委托的连贯思考和战略判断。
 
 5 维度审阅：准确性、完整性、逻辑性、可操作性、可追溯性。verdict 规则见 [quality-gates.md](./quality-gates.md)。
 
-### Stage 7: Delivery（Lead 执行）
+### Stage 7: Delivery（Lead 出 spec + analyst 生成 + reviewer 语义核验）
 
 | 项 | 说明 |
 |---|---|
-| 执行者 | Lead session |
-| 输入 | 审阅通过的产物 |
+| 执行者 | Lead session（出 spec）+ research-analyst（Task subagent，生成落盘）+ research-reviewer（Task subagent，语义核验） |
+| 输入 | 审阅通过的产物 + `pipeline/4_extracted/` |
 | 输出目录 | `deliverables/final/` |
 | 产物 | report.md + executive_summary.md + 附录 + report.html（见下 HTML 渲染子步骤） |
 
-**HTML 渲染子步骤**：Delivery 定稿（report.md 等已落盘 `deliverables/final/`）后，Lead spawn `deep-research:research-publisher`（Task subagent），把 report.md 渲染成 `report.html`——自包含 HTML 展示视图（VIEW 层，见 [principles.md](./principles.md) 原则 5），零新事实。publisher 渲染完成后自调 `scripts/verify_report_html.py` 机械门自校验（三态 exit：`0`=PASS/`1`=FAIL/`2`=N/A，校验链接守恒 + 章节守恒 + 自包含），不 PASS 须修正后复渲。
+绝对规则下 Lead 不读 `4_extracted` 全文、不亲自落盘 final 文档。执行分三步：
 
-### Stage 8: Landing & Feedback（Lead 执行，experimental）
+- **Lead 出 spec**：Lead 产出 **report-spec**（`{报告大纲, 每节裁决要点, 引用指针}`，schema 见下「Stage 间契约」），全在主上下文完成，不含 `4_extracted` 全文。
+- **analyst 生成**：Lead spawn `deep-research:research-analyst`，按 spec + 盘上 `4_extracted` 渲染 `deliverables/final/report.md`、`executive_summary.md`，回传 `{落盘路径, 机械门 receipt}`。Lead 不亲读生成内容。
+- **reviewer 语义核验**：生成落盘后，Lead spawn 轻量 `deep-research:research-reviewer`（mode=review 既有能力）对 report.md/report.html 做 no-new-facts 语义核验，回传 verdict receipt（含 FAIL 分支的问题定位字段，见下「Stage 间契约」receipt schema）。Lead 不亲读审阅报告全文，只据 receipt 裁决。这一步补上「Lead 视觉核验兜底」在绝对规则下的断裂——原先靠 Lead 亲眼看一遍成品的安全网，现由 reviewer 语义核验替代。
+
+**HTML 渲染子步骤**：Delivery 定稿（report.md 等已落盘 `deliverables/final/`）后，Lead spawn `deep-research:research-publisher`（Task subagent），把 report.md 渲染成 `report.html`——自包含 HTML 展示视图（VIEW 层，见 [principles.md](./principles.md) 原则 5），零新事实。publisher 渲染完成后自调 `scripts/verify_report_html.py` 机械门自校验（三态 exit：`0`=PASS/`1`=FAIL/`2`=N/A，校验链接守恒 + 章节守恒 + 自包含），不 PASS 须修正后复渲。report.html 仍归 publisher 生成，不受本 Stage 生成卸载影响。
+
+### Stage 8: Landing & Feedback（Lead 出对比指令 + analyst 执行，experimental）
 
 > ⚠ **EXPERIMENTAL（Stage 8）**：本阶段为 track_h 草案（#11）落地，待 ≥1 真实项目字面复制验证后转 stable。验证通过去标记升 stable；暴露问题走 Correction Record 修正（原则 5）。验证记录见 #11。
 
 | 项 | 说明 |
 |---|---|
-| 执行者 | **Lead session**（落地实测后自评回写，不派 subagent） |
+| 执行者 | **research-analyst**（Task subagent，落地实测后自评回写执行者；归属复用 analyst——已具 Write、已读 deliverables 语义，landing 性质同 Synthesis） |
 | 触发点 | 已交付结论被真实落地、产生「设计预期 vs 落地实际」的 delta 之后（与主管线异步，非每个项目必经） |
-| 输入 | 已交付结论（`deliverables/final/`）+ 落地环境实测反馈 |
+| 输入 | Lead 的 delta 对比指令 + 已交付结论（`deliverables/final/`）+ 落地环境实测反馈 |
 | 输出目录 | `deliverables/final/`（追加，不覆盖原文） |
 | 产物 | landing 回填文档（五段结构，见模板）+ 按需触发的 Correction Record / 补轨 handoff |
+
+绝对规则下 Lead 不读 `deliverables/final/` 全文。Lead 出**对比指令**（落地实测反馈 + 需要对照哪些已交付结论），spawn analyst 执行「读 final + 落地反馈 → 产 delta 对比」。analyst 回传 Lead 一份 **delta receipt**（`{delta 四分类标签, 每 delta 一句话结论, 支撑指针, 触发的下游动作, 落盘路径}`，schema 见下「Stage 间契约」），Lead 只持 receipt 做四分类分流裁决，不亲读回填文档全文。Correction Record、补轨 handoff 均由 analyst 落盘。
 
 **Landing 五段结构**（模板 [landing-feedback.md.tmpl](../assets/landing-feedback.md.tmpl)）：① 落地概览 → ② 设计→实践 Delta 表（四分类，见 [principles.md](./principles.md) 原则 5）→ ③ delta 分述 → ④ 方法论边界声明（n=1 防护）→ ⑤ 权威指针 + 补轨登记。
 
@@ -166,5 +178,17 @@ Lead 参与综合分析中不可委托的连贯思考和战略判断。
 5. **命名一致**：所有 pipeline 产物使用 `YYYYMMDD_HHMMSS_{source}_{description}` 命名；补轨产物加 `track_{x}_` 前缀（见 principles.md 原则 6）
 6. **Gate 阻塞**：G0/G1/G2/G3 未通过时，后续 Stage 禁止启动
 7. **回退权限**：只有 Lead 可以决定 Stage 回退。G3 裁决 RECYCLE 时强制回退到 G0 重校准问题定义（区别于 FAIL 的原阶段补充）
+8. **主 session 只持指针**：Lead（主 session，`agent_id` 为空）对 `pipeline/**` 和 `deliverables/**` 下的文件只允许持有路径指针，禁止读取其内容（Read 工具 + Bash cat 类读取）。所有内容读取/生成/审阅由 subagent 在隔离上下文完成，回传 Lead 的只有 manifest/receipt/spec/delta-receipt（路径 + 结构化裁决摘要），永不含全文。物理焊死靠 PreToolUse `read_guard` hook。详见 [adr-main-session-cost-fix.md](../../../docs/adr-main-session-cost-fix.md)。
+
+### manifest / receipt / spec / delta-receipt 产物定义
+
+上一条契约催生的四类 Lead-subagent 间结构化传递产物，长在现有 PRIMARY/VIEW/派生层概念之上，不是新分层，只是数据流的传递格式约定：
+
+| 产物 | 产生者 → 消费者 | 结构 | 用于哪个 Stage |
+|---|---|---|---|
+| **synthesis-manifest** | analyst → Lead | `{claim_id, 一句话结论, 支撑文件路径+行号指针, 冲突/取舍待决项}`（每条洞察一条，几百 token） | Stage 5 Synthesis 第一轮 |
+| **receipt**（Gate/审阅通用） | reviewer → Lead | `GATE_VERDICT` 独立成行 + 项目路径 + `verdict` + 维度评分表 + 报告路径；FAIL 分支必含 `{问题/幻觉原文摘录, 所在文件+段落指针, 错误原因, 达标所需具体改进}` | G1/G2/G3、Stage 6 Validation、Stage 7 语义核验 |
+| **report-spec** | Lead → analyst（Stage 7 writer） | `{报告大纲, 每节裁决要点, 引用指针}`，全在主上下文产出，不含 `4_extracted` 全文 | Stage 7 Delivery |
+| **delta receipt** | analyst → Lead | `{delta 四分类标签, 每 delta 一句话结论, 支撑指针, 触发的下游动作(Correction Record/补轨 handoff/无), 落盘路径}` | Stage 8 Landing |
 
 **关联文件**：[principles.md](./principles.md) · [quality-gates.md](./quality-gates.md) · 角色定义见 deep-research 插件的 research-harvester / research-analyst / research-reviewer / research-publisher subagent

--- a/plugins/deep-research/skills/deep-research/references/principles.md
+++ b/plugins/deep-research/skills/deep-research/references/principles.md
@@ -43,7 +43,7 @@ pipeline 分层是数据流的唯一合法路径，禁止跳层：
 pipeline/1_raw/        → 原始采集数据（harvester 写入）
 pipeline/2_cleaned/    → 脱敏后数据（harvester 写入，下游只读）
 pipeline/3_structured/ → 域拆解产物（analyst 写入）
-pipeline/4_extracted/  → 洞察提取产物（analyst + Lead 写入）
+pipeline/4_extracted/  → 洞察提取产物（analyst 写入）
 deliverables/          → 最终交付物（draft/ + final/）
 ```
 

--- a/plugins/deep-research/tests/test_read_guard.py
+++ b/plugins/deep-research/tests/test_read_guard.py
@@ -51,6 +51,23 @@ class TestAgentIdGate(_ProjectFixture):
             self._block("", "Read", {"file_path": str(self.big)})
         )
 
+    def test_none_agent_id_treated_as_main_session_blocked(self):
+        # copilot review: agent_id 缺失(None)不能 fail-open——主 session 的事件本就
+        # 携带空/缺失 agent_id，对 None 放行会让主 session 永远绕过门禁。None 必须
+        # 与主 session 同路径处理：研究项目内 + 受管大文件 → 拦。
+        self.assertTrue(
+            self._block(None, "Read", {"file_path": str(self.big)})
+        )
+
+    def test_none_agent_id_non_research_project_passes_via_path_layer(self):
+        # 真正的 fail-open 在路径层：None agent_id 但非研究项目 → 放行。
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "random.md"
+            f.write_text("x" * 20000)
+            self.assertFalse(
+                read_guard._should_block(None, "Read", {"file_path": str(f)}, d)[0]
+            )
+
     def test_main_session_reads_big_deliverables_file_blocked(self):
         big_deliv = self.proj / "deliverables" / "final" / "report.md"
         big_deliv.write_text("z" * 20000)

--- a/plugins/deep-research/tests/test_read_guard.py
+++ b/plugins/deep-research/tests/test_read_guard.py
@@ -1,0 +1,164 @@
+"""Unit tests for hooks/read_guard.py — 主 session 绝对规则门禁。
+
+覆盖契约①（adr-main-session-cost-fix.md）的判定边界：agent_id 空/非空区分主/子、
+Read/Bash 命中受管路径、白名单放行、fail-open 硬约束、Bash 读取模式解析。
+
+fail-open 是硬约束：宁可漏检不可误伤（never break userspace）——测试特别覆盖
+grep 检索/ls/find/非研究项目等必须放行的场景。
+"""
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+import read_guard  # noqa: E402
+
+
+class _ProjectFixture(unittest.TestCase):
+    """建一个含 pipeline/ 的假研究项目，pipeline 下放一个大文件、一个白名单文件。"""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.proj = Path(self.tmp.name).resolve() / "proj"
+        (self.proj / "pipeline" / "verification").mkdir(parents=True)
+        (self.proj / "deliverables" / "final").mkdir(parents=True)
+        self.big = self.proj / "pipeline" / "verification" / "big-report.md"
+        self.big.write_text("x" * 20000)  # > 8KB 阈值
+        self.receipt = self.proj / "deliverables" / "final" / "g1-receipt.md"
+        self.receipt.write_text("tiny receipt")
+        self.verdict = self.proj / "pipeline" / "verification" / "G1-verdict.md"
+        self.verdict.write_text("y" * 20000)  # 大文件但白名单命名
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _block(self, agent_id, tool_name, tool_input):
+        return read_guard._should_block(
+            agent_id, tool_name, tool_input, str(self.proj)
+        )[0]
+
+
+class TestAgentIdGate(_ProjectFixture):
+    def test_subagent_reads_pipeline_passes(self):
+        # agent_id 非空 = subagent，任何读取放行
+        self.assertFalse(
+            self._block("abc123", "Read", {"file_path": str(self.big)})
+        )
+
+    def test_main_session_reads_big_pipeline_file_blocked(self):
+        self.assertTrue(
+            self._block("", "Read", {"file_path": str(self.big)})
+        )
+
+    def test_main_session_reads_big_deliverables_file_blocked(self):
+        big_deliv = self.proj / "deliverables" / "final" / "report.md"
+        big_deliv.write_text("z" * 20000)
+        self.assertTrue(
+            self._block("", "Read", {"file_path": str(big_deliv)})
+        )
+
+
+class TestWhitelist(_ProjectFixture):
+    def test_receipt_file_passes(self):
+        self.assertFalse(
+            self._block("", "Read", {"file_path": str(self.receipt)})
+        )
+
+    def test_verdict_named_file_passes_even_if_large(self):
+        # *-verdict.md 白名单命名，即便 > 8KB 也放行
+        self.assertFalse(
+            self._block("", "Read", {"file_path": str(self.verdict)})
+        )
+
+    def test_small_file_under_threshold_passes(self):
+        small = self.proj / "pipeline" / "small.md"
+        small.write_text("small")
+        self.assertFalse(
+            self._block("", "Read", {"file_path": str(small)})
+        )
+
+
+class TestFailOpen(_ProjectFixture):
+    def test_non_research_project_passes(self):
+        # cwd 下无 pipeline/ → 非研究项目 → fail-open
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "random.md"
+            f.write_text("x" * 20000)
+            self.assertFalse(
+                read_guard._should_block(
+                    "", "Read", {"file_path": str(f)}, d
+                )[0]
+            )
+
+    def test_read_without_file_path_passes(self):
+        self.assertFalse(self._block("", "Read", {}))
+
+    def test_bash_without_command_passes(self):
+        self.assertFalse(self._block("", "Bash", {}))
+
+    def test_unknown_tool_passes(self):
+        self.assertFalse(
+            self._block("", "Grep", {"pattern": "foo"})
+        )
+
+
+class TestBashReadDetection(_ProjectFixture):
+    def test_cat_big_pipeline_file_blocked(self):
+        self.assertTrue(
+            self._block("", "Bash", {"command": f"cat {self.big}"})
+        )
+
+    def test_head_tail_sed_awk_blocked(self):
+        for cmd in ("head", "tail", "sed -n 1,5p", "awk '{print}'"):
+            self.assertTrue(
+                self._block("", "Bash", {"command": f"{cmd} {self.big}"}),
+                msg=f"{cmd} should block",
+            )
+
+    def test_grep_with_pattern_passes(self):
+        # grep 带真实 pattern = 检索，不是读大文件 → 放行
+        self.assertFalse(
+            self._block("", "Bash", {"command": f"grep foobar {self.big}"})
+        )
+
+    def test_grep_empty_pattern_full_read_blocked(self):
+        # grep "" file = 全量读 → 拦
+        self.assertTrue(
+            self._block("", "Bash", {"command": f'grep "" {self.big}'})
+        )
+
+    def test_ls_and_find_pass(self):
+        self.assertFalse(
+            self._block("", "Bash", {"command": f"ls -la {self.proj}/pipeline"})
+        )
+        self.assertFalse(
+            self._block("", "Bash", {"command": f"find {self.proj} -name '*.md'"})
+        )
+
+    def test_echo_process_substitution_read_blocked(self):
+        self.assertTrue(
+            self._block("", "Bash", {"command": f'echo "$(< {self.big})"'})
+        )
+
+    def test_cat_whitelist_receipt_passes(self):
+        self.assertFalse(
+            self._block("", "Bash", {"command": f"cat {self.receipt}"})
+        )
+
+    def test_cat_file_outside_project_passes(self):
+        # cat 一个不在受管目录的文件 → 放行
+        outside = self.proj / "notes.md"
+        outside.write_text("x" * 20000)
+        self.assertFalse(
+            self._block("", "Bash", {"command": f"cat {outside}"})
+        )
+
+    def test_subagent_cat_passes(self):
+        self.assertFalse(
+            self._block("sub1", "Bash", {"command": f"cat {self.big}"})
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

deep-research 7-Stage 调研中，主 session(Lead，全程 opus)独占 ~90% 成本(research 仓复盘 #36/#37，n=2：\$379/\$422、\$217/\$242)。按 list price 拆解纠偏：成本核心是 **uncached input(\$291/78%)**，不是 cache_read(\$21/6%)。根因＝全文穿过主上下文按全价计 input。1h cache 是补丁(只保温已缓存的，管不到全文首次穿行)，已砍除。

## 方案：唯一绝对规则

> 主 session(`agent_id` 为空)对 `pipeline/**` 和 `deliverables/**` 只允许持路径指针，禁止读取内容(Read + Bash cat 类)。内容读取/生成/审阅全部下沉 subagent，回传 Lead 只有 receipt。

绝对规则 > 软规则：消除所有「这次就读一下」的边界情况，物理焊死靠 PreToolUse hook 按 agent_id 区分主/子。

## 改动

- **hooks/read_guard.py**(新增)：PreToolUse(Read|Bash) 门禁。Read 硬拦截 + Bash 尽力护栏(威胁模型分层——Lead 是协作方非攻击者，不做容器级隔离过度工程)。fail-open 硬约束(非研究项目/无 agent_id/解析异常→放行)。
- **research-reviewer**：`tools` 加 Write(锁 `verification/`)，审阅报告落盘，回传 receipt。GATE_VERDICT marker 保真触发 gate_check 引用校验门；**FAIL 分支带 {问题原文摘录, 段落指针, 原因, 改进} 定位字段**，因 Lead 禁读全文，纠错全靠 receipt 驱动。
- **research-analyst**：Synthesis 两轮不重读(第一轮回传 synthesis-manifest+落盘草稿，第二轮只读自己草稿+定向修正，消灭重读)、Stage7 report 生成(按 Lead 的 report-spec)、Stage8 Landing 执行者(复用)。
- **一致性清扫** pipeline/context-economics/principles/SKILL：消除「Lead 主上下文生成/落盘全文」自相矛盾软条款。
- **research-publisher**：语义核验兜底由 Lead 视觉核验改为 reviewer no-new-facts 核验(绝对规则下 Lead 不读 report.html)。
- **tests/test_read_guard.py**(新增)：19 单测覆盖判定边界。

## 破坏性推演(6 风险，均闭环)

1. 【致命】gate_check 引用校验门失效 → receipt 强制保留 GATE_VERDICT marker + 项目路径，回归测试验证仍触发。
2. 【高】publisher 语义安全网断裂 → 下沉 reviewer 语义核验。
3. 【高】Bash cat 绕过 → 门禁挂 Read+Bash 双 matcher，尽力护栏(诚实分级，非沙盒)。
4. 【中】Stage8 Lead 读 deliverables → 改 analyst subagent 执行。
5. 【中】自相矛盾软条款 → 一致性清扫清零。
6. 【低】reviewer Write 破坏不可变 → 锁 verification/(非编号目录、gate 裁决既有归宿)。

## 验证

- 全套 **356 tests 绿**(13 gate_check + 19 read_guard + 324 harvest/verify)。
- harvester/harvest.py 未动，**--no-api local mode 兼容**(28 相关测试绿)。
- 端到端流程推演：主上下文全程只吃 spec/manifest/receipt(KB 级)，全文一律落盘走指针。

## 预期收益(量级估算，非承诺)

主 session uncached input 1940万→~300万量级，\$379→~\$60-80，全局 \$422→~\$130-160。以真实调研的「主 session input 降 ≥60% 且 G0-G3 不退化」为验收基准。

详见 `plugins/deep-research/docs/adr-main-session-cost-fix.md`。