### PR TITLE
feat(harvest): NDJSON stderr 进度事件流 (v1.7.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -109,6 +109,22 @@ JUDGE_SYSTEM_PROMPT = (
 )
 
 
+_progress_lock = threading.Lock()
+
+
+def _emit(event, **kw):
+    """Thread-safe NDJSON progress line to stderr. Never raises."""
+    try:
+        kw["event"] = event
+        kw["t"] = round(time.time(), 1)
+        line = json.dumps(kw, default=str)
+        with _progress_lock:
+            sys.stderr.write(line + "\n")
+            sys.stderr.flush()
+    except Exception:
+        pass
+
+
 # ---------------------------------------------------------------------------
 # Rate limiting
 # ---------------------------------------------------------------------------
@@ -1703,6 +1719,16 @@ def run_worker(alias, model_id, client, config, search_backends, fetch_backends,
             messages.append(message)
             tool_calls = message.get("tool_calls") or []
             if tool_calls:
+                tool_names = ["?"]
+                target = ""
+                try:
+                    tool_names = [tc.get("function", {}).get("name", "?") for tc in tool_calls]
+                    if len(tool_calls) == 1:
+                        a = json.loads(tool_calls[0].get("function", {}).get("arguments", "{}"))
+                        target = str(a.get("query", a.get("url", "")))[:80]
+                except Exception:
+                    pass
+                _emit("worker_step", alias=alias, step=step, tools=tool_names, target=target)
                 is_all_fetch = len(tool_calls) > 1 and all(
                     tc.get("function", {}).get("name") == "fetch" for tc in tool_calls
                 )
@@ -1727,6 +1753,7 @@ def run_worker(alias, model_id, client, config, search_backends, fetch_backends,
                 if remaining == 3:
                     append_or_merge_user(messages,
                         "[BUDGET] 3 rounds remaining. Begin converging — synthesize findings from evidence already fetched.")
+                    _emit("worker_converging", alias=alias, remaining=remaining)
                 elif remaining == 1:
                     append_or_merge_user(messages,
                         "[BUDGET] Last chance. Output findings JSON on your next turn or data will be lost.")
@@ -1838,10 +1865,20 @@ def run_panel(config, goal_text, local_manifest, local_dir, client_factory):
         for fut in as_completed(futures):
             alias = futures[fut]
             try:
-                results.append(fut.result())
+                r = fut.result()
+                results.append(r)
             except Exception as e:
-                results.append(WorkerResult(alias, "?", "FAILED", None, [], f"executor_exception: {e}"))
+                r = WorkerResult(alias, "?", "FAILED", None, [], f"executor_exception: {e}")
+                results.append(r)
+            claims_count = 0
+            try:
+                claims = r.findings.get("claims") if isinstance(r.findings, dict) else None
+                claims_count = len(claims) if isinstance(claims, list) else 0
+            except Exception:
+                pass
+            _emit("worker_done", alias=r.alias, model_id=r.model_id, status=r.status, claims=claims_count)
     alive = [r for r in results if r.status == "OK"]
+    _emit("panel_done", alive=[r.alias for r in alive], quorum_met=len(alive) >= quorum)
     return results, alive, len(alive) >= quorum
 
 
@@ -2508,6 +2545,9 @@ def cmd_run(args):
             local_manifest = build_local_manifest(local_dir, config)
 
         client_factory = make_client_factory(config)
+        _emit("run_start", models=config["panel_models"],
+              max_steps=config["limits"]["max_steps_per_model"],
+              wall_clock_s=config["limits"]["wall_clock_s"])
         results, alive, quorum_met = run_panel(config, goal_text, local_manifest, local_dir, client_factory)
 
         harvest_dir = raw_dir / HARVEST_SUBDIR
@@ -2529,7 +2569,10 @@ def cmd_run(args):
                                verify_filename=verify_filename)
 
         worker_findings_by_alias = {r.alias: r.findings for r in alive}
+        _emit("judge_start", model_id=config.get("judge_model") or config["panel_models"][0])
         judge_data, judge_err = run_judge_with_fallback(config, client_factory, worker_findings_by_alias, config["panel_models"])
+        _emit("judge_done", clusters=len(judge_data.get("clusters", [])) if judge_data else 0,
+              err=judge_err)
         if judge_data is None:
             abort_unavailable(verify_dir, goal_hash, f"judge failed: {judge_err}",
                                {"quorum_met": True, "models_alive": [r.alias for r in alive]},
@@ -2559,6 +2602,7 @@ def cmd_run(args):
             "invalid_claim_count": invalid_total,
             "total_claims": total_claims,
         }, verify_filename=verify_filename)
+        _emit("run_done", verdict=verdict, total_claims=total_claims, invalid_rate=round(invalid_rate, 4))
         print(f"harvest run complete: verdict={verdict}")
     except SystemExit:
         raise

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -5,6 +5,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unittest
 import urllib.parse
@@ -4039,6 +4040,75 @@ class TestCheckProjectLocalVerdict(unittest.TestCase):
             verdict, reason = harvest.check_project(project_dir)
         self.assertEqual(verdict, "N_A")
         self.assertIn("local mode", reason)
+
+
+# ---------------------------------------------------------------------------
+# _emit: progress reporting (NDJSON to stderr)
+# ---------------------------------------------------------------------------
+
+class TestProgressEmit(unittest.TestCase):
+    def test_emit_produces_valid_ndjson(self):
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            harvest._emit("test_event", foo="bar", num=42)
+        line = stderr.getvalue().strip()
+        data = json.loads(line)
+        self.assertEqual(data["event"], "test_event")
+        self.assertEqual(data["foo"], "bar")
+        self.assertEqual(data["num"], 42)
+        self.assertIn("t", data)
+
+    def test_emit_never_raises_on_unserializable(self):
+        class Unserializable:
+            def __str__(self):
+                raise RuntimeError("no repr for you")
+
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            harvest._emit("bad_event", obj=Unserializable())  # must not raise
+        output = stderr.getvalue()
+        if output.strip():
+            json.loads(output.strip())  # if anything was written, it's valid JSON
+
+    def test_emit_default_str_serializes_exception(self):
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            harvest._emit("err", detail=ValueError("boom"))
+        data = json.loads(stderr.getvalue().strip())
+        self.assertIn("boom", data["detail"])
+
+    def test_emit_thread_safety(self):
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            def worker(n):
+                for i in range(100):
+                    harvest._emit("concurrent", worker=n, i=i)
+
+            threads = [threading.Thread(target=worker, args=(n,)) for n in range(10)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+            lines = stderr.getvalue().splitlines()
+        self.assertEqual(len(lines), 1000)
+        for line in lines:
+            json.loads(line)  # every line must be independently valid JSON
+
+    def test_worker_step_emitted_during_run_worker(self):
+        client = ScriptedClient([
+            assistant_tool_call("c1", "search", {"query": "q"}),
+            assistant_final(findings_block([
+                {"claim": "c", "excerpt": "Rayleigh scattering explains the blue sky.",
+                 "url": "https://a.com/x", "credibility": 4, "language": "en"}])),
+        ])
+        search_backends = [({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0))]
+        with mock.patch("harvest.call_search_backend",
+                         return_value=[{"url": "https://a.com/x", "title": "t", "snippet": "s"}]), \
+             mock.patch("harvest.call_fetch_backend",
+                         return_value="Rayleigh scattering explains the blue sky."), \
+             mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            harvest.run_worker("m1", "model-a", client, base_config(), search_backends, [],
+                                "goal", [], None)
+        events = [json.loads(line) for line in stderr.getvalue().splitlines()]
+        worker_steps = [e for e in events if e["event"] == "worker_step"]
+        self.assertTrue(worker_steps)
+        self.assertEqual(worker_steps[0]["alias"], "m1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- harvest.py 多模型采集 30-90 分钟全程零中间信号，新增 `_emit()` 线程安全 NDJSON 进度事件流到 stderr
- 7 个埋点覆盖全生命周期：run_start → worker_step → worker_converging → worker_done → panel_done → judge_start/done → run_done
- 推模型（非拉模型）：调用方不需 polling，Bash 结束时 stderr 一并返回即可回溯全程
- 输出量上界 ~55 行 / ~8KB，对 agent 上下文无实质冲击

## Design decisions
- stderr NDJSON（非 progress file）——社区最佳实践，Unix 哲学对齐
- `threading.Lock` 保护并发写（3 worker 线程）
- `try...except Exception: pass` + `default=str`——进度报告绝不中断主控制流
- worker_step 在 tool 执行**前** emit——挂死时保留案发现场
- `ensure_ascii=True`（默认）——任何 stderr 编码环境下不抛 UnicodeEncodeError

## Test plan
- [x] 5 个新单测（TestProgressEmit）：NDJSON 合法性、异常隔离、default=str、线程安全(10×100)、集成
- [x] 全量回归 363 tests passed, 0 failures
- [ ] 真实调研时验证事件序列完整性