### PR TITLE
feat(harvest): panel KV-cache — gpt Responses API + claude effort

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest.config.json
+++ b/plugins/deep-research/scripts/harvest.config.json
@@ -53,6 +53,8 @@
     "call_timeout_s": 180,
     "completion_timeout_s": 600,
     "completion_max_tokens": 16384,
+    "claude_effort": "medium",
+    "gpt_endpoint": "responses",
     "wall_clock_s": 1800,
     "quorum": 2,
     "search_min_interval_s": 2,

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -1453,12 +1453,21 @@ def _anthropic_resp_to_oai(resp):
 
 
 class AnthropicGatewayClient:
-    def __init__(self, base_url, api_key, model_id, timeout_s, max_tokens):
+    def __init__(self, base_url, api_key, model_id, timeout_s, max_tokens, effort=None):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.model_id = model_id
         self.timeout_s = timeout_s
         self.max_tokens = max_tokens
+        # effort=None preserves the exact wire behavior from before this
+        # field existed (no output_config sent at all, provider default
+        # applies -- currently "high"). make_client_factory is the one place
+        # that supplies a non-None value (config-driven, default "medium");
+        # the class itself stays decoupled from that policy choice so it can
+        # be unit-tested with either shape. See ADR-011 (research repo) --
+        # this is a deliberate global default lowering, not "old behavior
+        # preserved for old configs".
+        self.effort = effort
 
     def complete(self, messages, tools):
         system, anth_messages = _oai_messages_to_anthropic(messages)
@@ -1473,6 +1482,8 @@ class AnthropicGatewayClient:
             payload["system"] = system
         if anth_tools is not None:
             payload["tools"] = anth_tools
+        if self.effort is not None:
+            payload["output_config"] = {"effort": self.effort}
         url = self.base_url + "/messages"
         headers = {
             "Authorization": f"Bearer {self.api_key}",
@@ -1561,6 +1572,191 @@ def _inject_cache_control(system, tools, messages):
     return system
 
 
+# ---------------------------------------------------------------------------
+# Responses-API client (gpt models only)
+#
+# gpt models get a dedicated path to the gateway's OpenAI Responses endpoint
+# (/responses) instead of /chat/completions. This is a KV-cache optimization,
+# not a capability upgrade: on this gateway (aapi.tbps.one, a new-api/one-api
+# aggregator that routes multiple upstream instances), repeated calls against
+# /chat/completions draw a random instance each time and essentially never
+# reuse a warm prefix cache, while /responses calls -- even called completely
+# statelessly (no previous_response_id, full messages resent every step,
+# exactly matching run_worker's calling pattern) -- land on the same instance
+# often enough to hit a growing prefix cache (see ADR-011 in the research
+# repo for the probe data). This is an *instance-affinity accident of this
+# particular gateway*, not a documented OpenAI Responses feature -- a
+# different gateway/provider must be re-probed before relying on it again.
+# Same complete(messages, tools) -> OpenAI-shaped-dict interface as
+# GatewayClient/AnthropicGatewayClient, so run_worker/judge_clusters/
+# run_judge_with_fallback stay unchanged; all protocol translation is
+# confined to the pure functions below.
+# ---------------------------------------------------------------------------
+
+def _oai_tools_to_responses(tools):
+    """OpenAI function-tool schema -> Responses API tool schema. Responses
+    tools are flat ({"type":"function","name":...,"parameters":...}) unlike
+    chat/completions' nested {"function": {...}} shape. Returns None for no
+    tools (judge path passes tools=None) so the caller omits the field
+    entirely, mirroring _oai_tools_to_anthropic."""
+    if not tools:
+        return None
+    out = []
+    for t in tools:
+        fn = t.get("function", {})
+        out.append({
+            "type": "function",
+            "name": fn.get("name", ""),
+            "description": fn.get("description", ""),
+            "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
+        })
+    return out
+
+
+def _oai_messages_to_responses(messages):
+    """OpenAI chat-messages -> (instructions, input_items) for the Responses
+    API. Mirrors _oai_messages_to_anthropic's role-by-role walk but targets
+    Responses' flat item list instead of Anthropic's nested content blocks.
+
+    - role=system   -> hoisted into `instructions` (concatenated; there is
+      only ever one here in practice).
+    - role=user     -> a message item with an input_text content block.
+    - role=assistant -> a message item carrying any text (output_text block)
+      followed by one function_call item per tool call. function_call
+      `arguments` is passed through as-is: run_worker's outbound tool_calls
+      already carry a JSON *string* (the same value the OpenAI chat-
+      completions wire format uses), which is exactly what a Responses
+      function_call item expects -- no json.loads/json.dumps round-trip
+      needed here (unlike the Anthropic path, whose tool_use.input is a
+      dict).
+    - role=tool     -> a function_call_output item keyed by call_id
+      (run_worker's tool_call_id becomes Responses' call_id).
+
+    Unlike _oai_messages_to_anthropic there is no consecutive-turn merging
+    requirement -- Responses' `input` is a flat item list with no
+    alternating-role constraint, so tool results and user nudges are each
+    emitted as their own item without a merge step."""
+    instructions_parts = []
+    items = []
+    for msg in messages:
+        role = msg.get("role")
+        if role == "system":
+            content = msg.get("content")
+            if isinstance(content, str) and content:
+                instructions_parts.append(content)
+            continue
+        if role == "tool":
+            items.append({
+                "type": "function_call_output",
+                "call_id": msg.get("tool_call_id", ""),
+                "output": msg.get("content", ""),
+            })
+            continue
+        if role == "assistant":
+            text = msg.get("content")
+            if isinstance(text, str) and text:
+                items.append({"role": "assistant", "content": [{"type": "output_text", "text": text}]})
+            for tc in (msg.get("tool_calls") or []):
+                fn = tc.get("function", {})
+                items.append({
+                    "type": "function_call",
+                    "call_id": tc.get("id", ""),
+                    "name": fn.get("name", ""),
+                    "arguments": fn.get("arguments") or "{}",
+                })
+            continue
+        # role == user (or unknown -> treat as user)
+        content = msg.get("content")
+        text = content if isinstance(content, str) else ""
+        if text:
+            items.append({"role": "user", "content": [{"type": "input_text", "text": text}]})
+    instructions = "\n\n".join(instructions_parts) if instructions_parts else None
+    return instructions, items
+
+
+def _responses_resp_to_oai(resp):
+    """Responses API response -> OpenAI chat-completions shape so
+    _extract_message and the run_worker/judge_clusters loops read it
+    unchanged (same contract as _anthropic_resp_to_oai).
+
+    - `output` is a list of items; "message" items carry output_text content
+      blocks (concatenated into `content`), "function_call" items become
+      OpenAI tool_calls. `arguments` on a Responses function_call item is
+      already a JSON string (same wire shape OpenAI chat/completions uses),
+      so it is passed straight through -- no re-serialization, unlike the
+      Anthropic path where tool_use.input is a dict needing json.dumps.
+    - content is a string for a text-only reply (judge / final synthesis
+      rely on a str here); it is None only when the turn is purely
+      function_call, mirroring the Anthropic conversion's contract.
+    - `status` is surfaced as finish_reason for observability (e.g.
+      "incomplete" from a max_output_tokens truncation shows up instead of
+      silently yielding half a JSON blob)."""
+    output = resp.get("output") or []
+    text_parts = []
+    tool_calls = []
+    for item in output:
+        itype = item.get("type")
+        if itype == "message":
+            for blk in item.get("content") or []:
+                if isinstance(blk, dict) and blk.get("type") in ("output_text", "text"):
+                    text_parts.append(blk.get("text", ""))
+        elif itype == "function_call":
+            tool_calls.append({
+                "id": item.get("call_id", ""),
+                "type": "function",
+                "function": {
+                    "name": item.get("name", ""),
+                    "arguments": item.get("arguments") or "{}",
+                },
+            })
+    message = {"role": "assistant"}
+    if tool_calls:
+        message["content"] = "".join(text_parts) if text_parts else None
+        message["tool_calls"] = tool_calls
+    else:
+        message["content"] = "".join(text_parts)
+    return {
+        "choices": [{"message": message, "finish_reason": resp.get("status")}],
+        "usage": resp.get("usage", {}),
+    }
+
+
+class ResponsesGatewayClient:
+    def __init__(self, base_url, api_key, model_id, timeout_s, max_output_tokens):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.model_id = model_id
+        self.timeout_s = timeout_s
+        # Mirrors AnthropicGatewayClient's max_tokens: Responses' equivalent
+        # knob is max_output_tokens, and it is mandatory here for the same
+        # reason max_tokens is mandatory on the Anthropic path -- a long
+        # findings/judge JSON silently truncated by an unset/too-small output
+        # cap surfaces as a parse_findings_json failure downstream, not as an
+        # obvious "output was cut off" error. make_client_factory sources
+        # this from the same limits.completion_max_tokens value used by the
+        # Anthropic path (config-level single source of truth for "how big
+        # can a completion be").
+        self.max_output_tokens = max_output_tokens
+
+    def complete(self, messages, tools):
+        instructions, input_items = _oai_messages_to_responses(messages)
+        resp_tools = _oai_tools_to_responses(tools)
+        payload = {
+            "model": self.model_id,
+            "input": input_items,
+            "max_output_tokens": self.max_output_tokens,
+        }
+        if instructions is not None:
+            payload["instructions"] = instructions
+        if resp_tools is not None:
+            payload["tools"] = resp_tools
+        url = self.base_url + "/responses"
+        headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+        resp = _http_json_post_with_retry(url, payload, headers, self.timeout_s,
+                                           transient_backoffs=_COMPLETION_RETRY_BACKOFFS)
+        return _responses_resp_to_oai(resp)
+
+
 def make_client_factory(config):
     gw = config["gateway"]
     api_key = os.environ.get(gw["api_key_env"], "")
@@ -1576,17 +1772,45 @@ def make_client_factory(config):
     # OpenAI path never set it. Read from config with a generous default so
     # large findings/judge outputs aren't truncated (truncation would surface
     # as finish_reason=max_tokens and a half-parsed JSON). Same .get()-with-
-    # default back-compat pattern as completion_timeout_s.
+    # default back-compat pattern as completion_timeout_s. Also doubles as
+    # the Responses path's max_output_tokens (same "how big can a completion
+    # be" knob, one config value, see ResponsesGatewayClient).
     max_tokens = config.get("limits", {}).get("completion_max_tokens", 16384)
+    # ADR-011: deliberate global default lowering, not a like-for-like
+    # migration. Before this key existed, AnthropicGatewayClient never sent
+    # output_config at all, so the provider's own default ("high") applied.
+    # Every existing config -- including ones written before this key was
+    # added -- now gets "medium" via this .get() default, because thinking-
+    # heavy "high" effort was identified as the main per-step latency driver
+    # for claude in the panel (see ADR-011's wall-clock investigation). This
+    # is NOT the usual back-compat contract ("old config behaves exactly as
+    # before"); it is an intentional behavior change that happens to reuse
+    # the same .get()-with-default mechanism. Config authors who want the
+    # old "high" back can set limits.claude_effort explicitly.
+    effort = config.get("limits", {}).get("claude_effort", "medium")
+    # Escape hatch for the /responses instance-affinity cache behavior: this
+    # is observed, gateway-specific behavior (see ResponsesGatewayClient's
+    # docstring), not a guaranteed OpenAI feature. If a future gateway/
+    # provider swap makes /responses worse than plain /chat/completions,
+    # config can flip this back to "chat_completions" without a code change
+    # -- gpt* then falls through to the same plain GatewayClient path gemini
+    # already uses, rather than needing a second personality inside
+    # ResponsesGatewayClient itself.
+    gpt_endpoint = config.get("limits", {}).get("gpt_endpoint", "responses")
 
     def factory(model_id):
         # claude models go through the Anthropic-native /messages path so
-        # prompt caching can take effect; everything else (gemini/gpt) stays
-        # on the OpenAI-compatible /chat/completions gateway. Same
-        # complete(messages, tools) interface either way, so run_judge_with_
-        # fallback can freely mix the two client types across its candidates.
+        # prompt caching can take effect; gpt models go through the
+        # Responses path for the same reason (see ResponsesGatewayClient);
+        # everything else (gemini, and gpt when gpt_endpoint is switched
+        # off) stays on the OpenAI-compatible /chat/completions gateway. All
+        # three share the same complete(messages, tools) interface, so
+        # run_judge_with_fallback can freely mix client types across its
+        # candidates.
         if model_id.startswith("claude"):
-            return AnthropicGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens)
+            return AnthropicGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens, effort=effort)
+        if model_id.startswith("gpt") and gpt_endpoint == "responses":
+            return ResponsesGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens)
         return GatewayClient(gw["base_url"], api_key, model_id, timeout)
 
     return factory

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -3369,6 +3369,338 @@ class TestAnthropicConversion(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# ADR-011: panel three-way KV-cache optimization -- gpt via Responses API,
+# claude effort configuration. Mirrors TestAnthropicConversion's structure
+# for the new Responses protocol conversion pure functions.
+# ---------------------------------------------------------------------------
+
+class TestResponsesConversion(unittest.TestCase):
+    def test_system_hoisted_to_instructions(self):
+        msgs = [{"role": "system", "content": "SYS"}, {"role": "user", "content": "hi"}]
+        instructions, items = harvest._oai_messages_to_responses(msgs)
+        self.assertEqual(instructions, "SYS")
+        self.assertEqual(items, [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}])
+
+    def test_no_system_yields_none_instructions(self):
+        instructions, _items = harvest._oai_messages_to_responses([{"role": "user", "content": "hi"}])
+        self.assertIsNone(instructions)
+
+    def test_plain_assistant_text_becomes_message_item(self):
+        _i, items = harvest._oai_messages_to_responses([{"role": "assistant", "content": "answer"}])
+        self.assertEqual(items, [{"role": "assistant", "content": [{"type": "output_text", "text": "answer"}]}])
+
+    def test_assistant_tool_calls_become_function_call_items(self):
+        msgs = [{"role": "assistant", "content": None,
+                 "tool_calls": [{"id": "tc1", "function": {"name": "search",
+                                 "arguments": json.dumps({"query": "中文"})}}]}]
+        _i, items = harvest._oai_messages_to_responses(msgs)
+        self.assertEqual(len(items), 1)  # no empty text item for null content
+        self.assertEqual(items[0]["type"], "function_call")
+        self.assertEqual(items[0]["call_id"], "tc1")
+        self.assertEqual(items[0]["name"], "search")
+        self.assertEqual(json.loads(items[0]["arguments"]), {"query": "中文"})
+
+    def test_assistant_text_plus_single_tool_call(self):
+        msgs = [{"role": "assistant", "content": "thinking",
+                 "tool_calls": [{"id": "t", "function": {"name": "fetch", "arguments": "{}"}}]}]
+        _i, items = harvest._oai_messages_to_responses(msgs)
+        self.assertEqual(items[0], {"role": "assistant", "content": [{"type": "output_text", "text": "thinking"}]})
+        self.assertEqual(items[1]["type"], "function_call")
+
+    def test_assistant_parallel_tool_calls_become_separate_items(self):
+        msgs = [{"role": "assistant", "content": None, "tool_calls": [
+            {"id": "a", "function": {"name": "search", "arguments": json.dumps({"query": "q1"})}},
+            {"id": "b", "function": {"name": "search", "arguments": json.dumps({"query": "q2"})}}]}]
+        _i, items = harvest._oai_messages_to_responses(msgs)
+        self.assertEqual(len(items), 2)
+        self.assertEqual([it["call_id"] for it in items], ["a", "b"])
+        self.assertTrue(all(it["type"] == "function_call" for it in items))
+
+    def test_tool_message_becomes_function_call_output(self):
+        msgs = [{"role": "tool", "tool_call_id": "a", "content": "resA"}]
+        _i, items = harvest._oai_messages_to_responses(msgs)
+        self.assertEqual(items, [{"type": "function_call_output", "call_id": "a", "output": "resA"}])
+
+    def test_parallel_tool_results_become_separate_items_no_merge(self):
+        # Unlike the Anthropic conversion (which must merge consecutive tool
+        # messages into one user turn), Responses' flat input list needs no
+        # such merge -- each tool result is independently addressable by
+        # call_id.
+        msgs = [
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "a", "function": {"name": "search", "arguments": "{}"}},
+                {"id": "b", "function": {"name": "fetch", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "a", "content": "resA"},
+            {"role": "tool", "tool_call_id": "b", "content": "resB"},
+        ]
+        _i, items = harvest._oai_messages_to_responses(msgs)
+        outputs = [it for it in items if it["type"] == "function_call_output"]
+        self.assertEqual(len(outputs), 2)
+        self.assertEqual([o["call_id"] for o in outputs], ["a", "b"])
+        self.assertEqual([o["output"] for o in outputs], ["resA", "resB"])
+
+    def test_empty_user_content_produces_no_item(self):
+        for empty in ("", None):
+            _i, items = harvest._oai_messages_to_responses([{"role": "user", "content": empty}])
+            self.assertEqual(items, [], f"empty user content leaked an item for content={empty!r}")
+
+    def test_tools_none_returns_none(self):
+        self.assertIsNone(harvest._oai_tools_to_responses(None))
+        self.assertIsNone(harvest._oai_tools_to_responses([]))
+
+    def test_tools_converted_to_flat_responses_shape(self):
+        resp_tools = harvest._oai_tools_to_responses(harvest.TOOL_SCHEMAS)
+        self.assertEqual(len(resp_tools), len(harvest.TOOL_SCHEMAS))
+        self.assertEqual(resp_tools[0]["type"], "function")
+        self.assertEqual(resp_tools[0]["name"], "search")
+        self.assertIn("parameters", resp_tools[0])
+        self.assertNotIn("function", resp_tools[0])  # flat, not nested like chat/completions
+
+    def test_outbound_text_only_content_is_string(self):
+        resp = {"output": [{"type": "message", "content": [{"type": "output_text", "text": "hello"}]}],
+                "status": "completed"}
+        oai = harvest._responses_resp_to_oai(resp)
+        msg = oai["choices"][0]["message"]
+        self.assertEqual(msg["content"], "hello")
+        self.assertNotIn("tool_calls", msg)
+        self.assertEqual(oai["choices"][0]["finish_reason"], "completed")
+
+    def test_outbound_function_call_only_content_none(self):
+        resp = {"output": [{"type": "function_call", "call_id": "x", "name": "search",
+                            "arguments": json.dumps({"query": "q"})}], "status": "completed"}
+        msg = harvest._responses_resp_to_oai(resp)["choices"][0]["message"]
+        self.assertIsNone(msg["content"])
+        self.assertEqual(msg["tool_calls"][0]["id"], "x")
+        self.assertEqual(json.loads(msg["tool_calls"][0]["function"]["arguments"]), {"query": "q"})
+
+    def test_outbound_extract_message_compatible(self):
+        resp = {"output": [{"type": "message", "content": [{"type": "output_text", "text": "j"}]}],
+                "status": "completed"}
+        oai = harvest._responses_resp_to_oai(resp)
+        self.assertEqual(harvest._extract_message(oai), oai["choices"][0]["message"])
+
+    def test_roundtrip_single_function_call_idempotent(self):
+        resp = {"output": [{"type": "function_call", "call_id": "rid", "name": "fetch",
+                            "arguments": json.dumps({"url": "http://x", "q": "中文查询"})}],
+                "status": "completed"}
+        msg = harvest._responses_resp_to_oai(resp)["choices"][0]["message"]
+        _i, items = harvest._oai_messages_to_responses([msg])
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["call_id"], "rid")
+        self.assertEqual(items[0]["name"], "fetch")
+        self.assertEqual(json.loads(items[0]["arguments"]), {"url": "http://x", "q": "中文查询"})
+
+    def test_roundtrip_parallel_function_calls_idempotent(self):
+        resp = {"output": [
+            {"type": "function_call", "call_id": "r1", "name": "search", "arguments": json.dumps({"query": "a"})},
+            {"type": "function_call", "call_id": "r2", "name": "search", "arguments": json.dumps({"query": "b"})},
+        ], "status": "completed"}
+        msg = harvest._responses_resp_to_oai(resp)["choices"][0]["message"]
+        self.assertEqual(len(msg["tool_calls"]), 2)
+        _i, items = harvest._oai_messages_to_responses([msg])
+        self.assertEqual([it["call_id"] for it in items], ["r1", "r2"])
+
+    def test_roundtrip_tool_result_feedback(self):
+        # Simulate a full round: function_call from the model, then the
+        # worker's tool_call_id-keyed reply, converted to Responses items.
+        resp = {"output": [{"type": "function_call", "call_id": "rid", "name": "fetch",
+                            "arguments": json.dumps({"url": "http://x"})}], "status": "completed"}
+        msg = harvest._responses_resp_to_oai(resp)["choices"][0]["message"]
+        tool_msg = {"role": "tool", "tool_call_id": "rid", "content": "fetched body"}
+        _i, items = harvest._oai_messages_to_responses([msg, tool_msg])
+        self.assertEqual(items[0]["type"], "function_call")
+        self.assertEqual(items[1], {"type": "function_call_output", "call_id": "rid", "output": "fetched body"})
+
+
+class TestResponsesGatewayClient(unittest.TestCase):
+    def test_complete_posts_to_responses_endpoint(self):
+        client = harvest.ResponsesGatewayClient("http://gw", "key", "gpt-5.4", 5, 16384)
+        ok_response = {"output": [{"type": "message", "content": [{"type": "output_text", "text": "hi"}]}],
+                       "status": "completed"}
+        with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response) as m:
+            result = client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        self.assertEqual(result["choices"][0]["message"]["content"], "hi")
+        url = m.call_args[0][0]
+        self.assertTrue(url.endswith("/responses"))
+
+    def test_complete_sets_max_output_tokens(self):
+        client = harvest.ResponsesGatewayClient("http://gw", "key", "gpt-5.4", 5, 9999)
+        ok_response = {"output": [], "status": "completed"}
+        with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response) as m:
+            client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        payload = m.call_args[0][1]
+        self.assertEqual(payload["max_output_tokens"], 9999)
+
+    def test_truncated_output_surfaces_as_incomplete_not_silently_swallowed(self):
+        # plan-review MUST FIX-2: a findings JSON cut off by an output cap
+        # must be *observable* (finish_reason carries "incomplete", the
+        # chopped text is still returned) rather than silently dropped --
+        # parse_findings_json then legitimately fails on the truncated
+        # candidate, same failure mode the Anthropic path already has via
+        # stop_reason="max_tokens".
+        client = harvest.ResponsesGatewayClient("http://gw", "key", "gpt-5.4", 5, 64)
+        truncated_response = {
+            "output": [{"type": "message", "content": [
+                {"type": "output_text", "text": '{"claims": [{"claim": "A", "excerpt": "e", "url": "u'}
+            ]}],
+            "status": "incomplete",
+        }
+        with mock.patch("harvest._http_json_post_with_retry", return_value=truncated_response) as m:
+            result = client.complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        self.assertEqual(m.call_args[0][1]["max_output_tokens"], 64)
+        self.assertEqual(result["choices"][0]["finish_reason"], "incomplete")
+        content = result["choices"][0]["message"]["content"]
+        data, err = harvest.parse_findings_json(content)
+        self.assertIsNone(data)
+        self.assertIsNotNone(err)
+
+    def test_complete_omits_tools_field_when_none(self):
+        # Judge path (judge_clusters) calls complete(messages, tools=None) --
+        # the Responses payload must not carry a tools key at all.
+        client = harvest.ResponsesGatewayClient("http://gw", "key", "gpt-5.4", 5, 16384)
+        ok_response = {"output": [{"type": "message", "content": [{"type": "output_text", "text": "j"}]}],
+                       "status": "completed"}
+        with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response) as m:
+            client.complete(messages=[{"role": "system", "content": "sys"},
+                                       {"role": "user", "content": "judge input"}], tools=None)
+        payload = m.call_args[0][1]
+        self.assertNotIn("tools", payload)
+        self.assertEqual(payload["instructions"], "sys")
+
+    def test_complete_includes_tools_when_present(self):
+        client = harvest.ResponsesGatewayClient("http://gw", "key", "gpt-5.4", 5, 16384)
+        ok_response = {"output": [], "status": "completed"}
+        with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response) as m:
+            client.complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        payload = m.call_args[0][1]
+        self.assertEqual(len(payload["tools"]), len(harvest.TOOL_SCHEMAS))
+        self.assertEqual(payload["tools"][0]["type"], "function")
+
+    def test_judge_clusters_end_to_end_with_responses_client(self):
+        # judge_clusters(judge_client, ...) passes tools=None -- exercise the
+        # real call path (not just complete()) to prove the judge's
+        # nothing-but-text round-trip survives a ResponsesGatewayClient.
+        client = harvest.ResponsesGatewayClient("http://gw", "key", "gpt-5.4", 5, 16384)
+        judge_text = '```json\n{"clusters": [{"summary": "s", "source_claim_ids": ["m1-1"], "relation": "agree"}]}\n```'
+        ok_response = {"output": [{"type": "message", "content": [{"type": "output_text", "text": judge_text}]}],
+                       "status": "completed"}
+        worker_findings = {"m1": {"claims": [{"_id": "m1-1", "claim": "A", "excerpt": "e", "url": "u"}]}}
+        with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response) as m:
+            data, err = harvest.judge_clusters(client, worker_findings)
+        self.assertIsNone(err)
+        self.assertEqual(data["clusters"][0]["source_claim_ids"], ["m1-1"])
+        payload = m.call_args[0][1]
+        self.assertNotIn("tools", payload)
+
+
+class TestAnthropicEffortInjection(unittest.TestCase):
+    def test_effort_none_omits_output_config(self):
+        client = harvest.AnthropicGatewayClient("http://gw", "key", "claude-sonnet-5", 5, 16384, effort=None)
+        ok_response = {"content": [{"type": "text", "text": "hi"}], "stop_reason": "end_turn"}
+        with mock.patch("harvest._anthropic_post_with_retry", return_value=ok_response) as m:
+            client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        payload = m.call_args[0][1]
+        self.assertNotIn("output_config", payload)
+
+    def test_effort_medium_injects_output_config(self):
+        client = harvest.AnthropicGatewayClient("http://gw", "key", "claude-sonnet-5", 5, 16384, effort="medium")
+        ok_response = {"content": [{"type": "text", "text": "hi"}], "stop_reason": "end_turn"}
+        with mock.patch("harvest._anthropic_post_with_retry", return_value=ok_response) as m:
+            client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        payload = m.call_args[0][1]
+        self.assertEqual(payload["output_config"], {"effort": "medium"})
+
+    def test_effort_high_injects_output_config_high(self):
+        client = harvest.AnthropicGatewayClient("http://gw", "key", "claude-sonnet-5", 5, 16384, effort="high")
+        ok_response = {"content": [{"type": "text", "text": "hi"}], "stop_reason": "end_turn"}
+        with mock.patch("harvest._anthropic_post_with_retry", return_value=ok_response) as m:
+            client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        payload = m.call_args[0][1]
+        self.assertEqual(payload["output_config"], {"effort": "high"})
+
+
+class TestMakeClientFactoryThreeWayDispatch(unittest.TestCase):
+    def setUp(self):
+        self.env_patcher = mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "secret"})
+        self.env_patcher.start()
+        self.addCleanup(self.env_patcher.stop)
+
+    def test_claude_dispatches_to_anthropic_client(self):
+        factory = harvest.make_client_factory(base_config())
+        client = factory("claude-sonnet-5")
+        self.assertIsInstance(client, harvest.AnthropicGatewayClient)
+
+    def test_gpt_dispatches_to_responses_client(self):
+        factory = harvest.make_client_factory(base_config())
+        client = factory("gpt-5.4")
+        self.assertIsInstance(client, harvest.ResponsesGatewayClient)
+
+    def test_gemini_dispatches_to_plain_gateway_client(self):
+        factory = harvest.make_client_factory(base_config())
+        client = factory("gemini-3.5-flash")
+        self.assertIsInstance(client, harvest.GatewayClient)
+        self.assertNotIsInstance(client, harvest.ResponsesGatewayClient)
+
+    def test_claude_effort_defaults_to_medium(self):
+        # No limits.claude_effort key in base_config() at all -- this is the
+        # "old config missing the new key" case ADR-011 calls out as a
+        # deliberate global default *lowering* to medium, not a no-op.
+        factory = harvest.make_client_factory(base_config())
+        client = factory("claude-sonnet-5")
+        self.assertEqual(client.effort, "medium")
+
+    def test_claude_effort_explicit_config_value_respected(self):
+        config = base_config()
+        config["limits"] = dict(config["limits"], claude_effort="high")
+        factory = harvest.make_client_factory(config)
+        client = factory("claude-sonnet-5")
+        self.assertEqual(client.effort, "high")
+
+    def test_responses_client_max_output_tokens_mirrors_completion_max_tokens(self):
+        config = base_config()
+        config["limits"] = dict(config["limits"], completion_max_tokens=12345)
+        factory = harvest.make_client_factory(config)
+        client = factory("gpt-5.4")
+        self.assertEqual(client.max_output_tokens, 12345)
+
+    def test_gpt_endpoint_config_switch_falls_back_to_chat_completions(self):
+        config = base_config()
+        config["limits"] = dict(config["limits"], gpt_endpoint="chat_completions")
+        factory = harvest.make_client_factory(config)
+        client = factory("gpt-5.4")
+        self.assertIsInstance(client, harvest.GatewayClient)
+        self.assertNotIsInstance(client, harvest.ResponsesGatewayClient)
+
+    def test_old_config_missing_all_new_keys_does_not_raise(self):
+        # base_config()'s "limits" dict has neither claude_effort nor
+        # gpt_endpoint -- constructing all three client types must not
+        # KeyError.
+        config = base_config()
+        self.assertNotIn("claude_effort", config["limits"])
+        self.assertNotIn("gpt_endpoint", config["limits"])
+        factory = harvest.make_client_factory(config)
+        factory("claude-sonnet-5")
+        factory("gpt-5.4")
+        factory("gemini-3.5-flash")
+
+    def test_judge_fallback_mixes_responses_client_with_tools_none(self):
+        # run_judge_with_fallback can route a candidate to a gpt model ->
+        # ResponsesGatewayClient with tools=None (judge_clusters never
+        # passes tools) -- exercise that combination through the real
+        # dispatch+call path.
+        config = base_config(judge_model="gpt-5.4", panel_models=["gpt-5.4", "model-b"])
+        factory = harvest.make_client_factory(config)
+        judge_text = '```json\n{"clusters": [{"summary": "s", "source_claim_ids": ["m1-1"], "relation": "agree"}]}\n```'
+        ok_response = {"output": [{"type": "message", "content": [{"type": "output_text", "text": judge_text}]}],
+                       "status": "completed"}
+        worker_findings = {"m1": {"claims": [{"_id": "m1-1", "claim": "A", "excerpt": "e", "url": "u"}]}}
+        with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response):
+            data, err = harvest.run_judge_with_fallback(config, factory, worker_findings, config["panel_models"])
+        self.assertIsNone(err)
+        self.assertEqual(data["clusters"][0]["source_claim_ids"], ["m1-1"])
+
+
+# ---------------------------------------------------------------------------
 # #64: completion-call retry schedule + forced-synthesis recovery on
 # exhausted retries
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `ResponsesGatewayClient` (OpenAI Responses API `/responses`), sharing the `complete(messages, tools) -> OpenAI-choices-shaped dict` contract with existing `GatewayClient`/`AnthropicGatewayClient`. Includes module-level pure protocol-conversion functions (`_oai_messages_to_responses`, `_responses_resp_to_oai`, `_oai_tools_to_responses`), explicit `max_output_tokens` (mirrors `completion_max_tokens`, prevents silent truncation of long findings JSON), and a config-controlled endpoint fallback (`limits.gpt_endpoint`, default `responses`, revertible to `chat/completions`) since the cache-hit behavior is gateway-instance-affinity, not a portable OpenAI guarantee.
- `make_client_factory` three-way dispatch: `claude*` → Anthropic, `gpt*` → Responses, else → GatewayClient (gemini path untouched).
- `AnthropicGatewayClient` now injects `output_config.effort` from new config key `limits.claude_effort`, defaulting to `medium`. This is a deliberate global default lowering (previously implicit `high`), not a behavior-preserving change — documented in code and accepted as a tradeoff per ADR-011.
- Plugin version bump 1.7.1 → 1.8.0 (`plugin.json` + `marketplace.json`, double-synced).

Design decision record: ADR-011 (research repo), plan-review APPROVED @ revision 1, code-review APPROVED @ fix 0 (6-dim BDA all PASS, 2 non-blocking suggestions — no action needed in this PR).

## Test plan

- [x] Baseline 306 harvest tests green before any change
- [x] 341 passed, 0 failed after implementation (35 new tests: Responses protocol conversion round-trips incl. parallel function_call + tool_result feedback, `tools=None` judge path, output-truncation boundary, effort injection, three-way factory dispatch, old-config back-compat with no KeyError)
- [x] Real wall-clock probe against the live gateway (not mocked) proving `cached_tokens>0` under stateless, full-resend, growing-messages calling shape matching `run_worker`'s real pattern: cached_tokens measured 0 → 0 → 2816 → 3968 → 1536 across 5 growing turns
- [x] `--no-api` local-mode isolation confirmed (zero code-path overlap with `make_client_factory`)