### PR TITLE
feat(doc-gate): 路径排除收敛单一来源 + pipeline 排除 (v1.5.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
     {
       "name": "doc-gate",
       "description": "Document editing governance — doc-maintenance skill + hard gate + recall advisory",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/doc-gate/.claude-plugin/plugin.json
+++ b/plugins/doc-gate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "doc-gate",
   "description": "Document editing governance — doc-maintenance skill + hard gate + recall advisory",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": { "name": "woodragon" },
   "skills": ["./skills/doc-maintenance"]
 }

--- a/plugins/doc-gate/README.md
+++ b/plugins/doc-gate/README.md
@@ -70,9 +70,11 @@ Both gates skip files that shouldn't be governed:
 | Category | Examples |
 |----------|---------|
 | **Basename** | `MEMORY.md`, `SKILL.md`, `CHANGELOG.md`, `LICENSE.md` (case-insensitive) |
-| **Path** | `.claude/*`, `.claude-plugin/*`, `.agents/directives/*`, `node_modules/*`, `.git/*` |
+| **Path** | `.claude/*`, `.claude-plugin/*`, `.agents/directives/*`, `node_modules/*`, `.git/*`, `logs/*`, `pipeline/*` |
 | **Temp dirs** | `/tmp/*`, `/var/tmp/*`, `/var/folders/*`, `/private/tmp/*` |
 | **Non-.md** | Any file not ending in `.md` (case-insensitive) |
+
+`pipeline/*` covers deep-research's machine-generated intermediate artifacts (e.g. `pipeline/verification/*.json`-adjacent notes) — the doc-maintenance workflow doesn't apply to them. `deliverables/*` is intentionally **not** excluded: final research output is prose documentation and stays governed. Both gates share this exclusion list from a single source, `scripts/_doc_gate_exclude.sh` (and its `EXCLUDED_DIRS` mirror in `tools/_doc_gate_common.py` for the recall-gate link graph) — add new exclusions there, not per-script.
 
 **Exception**: `~/.claude/CLAUDE.md` is always gated despite living under `.claude/` — it's the global config with the highest pollution surface.
 
@@ -154,15 +156,18 @@ python3 -m unittest tests/test_recall_gate.py -v
 
 | Suite | Tests | Coverage |
 |-------|-------|----------|
-| `skill-gate.bats` | 54 | Filters, exclusions, gate enforcement, fail-open, CLAUDE.md governance, stale cleanup, e2e |
+| `skill-gate.bats` | 57 | Filters, exclusions, gate enforcement, fail-open, CLAUDE.md governance, stale cleanup, e2e |
 | `skill-marker.bats` | 13 | Tracked/untracked skills, marker creation, namespacing, kill switch |
 | `recall-gate.bats` | 37 | Filters, kill switch, fail-open, markers, double-deny, BM25 integration, orphan, broken outlinks, monorepo root detection, e2e |
+| `exclude.bats` | 8 | Shared `_doc_gate_exclude.sh` predicate — pipeline/logs/tmp/git/node_modules excluded, deliverables/docs/CLAUDE.md governed |
 | `test_recall_gate.py` | 67 | Tokenization, BM25 scoring, link extraction/resolution, corpus building, orphan/broken checks, cmd_gate output, detect_root |
+| `test_exclude.py` | 1 | `build_corpus_and_graph` excludes `pipeline/`, includes `deliverables/` and `docs/` |
 
 ## Version History
 
 See [GitHub Issues](https://github.com/WooDragon/cc-plugins/issues) for detailed change logs:
 
+- **v1.5.0** — Path exclusions collapsed to single source (`_doc_gate_exclude.sh`); added `pipeline/*` exclusion for deep-research intermediate artifacts, `deliverables/*` remains governed
 - **v1.2.1** — Root detection: CLAUDE.md co-occurrence anchor for monorepo support (#22)
 - **v1.2.0** — Recall gate: BM25 lexical recall + link graph triple-dimension gate
 - **v1.0.4** — Deny message discourages env-var bypass

--- a/plugins/doc-gate/scripts/_doc_gate_exclude.sh
+++ b/plugins/doc-gate/scripts/_doc_gate_exclude.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# doc-gate 路径排除单一来源 — skill-gate.sh / recall-gate.sh 共享。
+# 新增排除只改此处；对齐 tools/_doc_gate_common.py 的 EXCLUDED_DIRS 设计意图。
+# 命中排除→return 0；否则→return 1。
+doc_gate_is_excluded_path() {
+  local fp="$1"
+  # location 排除（prepend / 统一处理相对路径）
+  # pipeline: deep-research 机器生成中间产物，doc-maintenance 工作流不适用。
+  # deliverables 刻意【不】排除——最终交付散文档受治理。
+  case "/$fp" in
+    */.claude/*|*/.claude-plugin/*|*/.agents/directives/*|*/node_modules/*|*/.git/*|*/logs/*|*/pipeline/*) return 0 ;;
+  esac
+  # 临时目录排除（绝对路径直配）
+  case "$fp" in
+    /tmp/*|/var/tmp/*|/var/folders/*|/private/tmp/*) return 0 ;;
+  esac
+  return 1
+}

--- a/plugins/doc-gate/scripts/recall-gate.sh
+++ b/plugins/doc-gate/scripts/recall-gate.sh
@@ -17,6 +17,8 @@
 #   SKILL_GATE_DISABLED          — if "1", recall-gate acts independently (no double-deny guard)
 set -euo pipefail
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_doc_gate_exclude.sh"
+
 _log() {
   local log_dir="${SKILL_GATE_LOG_DIR:-${REVIEW_LOG_DIR:-$HOME/.claude/logs}}"
   mkdir -p "$log_dir" 2>/dev/null || return
@@ -57,12 +59,7 @@ _main() {
   shopt -u nocasematch
 
   # Phase 6: Path exclusions
-  case "/$FILE_PATH" in
-    */.claude/*|*/.claude-plugin/*|*/.agents/directives/*|*/node_modules/*|*/.git/*|*/logs/*) return ;;
-  esac
-  case "$FILE_PATH" in
-    /tmp/*|/var/tmp/*|/var/folders/*|/private/tmp/*) return ;;
-  esac
+  if doc_gate_is_excluded_path "$FILE_PATH"; then return; fi
 
   GATE_DIR="${SKILL_GATE_DIR:-/tmp/claude-reviews}"
   STALE_MIN="${RECALL_GATE_STALE_MIN:-120}"

--- a/plugins/doc-gate/scripts/skill-gate.sh
+++ b/plugins/doc-gate/scripts/skill-gate.sh
@@ -11,6 +11,8 @@
 #   SKILL_GATE_STALE_MIN        — marker stale threshold minutes (default: 120)
 set -euo pipefail
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_doc_gate_exclude.sh"
+
 _log() {
   local log_dir="${SKILL_GATE_LOG_DIR:-${REVIEW_LOG_DIR:-$HOME/.claude/logs}}"
   mkdir -p "$log_dir" 2>/dev/null || return
@@ -68,14 +70,7 @@ _main() {
   # identity is established it must gate unconditionally, no matter where $HOME
   # lives (a containerized/test HOME under /tmp must not slip through either).
   if [ "$IS_GLOBAL_CLAUDE" != "1" ]; then
-    # Path exclusions (prepend / to handle relative paths uniformly)
-    case "/$FILE_PATH" in
-      */.claude/*|*/.claude-plugin/*|*/.agents/directives/*|*/node_modules/*|*/.git/*) return ;;
-    esac
-    # Temporary directory exclusions (match absolute paths directly)
-    case "$FILE_PATH" in
-      /tmp/*|/var/tmp/*|/var/folders/*|/private/tmp/*) return ;;
-    esac
+    if doc_gate_is_excluded_path "$FILE_PATH"; then return; fi
   fi
 
   # Path sanitization (match skill-marker.sh convention)

--- a/plugins/doc-gate/tests/exclude.bats
+++ b/plugins/doc-gate/tests/exclude.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# BDD tests for _doc_gate_exclude.sh (shared path-exclusion predicate)
+
+setup() {
+  source "${BATS_TEST_DIRNAME}/../scripts/_doc_gate_exclude.sh"
+}
+
+# ============================================================
+# Excluded (return 0)
+# ============================================================
+
+@test "excluded: pipeline/verification/x.md (deep-research intermediate)" {
+  run doc_gate_is_excluded_path "/project/pipeline/verification/x.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "excluded: logs/run.md" {
+  run doc_gate_is_excluded_path "/project/logs/run.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "excluded: /tmp/foo.md" {
+  run doc_gate_is_excluded_path "/tmp/foo.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "excluded: .git/COMMIT_EDITMSG" {
+  run doc_gate_is_excluded_path "/project/.git/COMMIT_EDITMSG"
+  [ "$status" -eq 0 ]
+}
+
+@test "excluded: node_modules/pkg/readme.md" {
+  run doc_gate_is_excluded_path "/project/node_modules/pkg/readme.md"
+  [ "$status" -eq 0 ]
+}
+
+# ============================================================
+# NOT excluded (return 1) — deliverables stays governed
+# ============================================================
+
+@test "not excluded: deliverables/final/report.md (final deliverable, governed)" {
+  run doc_gate_is_excluded_path "/project/deliverables/final/report.md"
+  [ "$status" -eq 1 ]
+}
+
+@test "not excluded: docs/guide.md" {
+  run doc_gate_is_excluded_path "/project/docs/guide.md"
+  [ "$status" -eq 1 ]
+}
+
+@test "not excluded: CLAUDE.md" {
+  run doc_gate_is_excluded_path "/project/CLAUDE.md"
+  [ "$status" -eq 1 ]
+}

--- a/plugins/doc-gate/tests/skill-gate.bats
+++ b/plugins/doc-gate/tests/skill-gate.bats
@@ -175,6 +175,25 @@ teardown() {
   assert_allowed
 }
 
+@test "path exclude: pipeline/verification/x.md → silent allow (deep-research intermediate)" {
+  INPUT=$(build_edit_input file_path=/project/pipeline/verification/x.md)
+  run_gate
+  assert_allowed
+  [ -z "$HOOK_STDOUT" ]
+}
+
+@test "gate: deliverables/final/report.md without marker → deny (final deliverable, governed)" {
+  INPUT=$(build_edit_input file_path=/project/deliverables/final/report.md)
+  run_gate
+  assert_deny_json
+}
+
+@test "path exclude: logs/run.md → silent allow (drift regression)" {
+  INPUT=$(build_edit_input file_path=/project/logs/run.md)
+  run_gate
+  assert_allowed
+}
+
 # ============================================================
 # Gate enforcement — no marker
 # ============================================================

--- a/plugins/doc-gate/tests/test_exclude.py
+++ b/plugins/doc-gate/tests/test_exclude.py
@@ -1,0 +1,41 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+# recall-gate.py has a hyphen in its filename, so it can't be imported via
+# plain `import` — load it by file path instead. _doc_gate_common must be on
+# sys.path first since recall-gate.py imports it by bare module name.
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+sys.path.insert(0, str(_TOOLS_DIR))
+_spec = importlib.util.spec_from_file_location("recall_gate", _TOOLS_DIR / "recall-gate.py")
+recall_gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(recall_gate)
+build_corpus_and_graph = recall_gate.build_corpus_and_graph
+
+
+def _write(path: Path, title: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"# {title}\n\n这是正文一句话。\n", encoding="utf-8")
+
+
+def test_pipeline_excluded_deliverables_and_docs_included(tmp_path):
+    _write(tmp_path / "pipeline" / "verification" / "a.md", "pipeline intermediate")
+    _write(tmp_path / "deliverables" / "final" / "report.md", "final report")
+    _write(tmp_path / "docs" / "guide.md", "guide")
+
+    corpus, all_files, _forward, _backward = build_corpus_and_graph(str(tmp_path))
+
+    corpus_paths = {doc["path"] for doc in corpus}
+
+    pipeline_rel = str(Path("pipeline") / "verification" / "a.md")
+    deliverables_rel = str(Path("deliverables") / "final" / "report.md")
+    docs_rel = str(Path("docs") / "guide.md")
+
+    assert pipeline_rel not in all_files
+    assert pipeline_rel not in corpus_paths
+
+    assert deliverables_rel in all_files
+    assert deliverables_rel in corpus_paths
+
+    assert docs_rel in all_files
+    assert docs_rel in corpus_paths

--- a/plugins/doc-gate/tools/_doc_gate_common.py
+++ b/plugins/doc-gate/tools/_doc_gate_common.py
@@ -16,8 +16,10 @@ from pathlib import Path
 
 # 扫描时排除的目录（路径部件匹配，非子串）。
 # .claude / logs 为 #23 降噪新增：工具产物、会话日志不应进文档引用图。
+# pipeline 为 deep-research 机器生成中间产物，同样不应进文档引用图；
+# deliverables（最终交付）刻意不在此列——它仍需可被 recall 索引。
 EXCLUDED_DIRS = {'.git', '.agents', 'node_modules', '.venv', 'research',
-                 'docs-graph-tests', '.claude', 'logs'}
+                 'docs-graph-tests', '.claude', 'logs', 'pipeline'}
 
 # orphans 白名单（文件名匹配）：索引 / 入口文件天然无入链，不报孤儿。
 ORPHAN_WHITELIST = {'CLAUDE.md', 'README.md', 'MEMORY.md'}


### PR DESCRIPTION
## Summary
- 将 `skill-gate.sh` / `recall-gate.sh` 各自硬编码且已漂移的路径排除 case 收敛到共享单一来源 `plugins/doc-gate/scripts/_doc_gate_exclude.sh`，修掉此前 recall-gate 有 `logs/*` 排除而 skill-gate 没有的漂移。
- 新增 `pipeline/*` 排除：deep-research 机器生成的中间产物不适用 doc-maintenance 工作流，不该进文档门禁。
- `deliverables/*` 刻意**保留**门禁——最终交付的散文档仍受治理，不在排除名单内。
- `plugins/doc-gate/tools/_doc_gate_common.py` 的 `EXCLUDED_DIRS` 同步加入 `pipeline`，与两个 shell hook 排除名单三处保持一致。
- 版本双同步：`plugins/doc-gate/.claude-plugin/plugin.json` 与仓根 `.claude-plugin/marketplace.json` 均 1.4.0 → 1.5.0。
- README 更新排除名单说明与版本历史。

设计取舍：deliverables 目录虽然也是 deep-research 产物，但其内容是面向人阅读的最终研究报告（prose documentation），与 pipeline 下的中间态机器产物性质不同，因此保留文档治理门禁，不加入排除名单。

对应 research 仓的一个 issue（描述见 commit message，未在此 PR 建立跨仓库引用）。

## Test plan
- [x] `bats tests/`（doc-gate 目录）：78 个测试全绿，含新增 `exclude.bats`（8 个直测排除谓词的用例）与 `skill-gate.bats` 新增 3 个集成回归用例（pipeline→allow、deliverables→deny、logs→allow）
- [x] `pytest tests/test_exclude.py -v`：新增用例验证 `build_corpus_and_graph` 在 pipeline 下的文件不进 corpus/all_files，deliverables 与 docs 下的文件正常纳入