### PR TITLE
fix(harvest): curl-cffi 识别反爬 JS 挑战页并降级 (v1.8.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -902,6 +902,65 @@ def _strip_html_to_text(raw_html):
 _CURL_CFFI_MAX_REDIRECT_HOPS = 3
 _CURL_CFFI_REDIRECT_STATUSES = (301, 302, 303, 307, 308)
 
+# curl_cffi impersonates a real browser's TLS/HTTP fingerprint but cannot
+# execute JavaScript -- so when a WAF (Cloudflare/DataDome/PerimeterX/
+# Imperva) serves a JS challenge ("holding page"), curl_cffi gets exactly
+# that holding page back as its final response, not the article. Without
+# this check, that holding page's body (often HTTP 200, sometimes 403/503)
+# is silently stripped-to-text and returned as if it were real page
+# content, poisoning the downstream citation-verification pipeline with
+# challenge-script prose that happens to contain no obvious HTTP error.
+# See issue #81.
+#
+# Markers are deliberately script paths / JS globals / DOM ids / CDN
+# domains -- unique implementation artifacts of the challenge widgets
+# themselves -- rather than human-readable phrases like "checking your
+# browser" or "just a moment". Human phrases appear verbatim in ordinary
+# prose (news articles about Cloudflare outages, blog posts explaining
+# Turnstile, this very code review) and would cause false positives;
+# the literal script/DOM/CDN artifacts below only ever appear when the
+# actual vendor widget markup is present on the page.
+_CHALLENGE_PAGE_MARKERS = (
+    # Cloudflare (challenge-platform script, browser-verification banner,
+    # the cf_chl_opt JS config object, Turnstile widget, _cf_chl JS global)
+    "/cdn-cgi/challenge-platform/",
+    "cf-browser-verification",
+    "_cf_chl_opt",
+    "cf-turnstile",
+    "window._cf_chl",
+    # DataDome (captcha delivery CDN the challenge script loads from)
+    "captcha-delivery.com",
+    # PerimeterX / HUMAN (captcha widget id, JS app-id global)
+    "px-captcha",
+    "window._pxappid",
+    # Imperva / Incapsula (challenge resource endpoint)
+    "_incapsula_resource",
+)
+
+# Challenge/holding pages are minimal (a script tag, a spinner, a couple
+# of divs) -- always tiny, never anywhere near fetch_max_chars territory.
+# Real long-form content that happens to discuss these vendors (e.g. a
+# deep-research task investigating WAF/Turnstile bypass techniques, or an
+# article with an embedded code sample) can legitimately contain these
+# same artifact strings inside tens of KB of genuine prose. This gate lets
+# such long-form pages through unconditionally while still catching even
+# a bloated/verbose challenge page, since real-world challenge HTML has
+# never been observed anywhere close to 100KB.
+_CHALLENGE_MAX_PAGE_CHARS = 100 * 1024
+
+
+def _looks_like_challenge_page(raw_html):
+    # resp.text can be None or "" (empty body, e.g. a HEAD-like 204, or a
+    # decode that yielded nothing) -- guard first, since .lower() on None
+    # would raise AttributeError and take curl-cffi out of rotation via
+    # call_fetch_backend's broad except instead of cleanly degrading.
+    if not raw_html:
+        return False
+    if len(raw_html) >= _CHALLENGE_MAX_PAGE_CHARS:
+        return False
+    lowered = raw_html.lower()
+    return any(marker in lowered for marker in _CHALLENGE_PAGE_MARKERS)
+
 
 def _fetch_curl_cffi(cfg, url, timeout, max_chars, config):
     # libcurl (which curl_cffi wraps via C bindings) does its own DNS
@@ -986,6 +1045,17 @@ def _fetch_curl_cffi(cfg, url, timeout, max_chars, config):
             text = resp.text
         except Exception as e:
             return None, f"curl-cffi: failed to decode response body: {e}"
+        # Gate 1: challenge page first, regardless of status code -- a
+        # Cloudflare/DataDome/etc holding page served with 403/503 must be
+        # reported as a challenge, not swallowed by the generic HTTP-error
+        # gate below (which would lose the actual root cause from
+        # telemetry: "anti-bot challenge" vs. "some 403").
+        if _looks_like_challenge_page(text):
+            return None, "curl-cffi: anti-bot JS challenge page (needs a JS-capable backend)"
+        # Gate 2: an ordinary error page (403/404/5xx, no challenge marker)
+        # is also not article content -- refuse to return its body too.
+        if not (200 <= resp.status_code < 300):
+            return None, f"curl-cffi: HTTP {resp.status_code}"
         return _strip_html_to_text(text), None
     return None, f"curl-cffi: exceeded max redirect hops ({_CURL_CFFI_MAX_REDIRECT_HOPS})"
 

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -1536,6 +1536,94 @@ class TestCurlCffiFetch(unittest.TestCase):
         self.assertIsNone(reason)
         self.assertIn("legacy ok", result)
 
+    def test_non_2xx_terminal_status_degrades_without_returning_body(self):
+        # No challenge marker in the body -- this is gate 2 (plain HTTP
+        # error), not gate 1. The body text must not leak into the reason.
+        with mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(403, "<html>Access Denied</html>")):
+            result, reason = self._fetch("https://a.com/x")
+        self.assertIsNone(result)
+        self.assertIn("HTTP 403", reason)
+        self.assertNotIn("Access Denied", reason)
+
+    def test_cloudflare_challenge_200_degrades(self):
+        body = "<html><body><script src='/cdn-cgi/challenge-platform/h/g'></script></body></html>"
+        with mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(200, body)):
+            result, reason = self._fetch("https://a.com/x")
+        self.assertIsNone(result)
+        self.assertIn("challenge", reason)
+
+    def test_cloudflare_challenge_403_reports_challenge_not_http_error(self):
+        # Locks down gate ordering: challenge detection (gate 1) must fire
+        # before the generic HTTP-status gate (gate 2), even on a 403.
+        body = "<html><body><script src='/cdn-cgi/challenge-platform/h/g'></script></body></html>"
+        with mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(403, body)):
+            result, reason = self._fetch("https://a.com/x")
+        self.assertIsNone(result)
+        self.assertIn("challenge", reason)
+        self.assertNotIn("HTTP 403", reason)
+
+    def test_datadome_challenge_degrades(self):
+        body = "<html><body><script src='https://ct.captcha-delivery.com/c.js'></script></body></html>"
+        with mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(200, body)):
+            result, reason = self._fetch("https://a.com/x")
+        self.assertIsNone(result)
+        self.assertIn("challenge", reason)
+
+    def test_perimeterx_challenge_degrades(self):
+        body = "<html><body><div id='px-captcha'></div></body></html>"
+        with mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(200, body)):
+            result, reason = self._fetch("https://a.com/x")
+        self.assertIsNone(result)
+        self.assertIn("challenge", reason)
+
+    def test_imperva_challenge_degrades(self):
+        # Mixed case in the source, verifying marker matching is
+        # case-insensitive.
+        body = "<html><body><div id='_Incapsula_Resource'></div></body></html>"
+        with mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(200, body)):
+            result, reason = self._fetch("https://a.com/x")
+        self.assertIsNone(result)
+        self.assertIn("challenge", reason)
+
+    def test_large_page_with_marker_not_flagged(self):
+        # A long-form article discussing Cloudflare Turnstile (e.g. a
+        # deep-research task investigating WAF bypass techniques) must not
+        # be misdetected as a challenge page just because it mentions
+        # "cf-turnstile" -- the size gate lets anything >= 100KB through.
+        body = "<p>" + "Cloudflare Turnstile 分析。" * 20000 + " cf-turnstile </p>"
+        self.assertGreaterEqual(len(body), 100 * 1024)
+        with mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(200, body)):
+            result, reason = self._fetch("https://a.com/x")
+        self.assertIsNone(reason)
+        self.assertIn("Cloudflare Turnstile", result)
+
+    def test_empty_body_does_not_crash(self):
+        with mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(200, "")):
+            result, reason = self._fetch("https://a.com/x")
+        self.assertIsNone(reason)
+        self.assertEqual(result, "")
+        self.assertFalse(harvest._looks_like_challenge_page(None))
+        self.assertFalse(harvest._looks_like_challenge_page(""))
+
+    def test_small_page_quoting_challenge_prose_not_flagged(self):
+        # Human-readable phrases like "just a moment" or vendor names like
+        # "datadome" appearing in ordinary prose must not trigger a false
+        # positive -- only the literal script/DOM/CDN artifacts do.
+        body = "<p>Just a moment while we discuss the datadome product review.</p>"
+        with mock.patch("harvest.curl_cffi_requests.get",
+                         return_value=FakeCurlResponse(200, body)):
+            result, reason = self._fetch("https://a.com/x")
+        self.assertIsNone(reason)
+        self.assertIn("Just a moment", result)
+
 
 class TestCurlCffiStartupCheck(unittest.TestCase):
     """_check_curl_cffi_available() is the fail-fast gate: if the backend is


### PR DESCRIPTION
## 背景

Issue #81 标题的 "5MB 硬编码" 已被 #76 修掉。真正未修的是其标 "推断（未实锤)" 的深层根因：

Cloudflare 等 WAF 的 JS 挑战页以 HTTP 200/403/503 返回一张 holding page（body 是挑战脚本而非正文）。curl_cffi 伪装 TLS 指纹能过被动检测，但跑不了挑战 JS，拿到的永远是这张过渡页——却被 `_fetch_curl_cffi` 当正文 strip 后返回，**污染下游引用验证管线**（一条 claim 会"验证"通过一张只写着"请启用 JavaScript"的页面）。

## 改动

`_fetch_curl_cffi` 非重定向路径新增两道门（顺序锁死）：

1. **门①（先，无视状态码）**：`_looks_like_challenge_page` 命中主流 WAF 的脚本/JS全局/DOM/CDN artifact marker → 降级到下一 backend（jina/tavily 服务端跑真浏览器能过挑战），报明确 `anti-bot JS challenge page` 根因，而非被门②的泛泛 HTTP 错误掩盖（保住遥测根因）
2. **门②（后）**：非 2xx 的普通错误页（403/404/5xx，无 challenge marker）也不是正文，拒绝返回其 body

**marker 集合**（覆盖 Cloudflare / DataDome / PerimeterX / Imperva）只用挑战页 body 内确实存在的实现 artifact（脚本路径 / JS 全局 / DOM id / CDN 域名），**不用** "just a moment" 等人类可读短语。

**误杀防护**（关键）：deep-research 工具本身可能调研 "WAF/Turnstile 绕过"，技术长文正文/code 会高频含这些词。叠加 **100KB 大小闸门**——挑战页总是极小（纯 JS 脚手架），技术长文远超此值直接放行。`_looks_like_challenge_page` 另有 `None`/空 body 防御（避免 `.lower()` AttributeError 崩管线）。

## 测试

`test_harvest.py` `TestCurlCffiFetch` 新增 9 例：

- 门顺序锁死（403 挑战页 reason 为 `challenge` 而非 `HTTP 403`)
- 各 WAF 命中降级（CF / DataDome / PerimeterX / Imperva，含大小写不敏感)
- 大页面（>100KB）含 `cf-turnstile` **不误杀**
- 空 body 不崩溃
- 正文引用 "just a moment"/"datadome" 小页面 **不误杀**
- 非挑战 403 错误页降级且 reason 不泄漏 body

`TestCurlCffiFetch` 23/23、全量 `test_harvest` 350/350 通过。

## 版本

`plugin.json` + `marketplace.json` 双同步 `1.8.0 → 1.8.1`。

fix #81
