### PR TITLE
feat(harvest): gemini via Gemini-native generateContent (v1.9.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.8.1",
+      "version": "1.9.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest.config.json
+++ b/plugins/deep-research/scripts/harvest.config.json
@@ -55,6 +55,7 @@
     "completion_max_tokens": 16384,
     "claude_effort": "medium",
     "gpt_endpoint": "responses",
+    "gemini_endpoint": "native",
     "wall_clock_s": 1800,
     "quorum": 2,
     "search_min_interval_s": 2,

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -2103,8 +2103,8 @@ def make_client_factory(config):
     # provider swap makes /responses worse than plain /chat/completions,
     # config can flip this back to "chat_completions" without a code change
     # -- gpt* then falls through to the same plain GatewayClient path gemini
-    # already uses, rather than needing a second personality inside
-    # ResponsesGatewayClient itself.
+    # used before GeminiNativeGatewayClient existed, rather than needing a
+    # second personality inside ResponsesGatewayClient itself.
     gpt_endpoint = config.get("limits", {}).get("gpt_endpoint", "responses")
     # Same escape hatch pattern as gpt_endpoint, for the Gemini-native
     # generateContent path (see GeminiNativeGatewayClient's docstring): if

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -33,6 +33,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -1827,6 +1828,244 @@ class ResponsesGatewayClient:
         return _responses_resp_to_oai(resp)
 
 
+# ---------------------------------------------------------------------------
+# Gemini-native client (gemini models only)
+#
+# gemini models get a dedicated path to the gateway's Gemini-native
+# generateContent endpoint (not the OpenAI-compatible /chat/completions used
+# before) so that the gateway's implicit/automatic prefix caching -- the same
+# instance-affinity mechanism ADR-011 identified for gpt's /responses path --
+# has a chance to kick in. No explicit cachedContents are created here; this
+# only switches the wire protocol so a growing, resent-in-full message prefix
+# is *observable* to the gateway's own caching, whatever it turns out to be.
+# Same complete(messages, tools) -> OpenAI-shaped-dict interface as the other
+# two native clients, so run_worker/judge_clusters/run_judge_with_fallback
+# stay unchanged; all protocol translation is confined to the pure functions
+# below.
+# ---------------------------------------------------------------------------
+
+def _gemini_generate_content_url(base_url, model_id):
+    """Derive the Gemini-native generateContent URL from the gateway's
+    OpenAI-compat base_url. Unlike _search_gemini_grounding's urlsplit
+    (scheme://netloc only, which silently drops any path prefix between the
+    origin and '/v1'), this strips only a trailing '/v1' *suffix* so a
+    base_url like 'https://gw.corp.com/ai-proxy/v1' keeps its '/ai-proxy'
+    prefix intact."""
+    base = base_url.rstrip("/")
+    if base.endswith("/v1"):
+        base = base[: -len("/v1")]
+    return f"{base}/v1beta/models/{model_id}:generateContent"
+
+
+def _oai_tools_to_gemini(tools):
+    """OpenAI function-tool schema -> Gemini tool schema (a single entry
+    carrying all function declarations). Returns None for no tools (judge
+    path passes tools=None) so the caller omits the field entirely,
+    mirroring _oai_tools_to_anthropic/_oai_tools_to_responses."""
+    if not tools:
+        return None
+    declarations = []
+    for t in tools:
+        fn = t.get("function", {})
+        declarations.append({
+            "name": fn.get("name", ""),
+            "description": fn.get("description", ""),
+            "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
+        })
+    return [{"functionDeclarations": declarations}]
+
+
+def _append_gemini_user_parts(contents, parts):
+    """Append `parts` as a Gemini user turn, merging into a trailing user
+    turn if present. Gemini enforces alternating roles the same way
+    Anthropic does, so a run of consecutive tool results (each becoming a
+    functionResponse part) and any immediately-following user nudge must
+    collapse into one turn rather than producing back-to-back user turns."""
+    if not parts:
+        return
+    if contents and contents[-1]["role"] == "user":
+        contents[-1]["parts"].extend(parts)
+    else:
+        contents.append({"role": "user", "parts": parts})
+
+
+def _gemini_tool_response_payload(content):
+    """Parse an OpenAI tool message's `content` string into the dict Gemini's
+    functionResponse.response requires. content is JSON-decoded when
+    possible; a non-JSON string, or JSON that decodes to a non-dict (list/
+    bool/number), is wrapped as {"result": <value>} so the final payload is
+    always a dict."""
+    try:
+        parsed = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        return {"result": content}
+    if not isinstance(parsed, dict):
+        return {"result": parsed}
+    return parsed
+
+
+def _oai_messages_to_gemini(messages):
+    """OpenAI chat-messages -> (system_instruction, contents) for the Gemini
+    generateContent API. Mirrors _oai_messages_to_anthropic's role-by-role
+    walk but targets Gemini's parts/role shape.
+
+    - role=system    -> hoisted into `system_instruction` (multiple system
+      messages are concatenated with '\\n\\n', never overwritten by a later
+      one). None when there is no system message.
+    - role=assistant -> role "model"; text content becomes a text part,
+      each tool_call becomes a functionCall part.
+    - role=tool      -> OpenAI's tool message carries no function name, but
+      Gemini's functionResponse requires one, so a forward pass records
+      {tool_call_id: function_name} from every assistant tool_call seen so
+      far; a tool message whose tool_call_id has no recorded name means the
+      upstream message sequence itself violates the OpenAI contract, and
+      that is raised explicitly rather than papered over with an empty name.
+    - role=user/other -> role "user", text part.
+
+    Consecutive user-role turns (tool results, and tool results immediately
+    followed by a user nudge) are merged via _append_gemini_user_parts,
+    mirroring _oai_messages_to_anthropic's tool-result collapsing."""
+    system_parts = []
+    contents = []
+    call_id_to_name = {}
+    for msg in messages:
+        role = msg.get("role")
+        if role == "system":
+            content = msg.get("content")
+            if isinstance(content, str) and content:
+                system_parts.append(content)
+            continue
+        if role == "assistant":
+            parts = []
+            text = msg.get("content")
+            if isinstance(text, str) and text:
+                parts.append({"text": text})
+            for tc in (msg.get("tool_calls") or []):
+                fn = tc.get("function", {})
+                name = fn.get("name", "")
+                call_id_to_name[tc.get("id")] = name
+                try:
+                    args = json.loads(fn.get("arguments") or "{}")
+                except json.JSONDecodeError:
+                    args = {}
+                parts.append({"functionCall": {"name": name, "args": args}})
+            if not parts:
+                parts = [{"text": ""}]
+            contents.append({"role": "model", "parts": parts})
+            continue
+        if role == "tool":
+            call_id = msg.get("tool_call_id")
+            name = call_id_to_name.get(call_id)
+            if name is None:
+                raise ValueError(
+                    f"tool message references unknown tool_call_id={call_id!r} "
+                    "(no matching assistant tool_call seen yet)"
+                )
+            payload = _gemini_tool_response_payload(msg.get("content", ""))
+            _append_gemini_user_parts(contents, [{"functionResponse": {"name": name, "response": payload}}])
+            continue
+        # role == user (or unknown -> treat as user)
+        content = msg.get("content")
+        text = content if isinstance(content, str) else ""
+        if text:
+            _append_gemini_user_parts(contents, [{"text": text}])
+    system_instruction = None
+    if system_parts:
+        system_instruction = {"parts": [{"text": "\n\n".join(system_parts)}]}
+    return system_instruction, contents
+
+
+def _gemini_resp_to_oai(resp):
+    """Gemini generateContent response -> OpenAI chat-completions shape so
+    _extract_message and the run_worker/judge_clusters loops read it
+    unchanged (same contract as _anthropic_resp_to_oai/_responses_resp_to_oai).
+
+    Two layers of safety-interception defense, both must not raise:
+    - prompt-level: an empty/missing `candidates` list (the whole prompt was
+      blocked) is checked *before* any `candidates[0]` indexing. The block
+      reason from promptFeedback is preserved in the returned usage dict
+      (diagnostic only; no consumer reads it today) rather than discarded.
+    - candidate-level: a candidate with finishReason=="SAFETY" or no
+      "content" key (HTTP 200, but nothing to read) degrades to empty
+      content/no tool_calls via .get() chains, never a bare KeyError.
+
+    finish_reason is semantically mapped, not passed through raw: any
+    parsed tool_calls force "tool_calls" (highest priority, regardless of
+    the raw finishReason); otherwise "STOP"->"stop", "MAX_TOKENS"->"length",
+    and any other raw value is lowercased and passed through as-is (never
+    forged into "stop")."""
+    candidates = resp.get("candidates")
+    if not candidates:
+        block_reason = (resp.get("promptFeedback") or {}).get("blockReason")
+        usage = dict(resp.get("usageMetadata") or {})
+        usage["prompt_block_reason"] = block_reason
+        message = {"role": "assistant", "content": "", "tool_calls": None}
+        return {"choices": [{"message": message, "finish_reason": "prompt_blocked"}], "usage": usage}
+
+    candidate = candidates[0]
+    raw_finish = candidate.get("finishReason")
+    content_parts = (candidate.get("content") or {}).get("parts") or []
+    text_parts = []
+    tool_calls = []
+    for part in content_parts:
+        if "text" in part:
+            text_parts.append(part["text"])
+        elif "functionCall" in part:
+            fc = part["functionCall"]
+            tool_calls.append({
+                "id": f"call_{uuid.uuid4().hex[:8]}",
+                "type": "function",
+                "function": {
+                    "name": fc.get("name", ""),
+                    "arguments": json.dumps(fc.get("args", {}), ensure_ascii=False),
+                },
+            })
+    message = {"role": "assistant", "content": "".join(text_parts)}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+        finish_reason = "tool_calls"
+    else:
+        message["tool_calls"] = None
+        if raw_finish == "STOP":
+            finish_reason = "stop"
+        elif raw_finish == "MAX_TOKENS":
+            finish_reason = "length"
+        elif raw_finish:
+            finish_reason = raw_finish.lower()
+        else:
+            finish_reason = None
+    return {
+        "choices": [{"message": message, "finish_reason": finish_reason}],
+        "usage": resp.get("usageMetadata", {}),
+    }
+
+
+class GeminiNativeGatewayClient:
+    def __init__(self, base_url, api_key, model_id, timeout_s, max_output_tokens):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.model_id = model_id
+        self.timeout_s = timeout_s
+        self.max_output_tokens = max_output_tokens
+
+    def complete(self, messages, tools):
+        system_instruction, contents = _oai_messages_to_gemini(messages)
+        gemini_tools = _oai_tools_to_gemini(tools)
+        payload = {
+            "contents": contents,
+            "generationConfig": {"maxOutputTokens": self.max_output_tokens},
+        }
+        if system_instruction is not None:
+            payload["systemInstruction"] = system_instruction
+        if gemini_tools is not None:
+            payload["tools"] = gemini_tools
+        url = _gemini_generate_content_url(self.base_url, self.model_id)
+        headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+        resp = _http_json_post_with_retry(url, payload, headers, self.timeout_s,
+                                           transient_backoffs=_COMPLETION_RETRY_BACKOFFS)
+        return _gemini_resp_to_oai(resp)
+
+
 def make_client_factory(config):
     gw = config["gateway"]
     api_key = os.environ.get(gw["api_key_env"], "")
@@ -1867,20 +2106,31 @@ def make_client_factory(config):
     # already uses, rather than needing a second personality inside
     # ResponsesGatewayClient itself.
     gpt_endpoint = config.get("limits", {}).get("gpt_endpoint", "responses")
+    # Same escape hatch pattern as gpt_endpoint, for the Gemini-native
+    # generateContent path (see GeminiNativeGatewayClient's docstring): if
+    # the gateway's implicit prefix caching turns out not to apply to this
+    # protocol either, config can flip back to "chat_completions" without a
+    # code change -- gemini* then falls through to the same plain
+    # GatewayClient path it used before this client existed.
+    gemini_endpoint = config.get("limits", {}).get("gemini_endpoint", "native")
 
     def factory(model_id):
         # claude models go through the Anthropic-native /messages path so
         # prompt caching can take effect; gpt models go through the
         # Responses path for the same reason (see ResponsesGatewayClient);
-        # everything else (gemini, and gpt when gpt_endpoint is switched
-        # off) stays on the OpenAI-compatible /chat/completions gateway. All
-        # three share the same complete(messages, tools) interface, so
+        # gemini models go through the Gemini-native generateContent path for
+        # the same reason (see GeminiNativeGatewayClient); everything else
+        # (and gpt/gemini when their *_endpoint switch is flipped off) stays
+        # on the OpenAI-compatible /chat/completions gateway. All four share
+        # the same complete(messages, tools) interface, so
         # run_judge_with_fallback can freely mix client types across its
         # candidates.
         if model_id.startswith("claude"):
             return AnthropicGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens, effort=effort)
         if model_id.startswith("gpt") and gpt_endpoint == "responses":
             return ResponsesGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens)
+        if model_id.startswith("gemini") and gemini_endpoint == "native":
+            return GeminiNativeGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens)
         return GatewayClient(gw["base_url"], api_key, model_id, timeout)
 
     return factory

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -3723,10 +3723,17 @@ class TestMakeClientFactoryThreeWayDispatch(unittest.TestCase):
         client = factory("gpt-5.4")
         self.assertIsInstance(client, harvest.ResponsesGatewayClient)
 
-    def test_gemini_dispatches_to_plain_gateway_client(self):
+    def test_gemini_dispatches_to_gemini_native_client(self):
+        # research#40 / ADR-011 follow-up: gemini now defaults to the
+        # Gemini-native generateContent path (see
+        # TestMakeClientFactoryGeminiDispatch for full coverage of this
+        # dispatch branch, including the chat_completions fallback). This
+        # class's job is only to prove claude/gpt dispatch is unaffected by
+        # that change -- see test_claude_dispatches_to_anthropic_client and
+        # test_gpt_dispatches_to_responses_client above.
         factory = harvest.make_client_factory(base_config())
         client = factory("gemini-3.5-flash")
-        self.assertIsInstance(client, harvest.GatewayClient)
+        self.assertIsInstance(client, harvest.GeminiNativeGatewayClient)
         self.assertNotIsInstance(client, harvest.ResponsesGatewayClient)
 
     def test_claude_effort_defaults_to_medium(self):
@@ -3781,6 +3788,328 @@ class TestMakeClientFactoryThreeWayDispatch(unittest.TestCase):
         judge_text = '```json\n{"clusters": [{"summary": "s", "source_claim_ids": ["m1-1"], "relation": "agree"}]}\n```'
         ok_response = {"output": [{"type": "message", "content": [{"type": "output_text", "text": judge_text}]}],
                        "status": "completed"}
+        worker_findings = {"m1": {"claims": [{"_id": "m1-1", "claim": "A", "excerpt": "e", "url": "u"}]}}
+        with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response):
+            data, err = harvest.run_judge_with_fallback(config, factory, worker_findings, config["panel_models"])
+        self.assertIsNone(err)
+        self.assertEqual(data["clusters"][0]["source_claim_ids"], ["m1-1"])
+
+
+# ---------------------------------------------------------------------------
+# research#40 / ADR-011 follow-up: gemini via Gemini-native generateContent,
+# mirroring TestAnthropicConversion / TestResponsesConversion's structure for
+# the new Gemini protocol conversion pure functions.
+# ---------------------------------------------------------------------------
+
+class TestGeminiGenerateContentUrl(unittest.TestCase):
+    def test_default_config_base_url(self):
+        url = harvest._gemini_generate_content_url("https://aapi.tbps.one/v1", "gemini-3.5-flash")
+        self.assertEqual(url, "https://aapi.tbps.one/v1beta/models/gemini-3.5-flash:generateContent")
+
+    def test_multi_level_path_prefix_preserved(self):
+        url = harvest._gemini_generate_content_url("https://gateway.corp.com/ai-proxy/v1", "gemini-3.5-flash")
+        self.assertEqual(url, "https://gateway.corp.com/ai-proxy/v1beta/models/gemini-3.5-flash:generateContent")
+
+    def test_no_v1_suffix_not_mis_truncated(self):
+        url = harvest._gemini_generate_content_url("https://gw.example.com", "gemini-3.5-flash")
+        self.assertEqual(url, "https://gw.example.com/v1beta/models/gemini-3.5-flash:generateContent")
+
+    def test_trailing_slash_stripped(self):
+        url = harvest._gemini_generate_content_url("https://aapi.tbps.one/v1/", "gemini-3.5-flash")
+        self.assertEqual(url, "https://aapi.tbps.one/v1beta/models/gemini-3.5-flash:generateContent")
+
+
+class TestGeminiToolsConversion(unittest.TestCase):
+    def test_tools_none_returns_none(self):
+        self.assertIsNone(harvest._oai_tools_to_gemini(None))
+        self.assertIsNone(harvest._oai_tools_to_gemini([]))
+
+    def test_tools_converted_to_function_declarations(self):
+        gemini_tools = harvest._oai_tools_to_gemini(harvest.TOOL_SCHEMAS)
+        self.assertEqual(len(gemini_tools), 1)
+        declarations = gemini_tools[0]["functionDeclarations"]
+        self.assertEqual(len(declarations), len(harvest.TOOL_SCHEMAS))
+        self.assertEqual(declarations[0]["name"], harvest.TOOL_SCHEMAS[0]["function"]["name"])
+        self.assertIn("parameters", declarations[0])
+
+
+class TestGeminiMessagesConversion(unittest.TestCase):
+    def test_system_hoisted_to_system_instruction(self):
+        msgs = [{"role": "system", "content": "SYS"}, {"role": "user", "content": "hi"}]
+        system, contents = harvest._oai_messages_to_gemini(msgs)
+        self.assertEqual(system, {"parts": [{"text": "SYS"}]})
+        self.assertEqual(contents, [{"role": "user", "parts": [{"text": "hi"}]}])
+
+    def test_no_system_yields_none(self):
+        system, _contents = harvest._oai_messages_to_gemini([{"role": "user", "content": "hi"}])
+        self.assertIsNone(system)
+
+    def test_multiple_system_messages_merged_not_overwritten(self):
+        msgs = [
+            {"role": "system", "content": "first rule"},
+            {"role": "system", "content": "second rule"},
+            {"role": "user", "content": "hi"},
+        ]
+        system, _contents = harvest._oai_messages_to_gemini(msgs)
+        self.assertEqual(system, {"parts": [{"text": "first rule\n\nsecond rule"}]})
+
+    def test_assistant_text_plus_function_call(self):
+        msgs = [{"role": "assistant", "content": "thinking",
+                 "tool_calls": [{"id": "t1", "function": {"name": "search",
+                                 "arguments": json.dumps({"query": "q"})}}]}]
+        _s, contents = harvest._oai_messages_to_gemini(msgs)
+        self.assertEqual(contents[0]["role"], "model")
+        parts = contents[0]["parts"]
+        self.assertEqual(parts[0], {"text": "thinking"})
+        self.assertEqual(parts[1]["functionCall"], {"name": "search", "args": {"query": "q"}})
+
+    def test_tool_role_resolves_name_from_prior_assistant_call(self):
+        msgs = [
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "c1", "function": {"name": "search", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": json.dumps({"result": "ok"})},
+        ]
+        _s, contents = harvest._oai_messages_to_gemini(msgs)
+        self.assertEqual(contents[1]["role"], "user")
+        fr = contents[1]["parts"][0]["functionResponse"]
+        self.assertEqual(fr["name"], "search")
+        self.assertEqual(fr["response"], {"result": "ok"})
+
+    def test_tool_content_non_json_wrapped_as_result_string(self):
+        msgs = [
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "c1", "function": {"name": "fetch", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "plain text, not json"},
+        ]
+        _s, contents = harvest._oai_messages_to_gemini(msgs)
+        fr = contents[1]["parts"][0]["functionResponse"]
+        self.assertEqual(fr["response"], {"result": "plain text, not json"})
+
+    def test_tool_content_valid_json_non_dict_wrapped_as_result(self):
+        for raw, expected in ((json.dumps([1, 2, 3]), [1, 2, 3]),
+                               (json.dumps(True), True),
+                               (json.dumps(42), 42)):
+            msgs = [
+                {"role": "assistant", "content": None,
+                 "tool_calls": [{"id": "c1", "function": {"name": "fetch", "arguments": "{}"}}]},
+                {"role": "tool", "tool_call_id": "c1", "content": raw},
+            ]
+            _s, contents = harvest._oai_messages_to_gemini(msgs)
+            fr = contents[1]["parts"][0]["functionResponse"]
+            self.assertEqual(fr["response"], {"result": expected})
+
+    def test_tool_call_id_not_found_raises(self):
+        msgs = [{"role": "tool", "tool_call_id": "ghost", "content": "{}"}]
+        with self.assertRaises(ValueError):
+            harvest._oai_messages_to_gemini(msgs)
+
+    def test_parallel_tool_calls_each_resolve_correct_name(self):
+        msgs = [
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "a", "function": {"name": "search", "arguments": "{}"}},
+                {"id": "b", "function": {"name": "fetch", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "a", "content": json.dumps({"r": "A"})},
+            {"role": "tool", "tool_call_id": "b", "content": json.dumps({"r": "B"})},
+        ]
+        _s, contents = harvest._oai_messages_to_gemini(msgs)
+        # both tool results collapse into one merged user turn
+        self.assertEqual(len(contents), 2)
+        self.assertEqual(contents[1]["role"], "user")
+        names = [p["functionResponse"]["name"] for p in contents[1]["parts"]]
+        self.assertEqual(names, ["search", "fetch"])
+        responses = [p["functionResponse"]["response"] for p in contents[1]["parts"]]
+        self.assertEqual(responses, [{"r": "A"}, {"r": "B"}])
+
+    def test_user_turn_after_tool_results_merges_not_consecutive(self):
+        msgs = [
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "a", "function": {"name": "search", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "a", "content": "{}"},
+            {"role": "user", "content": "nudge"},
+        ]
+        _s, contents = harvest._oai_messages_to_gemini(msgs)
+        user_turns = [c for c in contents if c["role"] == "user"]
+        self.assertEqual(len(user_turns), 1)
+        self.assertEqual(len(user_turns[0]["parts"]), 2)
+
+
+class TestGeminiRespToOai(unittest.TestCase):
+    def test_plain_text_stop_maps_to_stop(self):
+        resp = {"candidates": [{"finishReason": "STOP",
+                                "content": {"parts": [{"text": "hello"}]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        msg = oai["choices"][0]["message"]
+        self.assertEqual(msg["content"], "hello")
+        self.assertIsNone(msg["tool_calls"])
+        self.assertEqual(oai["choices"][0]["finish_reason"], "stop")
+
+    def test_single_function_call_maps_to_tool_calls_ignoring_raw_finish(self):
+        resp = {"candidates": [{"finishReason": "STOP",
+                                "content": {"parts": [{"functionCall": {"name": "search", "args": {"q": "x"}}}]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        msg = oai["choices"][0]["message"]
+        self.assertEqual(len(msg["tool_calls"]), 1)
+        self.assertEqual(msg["tool_calls"][0]["function"]["name"], "search")
+        self.assertEqual(json.loads(msg["tool_calls"][0]["function"]["arguments"]), {"q": "x"})
+        self.assertEqual(oai["choices"][0]["finish_reason"], "tool_calls")
+
+    def test_parallel_function_calls_all_present_with_unique_ids(self):
+        resp = {"candidates": [{"content": {"parts": [
+            {"functionCall": {"name": "search", "args": {"q": "1"}}},
+            {"functionCall": {"name": "fetch", "args": {"url": "u"}}},
+        ]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        tool_calls = oai["choices"][0]["message"]["tool_calls"]
+        self.assertEqual(len(tool_calls), 2)
+        ids = [tc["id"] for tc in tool_calls]
+        self.assertEqual(len(set(ids)), 2)
+
+    def test_max_tokens_maps_to_length(self):
+        resp = {"candidates": [{"finishReason": "MAX_TOKENS",
+                                "content": {"parts": [{"text": "cut off"}]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        self.assertEqual(oai["choices"][0]["finish_reason"], "length")
+
+    def test_unknown_finish_reason_lowercased_not_forged_to_stop(self):
+        resp = {"candidates": [{"finishReason": "RECITATION",
+                                "content": {"parts": [{"text": "x"}]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        self.assertEqual(oai["choices"][0]["finish_reason"], "recitation")
+
+    def test_candidate_level_safety_block_no_crash_empty_content(self):
+        resp = {"candidates": [{"finishReason": "SAFETY"}]}  # no "content" key
+        oai = harvest._gemini_resp_to_oai(resp)
+        msg = oai["choices"][0]["message"]
+        self.assertEqual(msg["content"], "")
+        self.assertIsNone(msg["tool_calls"])
+
+    def test_prompt_level_block_missing_candidates_key_no_crash(self):
+        resp = {"promptFeedback": {"blockReason": "SAFETY"}}
+        oai = harvest._gemini_resp_to_oai(resp)
+        msg = oai["choices"][0]["message"]
+        self.assertEqual(msg["content"], "")
+        self.assertIsNone(msg["tool_calls"])
+        self.assertEqual(oai["choices"][0]["finish_reason"], "prompt_blocked")
+        self.assertEqual(oai["usage"]["prompt_block_reason"], "SAFETY")
+
+    def test_prompt_level_block_empty_candidates_list_no_crash(self):
+        resp = {"candidates": [], "promptFeedback": {"blockReason": "OTHER"}}
+        oai = harvest._gemini_resp_to_oai(resp)
+        self.assertEqual(oai["choices"][0]["finish_reason"], "prompt_blocked")
+        self.assertEqual(oai["usage"]["prompt_block_reason"], "OTHER")
+
+    def test_tool_call_ids_unique_across_two_calls(self):
+        resp = {"candidates": [{"content": {"parts": [
+            {"functionCall": {"name": "search", "args": {}}}]}}]}
+        oai1 = harvest._gemini_resp_to_oai(resp)
+        oai2 = harvest._gemini_resp_to_oai(resp)
+        id1 = oai1["choices"][0]["message"]["tool_calls"][0]["id"]
+        id2 = oai2["choices"][0]["message"]["tool_calls"][0]["id"]
+        self.assertNotEqual(id1, id2)
+
+    def test_outbound_extract_message_compatible(self):
+        resp = {"candidates": [{"finishReason": "STOP",
+                                "content": {"parts": [{"text": "j"}]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        self.assertEqual(harvest._extract_message(oai), oai["choices"][0]["message"])
+
+
+class TestGeminiNativeGatewayClient(unittest.TestCase):
+    def test_complete_posts_to_generate_content_endpoint(self):
+        client = harvest.GeminiNativeGatewayClient("https://gw.example.com/v1", "key", "gemini-3.5-flash", 5, 16384)
+        ok_response = {"candidates": [{"finishReason": "STOP", "content": {"parts": [{"text": "hi"}]}}]}
+        with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response) as m:
+            result = client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        self.assertEqual(result["choices"][0]["message"]["content"], "hi")
+        url = m.call_args[0][0]
+        self.assertTrue(url.endswith("/v1beta/models/gemini-3.5-flash:generateContent"))
+
+    def test_complete_sets_max_output_tokens_in_generation_config(self):
+        client = harvest.GeminiNativeGatewayClient("https://gw.example.com/v1", "key", "gemini-3.5-flash", 5, 9999)
+        ok_response = {"candidates": [{"finishReason": "STOP", "content": {"parts": [{"text": "hi"}]}}]}
+        with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response) as m:
+            client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        payload = m.call_args[0][1]
+        self.assertEqual(payload["generationConfig"]["maxOutputTokens"], 9999)
+
+    def test_complete_omits_tools_field_when_none(self):
+        client = harvest.GeminiNativeGatewayClient("https://gw.example.com/v1", "key", "gemini-3.5-flash", 5, 16384)
+        ok_response = {"candidates": [{"finishReason": "STOP", "content": {"parts": [{"text": "j"}]}}]}
+        with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response) as m:
+            client.complete(messages=[{"role": "system", "content": "sys"},
+                                       {"role": "user", "content": "judge input"}], tools=None)
+        payload = m.call_args[0][1]
+        self.assertNotIn("tools", payload)
+        self.assertEqual(payload["systemInstruction"], {"parts": [{"text": "sys"}]})
+
+    def test_complete_includes_tools_when_present(self):
+        client = harvest.GeminiNativeGatewayClient("https://gw.example.com/v1", "key", "gemini-3.5-flash", 5, 16384)
+        ok_response = {"candidates": [{"finishReason": "STOP", "content": {"parts": [{"text": "j"}]}}]}
+        with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response) as m:
+            client.complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        payload = m.call_args[0][1]
+        self.assertEqual(len(payload["tools"][0]["functionDeclarations"]), len(harvest.TOOL_SCHEMAS))
+
+    def test_complete_parses_function_call_response(self):
+        client = harvest.GeminiNativeGatewayClient("https://gw.example.com/v1", "key", "gemini-3.5-flash", 5, 16384)
+        ok_response = {"candidates": [{"content": {"parts": [
+            {"functionCall": {"name": "search", "args": {"query": "x"}}}]}}]}
+        with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response):
+            result = client.complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        message = result["choices"][0]["message"]
+        self.assertEqual(message["tool_calls"][0]["function"]["name"], "search")
+        self.assertEqual(result["choices"][0]["finish_reason"], "tool_calls")
+
+
+class TestMakeClientFactoryGeminiDispatch(unittest.TestCase):
+    """Extends TestMakeClientFactoryThreeWayDispatch's dispatch coverage to
+    the fourth (Gemini-native) client type, without touching the existing
+    three-way test class -- claude/gpt dispatch behavior must not regress."""
+
+    def setUp(self):
+        self.env_patcher = mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "secret"})
+        self.env_patcher.start()
+        self.addCleanup(self.env_patcher.stop)
+
+    def test_gemini_native_default_dispatches_to_gemini_native_client(self):
+        factory = harvest.make_client_factory(base_config())
+        client = factory("gemini-3.5-flash")
+        self.assertIsInstance(client, harvest.GeminiNativeGatewayClient)
+
+    def test_gemini_endpoint_chat_completions_falls_back_to_plain_gateway_client(self):
+        config = base_config()
+        config["limits"] = dict(config["limits"], gemini_endpoint="chat_completions")
+        factory = harvest.make_client_factory(config)
+        client = factory("gemini-3.5-flash")
+        self.assertIsInstance(client, harvest.GatewayClient)
+        self.assertNotIsInstance(client, harvest.GeminiNativeGatewayClient)
+
+    def test_old_config_missing_gemini_endpoint_key_defaults_to_native(self):
+        config = base_config()
+        self.assertNotIn("gemini_endpoint", config["limits"])
+        factory = harvest.make_client_factory(config)
+        client = factory("gemini-3.5-flash")
+        self.assertIsInstance(client, harvest.GeminiNativeGatewayClient)
+
+    def test_claude_and_gpt_dispatch_unaffected_by_gemini_endpoint_change(self):
+        config = base_config()
+        config["limits"] = dict(config["limits"], gemini_endpoint="chat_completions")
+        factory = harvest.make_client_factory(config)
+        self.assertIsInstance(factory("claude-sonnet-5"), harvest.AnthropicGatewayClient)
+        self.assertIsInstance(factory("gpt-5.4"), harvest.ResponsesGatewayClient)
+
+    def test_gemini_native_max_output_tokens_mirrors_completion_max_tokens(self):
+        config = base_config()
+        config["limits"] = dict(config["limits"], completion_max_tokens=12345)
+        factory = harvest.make_client_factory(config)
+        client = factory("gemini-3.5-flash")
+        self.assertEqual(client.max_output_tokens, 12345)
+
+    def test_judge_fallback_mixes_gemini_native_client_with_tools_none(self):
+        config = base_config(judge_model="gemini-3.5-flash", panel_models=["gemini-3.5-flash", "model-b"])
+        factory = harvest.make_client_factory(config)
+        judge_text = '```json\n{"clusters": [{"summary": "s", "source_claim_ids": ["m1-1"], "relation": "agree"}]}\n```'
+        ok_response = {"candidates": [{"finishReason": "STOP", "content": {"parts": [{"text": judge_text}]}}]}
         worker_findings = {"m1": {"claims": [{"_id": "m1-1", "claim": "A", "excerpt": "e", "url": "u"}]}}
         with mock.patch("harvest._http_json_post_with_retry", return_value=ok_response):
             data, err = harvest.run_judge_with_fallback(config, factory, worker_findings, config["panel_models"])


### PR DESCRIPTION
## Summary
- 新增 `GeminiNativeGatewayClient`，gemini* 面板模型改走网关的 Gemini 原生 `generateContent` 端点（原路径是 OpenAI-compat `/chat/completions`），协议切换本身不涉及新凭据体系，复用同一网关 `base_url`/`api_key`
- `make_client_factory` 接入四路分派：`limits.gemini_endpoint` 新开关（默认 `native`，可设 `chat_completions` 回退旧路径，不破坏现有已跑通配置）
- 新增纯函数：`_gemini_generate_content_url`（URL 拼装，按后缀而非 `urlsplit` 裁剪 `/v1`，保留任意 path 前缀）、`_oai_tools_to_gemini`、`_oai_messages_to_gemini`（含 system 多条合并、tool_call_id→name 跨消息状态映射、tool content 非 dict 兜底）、`_gemini_resp_to_oai`（prompt 级 + candidate 级两层安全拦截防御、finish_reason 语义映射、tool_calls 用 uuid 生成唯一 id）
- `harvest.config.json` 新增 `"gemini_endpoint": "native"`

关联 research 仓 issue #40。

## Test plan
- [x] `pytest plugins/deep-research/tests/test_harvest.py -q` — 387 passed（新增 ~55 个测试用例覆盖 URL 拼装、tools/messages 双向转换、响应解析安全防御、四路 dispatch；同时修正了一条断言 gemini 走旧 GatewayClient 的过期测试）
- [x] 真实探针（非 mock）：用真实 `GeminiNativeGatewayClient` 对 `gemini-3.5-flash` 连续发 4 轮增长前缀请求 + 3 轮字节级完全重复的大 prompt（1200+ tokens，远超合理的最小前缀缓存阈值），`usageMetadata` 全程未出现 `cachedContentTokenCount` 字段 —— **协议已切换但该网关对 Gemini 原生端点未观测到缓存命中**，与 gpt `/responses` 路径的实测结果不同，根因待续查（写入 PR 描述供后续 ADR 参考，不在本 PR 内下结论）