### PR TITLE
feat(harvest): completion 路径流式改造 — fail-fast 看门狗 (v1.10.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest.config.json
+++ b/plugins/deep-research/scripts/harvest.config.json
@@ -63,7 +63,14 @@
     "fetch_max_chars": 20000,
     "fetch_connect_timeout_s": 5,
     "fetch_low_speed_bytes_s": 512,
-    "fetch_low_speed_window_s": 10
+    "fetch_low_speed_window_s": 10,
+    "stream_ttft_timeout_s": 300,
+    "stream_inter_token_timeout_s": 90,
+    "anthropic_stream": true,
+    "gpt_stream": true,
+    "gemini_stream": true,
+    "gateway_stream": true,
+    "gateway_stream_options": false
   },
   "blacklist_domains": [
     "blog.csdn.net",

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -1603,7 +1603,7 @@ class GatewayClient:
                             slot["id"] = tc["id"]
                         fn = tc.get("function") or {}
                         if fn.get("name"):
-                            slot["function"]["name"] += fn["name"]
+                            slot["function"]["name"] = fn["name"]
                         if fn.get("arguments"):
                             slot["function"]["arguments"] += fn["arguments"]
 
@@ -2294,8 +2294,6 @@ class ResponsesGatewayClient:
     def _complete_streaming(self, messages, tools):
         payload = self._build_payload(messages, tools)
         payload["stream"] = True
-        if self.stream_options:
-            payload["stream_options"] = {"include_usage": True}
         url = self.base_url + "/responses"
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
 
@@ -2701,8 +2699,14 @@ class GeminiNativeGatewayClient:
             if not seen_logical_end:
                 raise StreamConnectionLost("stream ended without a candidate finishReason")
 
+            # Determine finish_reason after all frames consumed (tool_calls
+            # may arrive in frames after finishReason — see ADR-013 review #4).
+            if tool_calls:
+                finish_reason = "tool_calls"
+
             message = {"role": "assistant", "content": "".join(text_parts)}
-            message["tool_calls"] = tool_calls or None
+            if tool_calls:
+                message["tool_calls"] = tool_calls
             return {
                 "choices": [{"message": message, "finish_reason": finish_reason}],
                 "usage": usage,
@@ -2772,7 +2776,7 @@ def make_client_factory(config):
     gpt_stream = config.get("limits", {}).get("gpt_stream", True)
     gemini_stream = config.get("limits", {}).get("gemini_stream", True)
     gateway_stream = config.get("limits", {}).get("gateway_stream", True)
-    gateway_stream_options = config.get("limits", {}).get("gateway_stream_options", True)
+    gateway_stream_options = config.get("limits", {}).get("gateway_stream_options", False)
 
     def factory(model_id):
         # claude models go through the Anthropic-native /messages path so

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -17,15 +17,18 @@ behavior coverage.
 """
 
 import argparse
+import contextlib
 import gzip
 import hashlib
 import html
+import http.client
 import ipaddress
 import json
 import os
 import re
 import shutil
 import socket
+import ssl
 import subprocess
 import sys
 import threading
@@ -480,6 +483,244 @@ def _http_json_post_with_retry(url, payload, headers, timeout, transient_backoff
             if retries_done >= len(backoffs):
                 raise RuntimeError(f"network error after {attempt} attempts: {e}") from e
             time.sleep(backoffs[retries_done])
+
+
+# ---------------------------------------------------------------------------
+# SSE streaming infrastructure (fail-fast watchdog for completion calls)
+#
+# Pure protocol layer: _http_stream_post knows nothing about any provider's
+# event shapes, only the generic SSE wire format (event:/data:/comment lines
+# terminated by a blank line). Each of the four completion clients' complete()
+# consumes this generator and layers its own provider-specific frame parsing
+# and logical-end detection on top -- see AnthropicGatewayClient.complete /
+# ResponsesGatewayClient.complete / GeminiNativeGatewayClient.complete /
+# GatewayClient.complete.
+# ---------------------------------------------------------------------------
+
+class StreamIdleTimeout(RuntimeError):
+    """Inter-token or TTFT (time-to-first-token) timeout -- transient,
+    retryable under the same backoff schedule as a network-layer failure."""
+
+
+class StreamConnectionLost(RuntimeError):
+    """Mid-stream connection drop (socket reset, truncated read, TLS error)
+    -- transient, retryable."""
+
+
+class StreamNotSupportedError(RuntimeError):
+    """Server returned HTTP 200 but the body is not an SSE stream (e.g. a
+    plain application/json error payload) -- permanent, callers must NOT
+    retry this as a transient stream failure. The escape-hatch config flags
+    (limits.anthropic_stream etc.) exist precisely so an operator can flip
+    back to the non-streaming path if a gateway turns out not to support
+    streaming at all."""
+
+
+def _get_raw_socket(resp):
+    """Best-effort extraction of the underlying socket from an
+    http.client.HTTPResponse so a caller can settimeout() it once streaming
+    is under way (tightening from a generous TTFT timeout to a tighter
+    inter-token timeout). Tries the shapes seen across CPython's http.client/
+    ssl-wrapped-socket implementations; returns None (never raises) if none
+    match, so a caller that can't get a socket degrades to "no watchdog
+    tightening" rather than crashing."""
+    for attr_chain in [('fp', 'raw', '_sock'), ('fp', '_sock'), ('sock',)]:
+        obj = resp
+        for attr in attr_chain:
+            obj = getattr(obj, attr, None)
+            if obj is None:
+                break
+        else:
+            if hasattr(obj, 'settimeout'):
+                return obj
+    return None
+
+
+# Exceptions that can surface from resp.readline()/resp.read() once the
+# connection is open -- collapsed into StreamIdleTimeout at the readline
+# call site (the caller distinguishes idle-timeout from connection-lost by
+# *when* in the frame lifecycle the exception occurred, not by exception
+# type -- both socket.timeout from an inter-token settimeout() and a genuine
+# mid-read connection reset raise through this same set on CPython).
+_STREAM_READ_EXCEPTIONS = (
+    http.client.IncompleteRead, urllib.error.URLError, ConnectionResetError,
+    TimeoutError, socket.timeout, ssl.SSLError,
+)
+
+
+def _http_stream_post(url, payload, headers, initial_timeout):
+    """POST `payload` and yield parsed Server-Sent-Events frames.
+
+    Usage::
+
+        stream = _http_stream_post(url, payload, headers, timeout)
+        resp = next(stream)            # underlying HTTPResponse
+        sock = _get_raw_socket(resp)   # may be None
+        for event_type, data_str in stream:
+            ...
+
+    Yields:
+        - First value: the raw HTTPResponse object, so the caller can obtain
+          the underlying socket via _get_raw_socket() before consuming any
+          frames.
+        - Every value after that: an ``(event_type, data_str)`` tuple, one
+          per complete SSE frame (a run of ``event:``/``data:`` lines
+          terminated by a blank line; multiple ``data:`` lines in one frame
+          are newline-joined per the SSE spec). A bare comment line (leading
+          ``:``) yields ``(None, None)`` immediately as a heartbeat -- it
+          does not participate in frame buffering.
+
+    Raises:
+        urllib.error.HTTPError: the initial connection attempt got a non-2xx
+            response. Re-raised as-is (not wrapped) so a caller's retry loop
+            can classify it exactly like `_http_json_post_with_retry` /
+            `_anthropic_post_with_retry` already do (429/408/5xx transient,
+            other 4xx not) -- the response body is stashed on
+            `e.stream_error_body` (best-effort, mirroring
+            `_read_http_error_body`'s pattern) since `e.read()` can only be
+            called once.
+        StreamNotSupportedError: the connection succeeded (HTTP 200) but the
+            response Content-Type is not text/event-stream (e.g. the gateway
+            fell back to a plain JSON error body) -- permanent, do not retry
+            as a stream failure.
+        StreamConnectionLost: reading the non-SSE response body itself failed
+            at the socket level, or a mid-stream error surfaces at the
+            protocol layer.
+        StreamIdleTimeout: a readline() call raised a socket-level exception
+            while consuming the event stream (covers both "no bytes for N
+            seconds" once the caller has tightened the socket timeout, and a
+            genuine connection drop -- the caller's retry loop treats both as
+            transient either way).
+
+    The whole body runs inside a ``with`` block around the connection-opening
+    call below, so a consumer that stops iterating early (GeneratorExit, e.g.
+    from ``contextlib.closing``) still closes the underlying connection via
+    the context manager's __exit__.
+    """
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=initial_timeout) as resp:
+            content_type = (resp.headers.get("Content-Type") or "").lower()
+            if "text/event-stream" not in content_type:
+                try:
+                    body = resp.read(500)
+                except _STREAM_READ_EXCEPTIONS as e:
+                    raise StreamConnectionLost(
+                        f"failed reading non-stream response body "
+                        f"(Content-Type={content_type!r}): {e}"
+                    ) from e
+                body_text = body.decode("utf-8", errors="replace")
+                raise StreamNotSupportedError(
+                    f"expected text/event-stream, got Content-Type={content_type!r}: {body_text}"
+                )
+
+            yield resp
+
+            event_type = None
+            data_lines = []
+            while True:
+                try:
+                    raw_line = resp.readline()
+                except _STREAM_READ_EXCEPTIONS as e:
+                    raise StreamIdleTimeout(f"stream read failed: {e}") from e
+
+                if raw_line == b"":
+                    # EOF -- flush a buffered partial frame (if any), then stop.
+                    if data_lines or event_type is not None:
+                        yield (event_type, "\n".join(data_lines))
+                    return
+
+                line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+
+                if line == "":
+                    # Blank line terminates the current frame (SSE spec) --
+                    # yield unconditionally, even if the frame is empty (a
+                    # stray keepalive blank line); callers already skip
+                    # empty/whitespace-only data_str per the shared
+                    # consumption contract.
+                    yield (event_type, "\n".join(data_lines))
+                    event_type = None
+                    data_lines = []
+                    continue
+
+                if line.startswith(":"):
+                    # Comment/heartbeat line -- does not belong to any frame.
+                    yield (None, None)
+                    continue
+
+                if line.startswith("event:"):
+                    event_type = line[len("event:"):].strip()
+                    continue
+
+                if line.startswith("data:"):
+                    # SSE spec: strip at most one leading space after "data:".
+                    field_value = line[len("data:"):]
+                    if field_value.startswith(" "):
+                        field_value = field_value[1:]
+                    data_lines.append(field_value)
+                    continue
+                # Other SSE fields (id:, retry:) carry no meaning for any of
+                # the four providers this module speaks to -- ignored.
+    except urllib.error.HTTPError as e:
+        # Re-raise (not wrapped in RuntimeError) so the caller's retry loop
+        # can classify by e.code exactly like the non-streaming paths do.
+        # Stash the body since e.read() is single-shot and the caller may
+        # want it for a final error message after retries are exhausted.
+        e.stream_error_body = _read_http_error_body(e)
+        raise
+
+
+# Exceptions a streaming completion attempt can raise that the retry loop
+# below treats as transient (same set specified for all four streaming
+# clients): idle/connection failures at the SSE layer, raw socket-level
+# timeouts (a caller's own settimeout() can raise these directly, not just
+# via _STREAM_READ_EXCEPTIONS inside _http_stream_post), and a malformed
+# frame body (JSONDecodeError) -- one garbled chunk is worth a resend, not a
+# hard failure. urllib.error.HTTPError is handled separately (by status
+# code) rather than blanket-listed here.
+_STREAM_RETRYABLE_EXCEPTIONS = (
+    StreamIdleTimeout, StreamConnectionLost, socket.timeout, TimeoutError,
+    urllib.error.URLError, json.JSONDecodeError, ssl.SSLError,
+)
+
+
+def _run_stream_attempt_with_retry(attempt_fn, backoffs=_COMPLETION_RETRY_BACKOFFS):
+    """Generic bounded-retry wrapper shared by all four streaming complete()
+    paths. `attempt_fn()` performs exactly one full attempt -- open the
+    stream, consume it to completion, assemble and return the OpenAI-shaped
+    result dict -- and this wrapper retries the whole attempt on any
+    transient failure, following the same fixed backoff schedule the
+    non-streaming paths use.
+
+    StreamNotSupportedError is deliberately not caught here: it means the
+    gateway returned HTTP 200 with a non-SSE body (e.g. plain JSON), which no
+    amount of retrying fixes -- it must propagate so the caller can fall back
+    via its escape-hatch config flag (limits.anthropic_stream etc.) instead
+    of being silently swallowed as "just another transient error".
+
+    HTTPError is classified by status like `_http_json_post_with_retry` /
+    `_anthropic_post_with_retry` already do: 429/408/5xx are transient and
+    retried; any other 4xx fails immediately (a malformed request resends
+    identically)."""
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            return attempt_fn()
+        except urllib.error.HTTPError as e:
+            status = e.code
+            transient = status in (429, 408) or 500 <= status < 600
+            body = getattr(e, "stream_error_body", None) or _read_http_error_body(e)
+            if not transient:
+                raise RuntimeError(f"HTTP {status} opening stream: {body}") from e
+            if attempt - 1 >= len(backoffs):
+                raise RuntimeError(f"HTTP {status} opening stream after {attempt} attempts: {body}") from e
+            time.sleep(backoffs[attempt - 1])
+        except _STREAM_RETRYABLE_EXCEPTIONS as e:
+            if attempt - 1 >= len(backoffs):
+                raise RuntimeError(f"stream failed after {attempt} attempts: {e}") from e
+            time.sleep(backoffs[attempt - 1])
 
 
 # ---------------------------------------------------------------------------
@@ -1276,20 +1517,111 @@ def build_backends(config):
 # ---------------------------------------------------------------------------
 
 class GatewayClient:
-    def __init__(self, base_url, api_key, model_id, timeout_s):
+    def __init__(self, base_url, api_key, model_id, timeout_s,
+                 stream_enabled=False, ttft_timeout=None, inter_token_timeout=None,
+                 stream_options=True):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.model_id = model_id
         self.timeout_s = timeout_s
+        # Streaming is opt-in (default False) so every existing call site --
+        # tests included -- keeps the exact non-streaming behavior it had
+        # before this parameter existed. make_client_factory is the one place
+        # that turns it on from config (limits.gateway_stream).
+        self.stream_enabled = stream_enabled
+        self.ttft_timeout = ttft_timeout
+        self.inter_token_timeout = inter_token_timeout
+        # Some OpenAI-compatible gateways only emit a final usage-bearing
+        # chunk (choices: []) if stream_options.include_usage is requested;
+        # others reject an unrecognized field outright, hence the escape
+        # hatch (limits.gateway_stream_options) rather than always-on.
+        self.stream_options = stream_options
 
     def complete(self, messages, tools):
+        if not self.stream_enabled:
+            url = self.base_url + "/chat/completions"
+            payload = {"model": self.model_id, "messages": messages}
+            if tools:
+                payload["tools"] = tools
+            headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+            return _http_json_post_with_retry(url, payload, headers, self.timeout_s,
+                                               transient_backoffs=_COMPLETION_RETRY_BACKOFFS)
+        return self._complete_streaming(messages, tools)
+
+    def _complete_streaming(self, messages, tools):
         url = self.base_url + "/chat/completions"
-        payload = {"model": self.model_id, "messages": messages}
+        payload = {"model": self.model_id, "messages": messages, "stream": True}
         if tools:
             payload["tools"] = tools
+        if self.stream_options:
+            payload["stream_options"] = {"include_usage": True}
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
-        return _http_json_post_with_retry(url, payload, headers, self.timeout_s,
-                                           transient_backoffs=_COMPLETION_RETRY_BACKOFFS)
+
+        def attempt():
+            with contextlib.closing(_http_stream_post(url, payload, headers, self.ttft_timeout)) as stream:
+                resp = next(stream)
+                sock = _get_raw_socket(resp)
+                text_parts = []
+                tool_calls = {}  # index -> {"id","type","function":{"name","arguments"}}
+                finish_reason = None
+                usage = {}
+                seen_done = False
+                tightened = False
+                for _event_type, data_str in stream:
+                    if data_str is None or not data_str.strip():
+                        continue
+                    if data_str == "[DONE]":
+                        seen_done = True
+                        break
+                    chunk = json.loads(data_str)  # JSONDecodeError -> outer retry loop
+                    if chunk.get("error"):
+                        raise StreamConnectionLost(f"error frame mid-stream: {chunk['error']}")
+                    if chunk.get("usage"):
+                        usage = chunk["usage"]
+                    choices = chunk.get("choices") or []
+                    if not choices:
+                        # A choices:[] chunk carries only usage (the
+                        # include_usage final chunk) -- nothing else to do.
+                        continue
+                    choice = choices[0]
+                    delta = choice.get("delta") or {}
+                    if choice.get("finish_reason"):
+                        finish_reason = choice["finish_reason"]
+                    has_content = bool(delta.get("content")) or bool(delta.get("tool_calls"))
+                    if has_content and not tightened and sock is not None:
+                        sock.settimeout(self.inter_token_timeout)
+                        tightened = True
+                    if delta.get("content"):
+                        text_parts.append(delta["content"])
+                    for tc in (delta.get("tool_calls") or []):
+                        idx = tc.get("index", 0)
+                        slot = tool_calls.setdefault(idx, {
+                            "id": "", "type": "function",
+                            "function": {"name": "", "arguments": ""},
+                        })
+                        if tc.get("id"):
+                            slot["id"] = tc["id"]
+                        fn = tc.get("function") or {}
+                        if fn.get("name"):
+                            slot["function"]["name"] += fn["name"]
+                        if fn.get("arguments"):
+                            slot["function"]["arguments"] += fn["arguments"]
+
+            if not seen_done and finish_reason is None:
+                raise StreamConnectionLost("stream ended without [DONE] or a finish_reason")
+
+            message = {"role": "assistant"}
+            if tool_calls:
+                message["content"] = "".join(text_parts) if text_parts else None
+                message["tool_calls"] = [tool_calls[i] for i in sorted(tool_calls)]
+            else:
+                message["content"] = "".join(text_parts)
+            return {
+                "choices": [{"message": message, "finish_reason": finish_reason}],
+                "usage": usage,
+            }
+
+        return _run_stream_attempt_with_retry(attempt)
 
 
 # ---------------------------------------------------------------------------
@@ -1524,7 +1856,8 @@ def _anthropic_resp_to_oai(resp):
 
 
 class AnthropicGatewayClient:
-    def __init__(self, base_url, api_key, model_id, timeout_s, max_tokens, effort=None):
+    def __init__(self, base_url, api_key, model_id, timeout_s, max_tokens, effort=None,
+                 stream_enabled=False, ttft_timeout=None, inter_token_timeout=None):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.model_id = model_id
@@ -1539,8 +1872,14 @@ class AnthropicGatewayClient:
         # this is a deliberate global default lowering, not "old behavior
         # preserved for old configs".
         self.effort = effort
+        # Streaming opt-in, same contract as GatewayClient's stream_enabled --
+        # default False keeps every existing (positional-args-only) call site
+        # on the old non-streaming behavior untouched.
+        self.stream_enabled = stream_enabled
+        self.ttft_timeout = ttft_timeout
+        self.inter_token_timeout = inter_token_timeout
 
-    def complete(self, messages, tools):
+    def _build_payload(self, messages, tools):
         system, anth_messages = _oai_messages_to_anthropic(messages)
         anth_tools = _oai_tools_to_anthropic(tools)
         system = _inject_cache_control(system, anth_tools, anth_messages)
@@ -1555,6 +1894,15 @@ class AnthropicGatewayClient:
             payload["tools"] = anth_tools
         if self.effort is not None:
             payload["output_config"] = {"effort": self.effort}
+        return payload
+
+    def complete(self, messages, tools):
+        if not self.stream_enabled:
+            return self._complete_blocking(messages, tools)
+        return self._complete_streaming(messages, tools)
+
+    def _complete_blocking(self, messages, tools):
+        payload = self._build_payload(messages, tools)
         url = self.base_url + "/messages"
         headers = {
             "Authorization": f"Bearer {self.api_key}",
@@ -1564,6 +1912,99 @@ class AnthropicGatewayClient:
         resp = _anthropic_post_with_retry(url, payload, headers, self.timeout_s,
                                           transient_backoffs=_COMPLETION_RETRY_BACKOFFS)
         return _anthropic_resp_to_oai(resp)
+
+    def _complete_streaming(self, messages, tools):
+        payload = self._build_payload(messages, tools)
+        payload["stream"] = True
+        url = self.base_url + "/messages"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+        }
+
+        def attempt():
+            with contextlib.closing(_http_stream_post(url, payload, headers, self.ttft_timeout)) as stream:
+                resp = next(stream)
+                sock = _get_raw_socket(resp)
+                text_parts = []
+                tool_calls = []  # list, in content_block index order
+                current_tool_input_json = {}  # block_index -> accumulated partial_json
+                finish_reason = None
+                usage = {}
+                seen_message_stop = False
+                tightened = False
+                for event_type, data_str in stream:
+                    if data_str is None or not data_str.strip():
+                        continue
+                    chunk = json.loads(data_str)  # JSONDecodeError -> outer retry loop
+                    if event_type == "error":
+                        raise StreamConnectionLost(f"error event mid-stream: {chunk}")
+                    if event_type == "message_start":
+                        msg_usage = (chunk.get("message") or {}).get("usage") or {}
+                        if msg_usage:
+                            usage["input_tokens"] = msg_usage.get("input_tokens")
+                    elif event_type == "content_block_start":
+                        block = chunk.get("content_block") or {}
+                        if block.get("type") == "tool_use":
+                            idx = chunk.get("index", len(tool_calls))
+                            tool_calls.append((idx, {
+                                "id": block.get("id", ""),
+                                "type": "function",
+                                "function": {"name": block.get("name", ""), "arguments": ""},
+                            }))
+                            current_tool_input_json[idx] = ""
+                    elif event_type == "content_block_delta":
+                        delta = chunk.get("delta") or {}
+                        dtype = delta.get("type")
+                        is_content_delta = dtype in ("text_delta", "thinking_delta", "input_json_delta")
+                        if is_content_delta and not tightened and sock is not None:
+                            sock.settimeout(self.inter_token_timeout)
+                            tightened = True
+                        if dtype == "text_delta":
+                            text_parts.append(delta.get("text", ""))
+                        elif dtype == "input_json_delta":
+                            idx = chunk.get("index")
+                            if idx in current_tool_input_json:
+                                current_tool_input_json[idx] += delta.get("partial_json", "")
+                    elif event_type == "message_delta":
+                        delta_usage = chunk.get("usage") or {}
+                        if delta_usage:
+                            usage["output_tokens"] = delta_usage.get("output_tokens")
+                        raw_stop_reason = (chunk.get("delta") or {}).get("stop_reason")
+                        if raw_stop_reason:
+                            finish_reason = raw_stop_reason
+                    elif event_type == "message_stop":
+                        seen_message_stop = True
+
+            if not seen_message_stop:
+                raise StreamConnectionLost("stream ended without a message_stop event")
+
+            # Fold each tool call's accumulated partial_json into its
+            # function.arguments, matching _anthropic_resp_to_oai's
+            # json.dumps(tool_use.input)-as-a-string contract.
+            ordered_tool_calls = []
+            for idx, tc in tool_calls:
+                raw_json = current_tool_input_json.get(idx, "")
+                try:
+                    parsed_input = json.loads(raw_json) if raw_json else {}
+                except json.JSONDecodeError:
+                    parsed_input = {}
+                tc["function"]["arguments"] = json.dumps(parsed_input, ensure_ascii=False)
+                ordered_tool_calls.append(tc)
+
+            message = {"role": "assistant"}
+            if ordered_tool_calls:
+                message["content"] = "".join(text_parts) if text_parts else None
+                message["tool_calls"] = ordered_tool_calls
+            else:
+                message["content"] = "".join(text_parts)
+            return {
+                "choices": [{"message": message, "finish_reason": finish_reason}],
+                "usage": usage,
+            }
+
+        return _run_stream_attempt_with_retry(attempt)
 
 
 _CACHE_CONTROL = {"type": "ephemeral"}
@@ -1793,7 +2234,9 @@ def _responses_resp_to_oai(resp):
 
 
 class ResponsesGatewayClient:
-    def __init__(self, base_url, api_key, model_id, timeout_s, max_output_tokens):
+    def __init__(self, base_url, api_key, model_id, timeout_s, max_output_tokens,
+                 stream_enabled=False, ttft_timeout=None, inter_token_timeout=None,
+                 stream_options=True):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.model_id = model_id
@@ -1808,8 +2251,20 @@ class ResponsesGatewayClient:
         # Anthropic path (config-level single source of truth for "how big
         # can a completion be").
         self.max_output_tokens = max_output_tokens
+        # Streaming opt-in, same contract as GatewayClient/AnthropicGatewayClient.
+        self.stream_enabled = stream_enabled
+        self.ttft_timeout = ttft_timeout
+        self.inter_token_timeout = inter_token_timeout
+        # Defaults to always-on (unlike GatewayClient's stream_options, which
+        # defaults on but is meant to be flippable per-gateway) -- Responses
+        # needs the final usage-bearing event to populate the returned
+        # dict's "usage" key at all. Exposed as a constructor param anyway
+        # so make_client_factory can wire it to the same
+        # limits.gateway_stream_options escape hatch as GatewayClient, in
+        # case a gateway ever rejects the field outright.
+        self.stream_options = stream_options
 
-    def complete(self, messages, tools):
+    def _build_payload(self, messages, tools):
         instructions, input_items = _oai_messages_to_responses(messages)
         resp_tools = _oai_tools_to_responses(tools)
         payload = {
@@ -1821,11 +2276,98 @@ class ResponsesGatewayClient:
             payload["instructions"] = instructions
         if resp_tools is not None:
             payload["tools"] = resp_tools
+        return payload
+
+    def complete(self, messages, tools):
+        if not self.stream_enabled:
+            return self._complete_blocking(messages, tools)
+        return self._complete_streaming(messages, tools)
+
+    def _complete_blocking(self, messages, tools):
+        payload = self._build_payload(messages, tools)
         url = self.base_url + "/responses"
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
         resp = _http_json_post_with_retry(url, payload, headers, self.timeout_s,
                                            transient_backoffs=_COMPLETION_RETRY_BACKOFFS)
         return _responses_resp_to_oai(resp)
+
+    def _complete_streaming(self, messages, tools):
+        payload = self._build_payload(messages, tools)
+        payload["stream"] = True
+        if self.stream_options:
+            payload["stream_options"] = {"include_usage": True}
+        url = self.base_url + "/responses"
+        headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+
+        def attempt():
+            with contextlib.closing(_http_stream_post(url, payload, headers, self.ttft_timeout)) as stream:
+                resp = next(stream)
+                sock = _get_raw_socket(resp)
+                text_parts = []
+                tool_calls = {}  # output_index -> {"id","type","function":{"name","arguments"}}
+                finish_reason = None
+                usage = {}
+                seen_completed = False
+                tightened = False
+                for _event_type, data_str in stream:
+                    if data_str is None or not data_str.strip():
+                        continue
+                    chunk = json.loads(data_str)  # JSONDecodeError -> outer retry loop
+                    ctype = chunk.get("type", "")
+                    if ctype == "error" or chunk.get("error"):
+                        raise StreamConnectionLost(f"error event mid-stream: {chunk}")
+                    if ctype.endswith(".delta") and not tightened and sock is not None:
+                        sock.settimeout(self.inter_token_timeout)
+                        tightened = True
+                    if ctype == "response.output_text.delta":
+                        text_parts.append(chunk.get("delta", ""))
+                    elif ctype in ("response.output_item.added", "response.output_item.done"):
+                        item = chunk.get("item") or {}
+                        if item.get("type") == "function_call":
+                            idx = chunk.get("output_index", len(tool_calls))
+                            slot = tool_calls.setdefault(idx, {
+                                "id": "", "type": "function",
+                                "function": {"name": "", "arguments": ""},
+                            })
+                            if item.get("call_id"):
+                                slot["id"] = item["call_id"]
+                            if item.get("name"):
+                                slot["function"]["name"] = item["name"]
+                            if ctype == "response.output_item.done" and item.get("arguments"):
+                                # Consolidated final arguments string, in case
+                                # any function_call_arguments.delta frames
+                                # were missed or coalesced upstream.
+                                slot["function"]["arguments"] = item["arguments"]
+                    elif ctype == "response.function_call_arguments.delta":
+                        idx = chunk.get("output_index")
+                        if idx is not None:
+                            slot = tool_calls.setdefault(idx, {
+                                "id": "", "type": "function",
+                                "function": {"name": "", "arguments": ""},
+                            })
+                            slot["function"]["arguments"] += chunk.get("delta", "")
+                    elif ctype in ("response.completed", "response.incomplete"):
+                        seen_completed = True
+                        response_obj = chunk.get("response") or {}
+                        usage = response_obj.get("usage") or {}
+                        finish_reason = response_obj.get("status")
+
+            if not seen_completed:
+                raise StreamConnectionLost("stream ended without a response.completed/incomplete event")
+
+            message = {"role": "assistant"}
+            ordered_tool_calls = [tool_calls[i] for i in sorted(tool_calls)]
+            if ordered_tool_calls:
+                message["content"] = "".join(text_parts) if text_parts else None
+                message["tool_calls"] = ordered_tool_calls
+            else:
+                message["content"] = "".join(text_parts)
+            return {
+                "choices": [{"message": message, "finish_reason": finish_reason}],
+                "usage": usage,
+            }
+
+        return _run_stream_attempt_with_retry(attempt)
 
 
 # ---------------------------------------------------------------------------
@@ -1855,6 +2397,17 @@ def _gemini_generate_content_url(base_url, model_id):
     if base.endswith("/v1"):
         base = base[: -len("/v1")]
     return f"{base}/v1beta/models/{model_id}:generateContent"
+
+
+def _gemini_stream_generate_content_url(base_url, model_id):
+    """Streaming counterpart of _gemini_generate_content_url -- same base-url
+    normalization, but the streamGenerateContent method with alt=sse so the
+    gateway (assumed to speak the standard Gemini REST surface) emits
+    Server-Sent Events instead of a single buffered JSON array."""
+    base = base_url.rstrip("/")
+    if base.endswith("/v1"):
+        base = base[: -len("/v1")]
+    return f"{base}/v1beta/models/{model_id}:streamGenerateContent?alt=sse"
 
 
 def _oai_tools_to_gemini(tools):
@@ -2041,14 +2594,19 @@ def _gemini_resp_to_oai(resp):
 
 
 class GeminiNativeGatewayClient:
-    def __init__(self, base_url, api_key, model_id, timeout_s, max_output_tokens):
+    def __init__(self, base_url, api_key, model_id, timeout_s, max_output_tokens,
+                 stream_enabled=False, ttft_timeout=None, inter_token_timeout=None):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.model_id = model_id
         self.timeout_s = timeout_s
         self.max_output_tokens = max_output_tokens
+        # Streaming opt-in, same contract as the other three clients.
+        self.stream_enabled = stream_enabled
+        self.ttft_timeout = ttft_timeout
+        self.inter_token_timeout = inter_token_timeout
 
-    def complete(self, messages, tools):
+    def _build_payload(self, messages, tools):
         system_instruction, contents = _oai_messages_to_gemini(messages)
         gemini_tools = _oai_tools_to_gemini(tools)
         payload = {
@@ -2059,11 +2617,98 @@ class GeminiNativeGatewayClient:
             payload["systemInstruction"] = system_instruction
         if gemini_tools is not None:
             payload["tools"] = gemini_tools
+        return payload
+
+    def complete(self, messages, tools):
+        if not self.stream_enabled:
+            return self._complete_blocking(messages, tools)
+        return self._complete_streaming(messages, tools)
+
+    def _complete_blocking(self, messages, tools):
+        payload = self._build_payload(messages, tools)
         url = _gemini_generate_content_url(self.base_url, self.model_id)
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
         resp = _http_json_post_with_retry(url, payload, headers, self.timeout_s,
                                            transient_backoffs=_COMPLETION_RETRY_BACKOFFS)
         return _gemini_resp_to_oai(resp)
+
+    def _complete_streaming(self, messages, tools):
+        # No "stream": true on the payload -- Gemini switches to SSE purely
+        # via the :streamGenerateContent?alt=sse URL, unlike the other three
+        # providers which flip a payload field on the same endpoint.
+        payload = self._build_payload(messages, tools)
+        url = _gemini_stream_generate_content_url(self.base_url, self.model_id)
+        headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+
+        def attempt():
+            with contextlib.closing(_http_stream_post(url, payload, headers, self.ttft_timeout)) as stream:
+                resp = next(stream)
+                sock = _get_raw_socket(resp)
+                text_parts = []
+                tool_calls = []
+                usage = {}
+                finish_reason = None
+                prompt_block_reason = None
+                seen_logical_end = False
+                tightened = False
+                for _event_type, data_str in stream:
+                    if data_str is None or not data_str.strip():
+                        continue
+                    # Each SSE data frame is itself a complete
+                    # generateContent-shaped response object (not a delta
+                    # envelope like the other three providers) -- accumulate
+                    # its parts and keep only the latest usageMetadata, which
+                    # the API reports cumulatively.
+                    chunk = json.loads(data_str)  # JSONDecodeError -> outer retry loop
+                    candidates = chunk.get("candidates")
+                    if not candidates:
+                        prompt_block_reason = (chunk.get("promptFeedback") or {}).get("blockReason")
+                        if prompt_block_reason:
+                            raise StreamConnectionLost(f"prompt blocked mid-stream: {prompt_block_reason}")
+                        continue
+                    if chunk.get("usageMetadata"):
+                        usage = chunk["usageMetadata"]
+                    candidate = candidates[0]
+                    content_parts = (candidate.get("content") or {}).get("parts") or []
+                    if content_parts and not tightened and sock is not None:
+                        sock.settimeout(self.inter_token_timeout)
+                        tightened = True
+                    for part in content_parts:
+                        if "text" in part:
+                            text_parts.append(part["text"])
+                        elif "functionCall" in part:
+                            fc = part["functionCall"]
+                            tool_calls.append({
+                                "id": f"call_{uuid.uuid4().hex[:8]}",
+                                "type": "function",
+                                "function": {
+                                    "name": fc.get("name", ""),
+                                    "arguments": json.dumps(fc.get("args", {}), ensure_ascii=False),
+                                },
+                            })
+                    raw_finish = candidate.get("finishReason")
+                    if raw_finish:
+                        seen_logical_end = True
+                        if tool_calls:
+                            finish_reason = "tool_calls"
+                        elif raw_finish == "STOP":
+                            finish_reason = "stop"
+                        elif raw_finish == "MAX_TOKENS":
+                            finish_reason = "length"
+                        else:
+                            finish_reason = raw_finish.lower()
+
+            if not seen_logical_end:
+                raise StreamConnectionLost("stream ended without a candidate finishReason")
+
+            message = {"role": "assistant", "content": "".join(text_parts)}
+            message["tool_calls"] = tool_calls or None
+            return {
+                "choices": [{"message": message, "finish_reason": finish_reason}],
+                "usage": usage,
+            }
+
+        return _run_stream_attempt_with_retry(attempt)
 
 
 def make_client_factory(config):
@@ -2113,6 +2758,21 @@ def make_client_factory(config):
     # code change -- gemini* then falls through to the same plain
     # GatewayClient path it used before this client existed.
     gemini_endpoint = config.get("limits", {}).get("gemini_endpoint", "native")
+    # ADR-013: streaming fail-fast watchdog config. ttft (time-to-first-token)
+    # bounds the initial connection + wait-for-first-frame; once any content
+    # delta arrives each client's own settimeout() call tightens to the
+    # (much shorter) inter-token bound, so a stalled-mid-stream gateway is
+    # caught fast instead of hanging for the full ttft window every token.
+    # Same .get()-with-default back-compat pattern as every other key here --
+    # an older config without these keys gets the same defaults declared in
+    # harvest.config.json (streaming on, generous but bounded timeouts).
+    stream_ttft = config.get("limits", {}).get("stream_ttft_timeout_s", 300)
+    stream_inter = config.get("limits", {}).get("stream_inter_token_timeout_s", 90)
+    anthropic_stream = config.get("limits", {}).get("anthropic_stream", True)
+    gpt_stream = config.get("limits", {}).get("gpt_stream", True)
+    gemini_stream = config.get("limits", {}).get("gemini_stream", True)
+    gateway_stream = config.get("limits", {}).get("gateway_stream", True)
+    gateway_stream_options = config.get("limits", {}).get("gateway_stream_options", True)
 
     def factory(model_id):
         # claude models go through the Anthropic-native /messages path so
@@ -2126,12 +2786,21 @@ def make_client_factory(config):
         # run_judge_with_fallback can freely mix client types across its
         # candidates.
         if model_id.startswith("claude"):
-            return AnthropicGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens, effort=effort)
+            return AnthropicGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens, effort=effort,
+                                           stream_enabled=anthropic_stream, ttft_timeout=stream_ttft,
+                                           inter_token_timeout=stream_inter)
         if model_id.startswith("gpt") and gpt_endpoint == "responses":
-            return ResponsesGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens)
+            return ResponsesGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens,
+                                           stream_enabled=gpt_stream, ttft_timeout=stream_ttft,
+                                           inter_token_timeout=stream_inter,
+                                           stream_options=gateway_stream_options)
         if model_id.startswith("gemini") and gemini_endpoint == "native":
-            return GeminiNativeGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens)
-        return GatewayClient(gw["base_url"], api_key, model_id, timeout)
+            return GeminiNativeGatewayClient(gw["base_url"], api_key, model_id, timeout, max_tokens,
+                                              stream_enabled=gemini_stream, ttft_timeout=stream_ttft,
+                                              inter_token_timeout=stream_inter)
+        return GatewayClient(gw["base_url"], api_key, model_id, timeout,
+                              stream_enabled=gateway_stream, ttft_timeout=stream_ttft,
+                              inter_token_timeout=stream_inter, stream_options=gateway_stream_options)
 
     return factory
 

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -33,7 +33,15 @@ def base_config(**overrides):
         "limits": {"max_steps_per_model": 6, "call_timeout_s": 5, "wall_clock_s": 60,
                    "quorum": 2, "search_min_interval_s": 0, "fetch_max_chars": 20000,
                    "fetch_connect_timeout_s": 5, "fetch_low_speed_bytes_s": 512,
-                   "fetch_low_speed_window_s": 10},
+                   "fetch_low_speed_window_s": 10,
+                   # ADR-013: keep the existing test suite on the deterministic
+                   # non-streaming path (which the existing HTTP-level mocks
+                   # target). Streaming behavior gets its own dedicated test
+                   # classes that construct clients directly with
+                   # stream_enabled=True.
+                   "anthropic_stream": False, "gpt_stream": False,
+                   "gemini_stream": False, "gateway_stream": False,
+                   "gateway_stream_options": False},
         "blacklist_domains": ["blog.csdn.net", "cloud.baidu.com", "aliyun.com"],
     }
     cfg.update(overrides)
@@ -4858,6 +4866,586 @@ class TestProgressEmit(unittest.TestCase):
         worker_steps = [e for e in events if e["event"] == "worker_step"]
         self.assertTrue(worker_steps)
         self.assertEqual(worker_steps[0]["alias"], "m1")
+
+
+# ---------------------------------------------------------------------------
+# SSE streaming (ADR-013): shared fakes + per-provider streaming coverage.
+# The four completion clients call _http_stream_post at a single boundary, so
+# provider-level tests mock that boundary directly with a fake generator that
+# reproduces its contract (yield resp first, then (event_type, data_str)
+# frames). Only TestStreamPost drops down to the urllib.request.urlopen layer,
+# since it exercises _http_stream_post's own SSE parsing.
+# ---------------------------------------------------------------------------
+
+class _RecordingSocket:
+    """Fake raw socket whose settimeout() calls are recorded, so a test can
+    assert the inter-token watchdog tightening fired exactly once."""
+
+    def __init__(self):
+        self.timeouts = []
+
+    def settimeout(self, t):
+        self.timeouts.append(t)
+
+
+class _StreamRespStub:
+    """Stand-in for the HTTPResponse _http_stream_post yields first. Exposes a
+    .sock so _get_raw_socket() finds it via its ('sock',) probe chain (None ->
+    _get_raw_socket returns None and the client skips watchdog tightening)."""
+
+    def __init__(self, sock=None):
+        self.sock = sock
+
+
+def _stream_of(frames, sock=None):
+    """side_effect factory: each invocation returns a fresh generator matching
+    _http_stream_post's contract -- the resp stub first, then one
+    (event_type, data_str) tuple per scripted frame. A factory (not a bare
+    generator) so a retrying client gets a new, un-exhausted stream per
+    attempt."""
+    def factory(*args, **kwargs):
+        def gen():
+            yield _StreamRespStub(sock)
+            for frame in frames:
+                yield frame
+        return gen()
+    return factory
+
+
+def _stream_raising(exc):
+    """side_effect factory whose generator raises `exc` on first next() --
+    simulates a TTFT/connect failure surfacing when the client calls
+    next(stream) to obtain the response object."""
+    def factory(*args, **kwargs):
+        def gen():
+            raise exc
+            yield  # unreachable; marks gen() a generator function
+        return gen()
+    return factory
+
+
+class FakeSSEHTTPResponse:
+    """urlopen()-compatible fake for exercising _http_stream_post directly:
+    a .headers dict (Content-Type lookup), .read(n) for the non-stream body
+    probe, and .readline() draining a scripted list of raw SSE line bytes
+    (b'' signals EOF, as a real HTTPResponse does)."""
+
+    def __init__(self, lines=(), content_type="text/event-stream", body=b""):
+        self._lines = list(lines)
+        self.headers = {"Content-Type": content_type}
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self, *args):
+        return self._body
+
+    def readline(self):
+        return self._lines.pop(0) if self._lines else b""
+
+
+class TestStreamPost(unittest.TestCase):
+    """_http_stream_post's generic SSE wire parsing (provider-agnostic)."""
+
+    def _run(self, fake):
+        with mock.patch("harvest.urllib.request.urlopen", return_value=fake):
+            stream = harvest._http_stream_post("http://gw/stream", {}, {}, 5)
+            resp = next(stream)
+            frames = list(stream)
+        return resp, frames
+
+    def test_parses_event_and_data_frame(self):
+        fake = FakeSSEHTTPResponse([b"event: message\n", b"data: hello\n", b"\n"])
+        _, frames = self._run(fake)
+        self.assertEqual(frames, [("message", "hello")])
+
+    def test_multiline_data_joined_with_newline(self):
+        # SSE spec: multiple data: lines in one frame are newline-joined.
+        fake = FakeSSEHTTPResponse([b"data: line1\n", b"data: line2\n", b"\n"])
+        _, frames = self._run(fake)
+        self.assertEqual(frames, [(None, "line1\nline2")])
+
+    def test_comment_line_yields_heartbeat_tuple(self):
+        # A bare comment (leading ':') is a heartbeat -> (None, None), and does
+        # not merge into the following frame.
+        fake = FakeSSEHTTPResponse([b": keep-alive\n", b"data: x\n", b"\n"])
+        _, frames = self._run(fake)
+        self.assertEqual(frames, [(None, None), (None, "x")])
+
+    def test_done_sentinel_passes_through_as_data(self):
+        fake = FakeSSEHTTPResponse([b"data: [DONE]\n", b"\n"])
+        _, frames = self._run(fake)
+        self.assertEqual(frames, [(None, "[DONE]")])
+
+    def test_single_leading_space_after_data_colon_stripped(self):
+        # Exactly one space after 'data:' is stripped; a second is preserved.
+        fake = FakeSSEHTTPResponse([b"data:  two-spaces\n", b"\n"])
+        _, frames = self._run(fake)
+        self.assertEqual(frames, [(None, " two-spaces")])
+
+    def test_non_2xx_reraises_httperror_with_body_stashed(self):
+        # A non-2xx open is re-raised as-is (not wrapped) so the caller's retry
+        # loop can classify by status; the body is stashed on stream_error_body
+        # since e.read() is single-shot.
+        err = harvest.urllib.error.HTTPError(
+            url="http://gw/stream", code=503, msg="err", hdrs=None,
+            fp=io.BytesIO(b"upstream unavailable"))
+        with mock.patch("harvest.urllib.request.urlopen", side_effect=err):
+            stream = harvest._http_stream_post("http://gw/stream", {}, {}, 5)
+            with self.assertRaises(harvest.urllib.error.HTTPError) as ctx:
+                next(stream)
+        self.assertEqual(ctx.exception.stream_error_body, "upstream unavailable")
+
+    def test_non_event_stream_content_type_raises_not_supported(self):
+        # HTTP 200 with a non-SSE Content-Type (a plain JSON error body) is a
+        # permanent StreamNotSupportedError, never a transient stream failure.
+        fake = FakeSSEHTTPResponse(content_type="application/json",
+                                   body=b'{"error":"no streaming here"}')
+        with mock.patch("harvest.urllib.request.urlopen", return_value=fake):
+            stream = harvest._http_stream_post("http://gw/stream", {}, {}, 5)
+            with self.assertRaises(harvest.StreamNotSupportedError):
+                next(stream)
+
+
+class TestAnthropicStreaming(unittest.TestCase):
+    """AnthropicGatewayClient._complete_streaming assembles the same
+    OpenAI-shaped dict as the non-streaming _anthropic_resp_to_oai path."""
+
+    def _client(self, sock=None):
+        return harvest.AnthropicGatewayClient(
+            "http://gw", "key", "claude-sonnet-5", 5, 16384,
+            stream_enabled=True, ttft_timeout=5, inter_token_timeout=5)
+
+    def test_text_and_tool_call_stream_assembled(self):
+        frames = [
+            ("message_start", json.dumps({"message": {"usage": {"input_tokens": 11}}})),
+            ("content_block_start", json.dumps({"index": 0, "content_block": {"type": "text", "text": ""}})),
+            ("content_block_delta", json.dumps({"index": 0, "delta": {"type": "text_delta", "text": "Hello "}})),
+            ("content_block_delta", json.dumps({"index": 0, "delta": {"type": "text_delta", "text": "world"}})),
+            ("content_block_stop", json.dumps({"index": 0})),
+            ("content_block_start", json.dumps({"index": 1, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "search"}})),
+            ("content_block_delta", json.dumps({"index": 1, "delta": {"type": "input_json_delta", "partial_json": '{"query":'}})),
+            ("content_block_delta", json.dumps({"index": 1, "delta": {"type": "input_json_delta", "partial_json": ' "sky"}'}})),
+            ("content_block_stop", json.dumps({"index": 1})),
+            ("message_delta", json.dumps({"delta": {"stop_reason": "tool_use"}, "usage": {"output_tokens": 7}})),
+            ("message_stop", json.dumps({})),
+        ]
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        msg = result["choices"][0]["message"]
+        self.assertEqual(msg["content"], "Hello world")
+        self.assertEqual(len(msg["tool_calls"]), 1)
+        tc = msg["tool_calls"][0]
+        self.assertEqual(tc["id"], "toolu_1")
+        self.assertEqual(tc["function"]["name"], "search")
+        self.assertEqual(json.loads(tc["function"]["arguments"]), {"query": "sky"})
+        self.assertEqual(result["choices"][0]["finish_reason"], "tool_use")
+        self.assertEqual(result["usage"], {"input_tokens": 11, "output_tokens": 7})
+
+    def test_text_only_stream_has_no_tool_calls(self):
+        frames = [
+            ("message_start", json.dumps({"message": {"usage": {"input_tokens": 3}}})),
+            ("content_block_start", json.dumps({"index": 0, "content_block": {"type": "text", "text": ""}})),
+            ("content_block_delta", json.dumps({"index": 0, "delta": {"type": "text_delta", "text": "just text"}})),
+            ("content_block_stop", json.dumps({"index": 0})),
+            ("message_delta", json.dumps({"delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 2}})),
+            ("message_stop", json.dumps({})),
+        ]
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        msg = result["choices"][0]["message"]
+        self.assertEqual(msg["content"], "just text")
+        self.assertNotIn("tool_calls", msg)
+        self.assertEqual(result["choices"][0]["finish_reason"], "end_turn")
+
+
+class TestResponsesStreaming(unittest.TestCase):
+    """ResponsesGatewayClient._complete_streaming -> OpenAI-shaped dict."""
+
+    def _client(self, sock=None):
+        return harvest.ResponsesGatewayClient(
+            "http://gw", "key", "gpt-5.4", 5, 16384,
+            stream_enabled=True, ttft_timeout=5, inter_token_timeout=5)
+
+    def test_text_delta_stream_assembled(self):
+        frames = [
+            (None, json.dumps({"type": "response.output_text.delta", "delta": "Hel"})),
+            (None, json.dumps({"type": "response.output_text.delta", "delta": "lo"})),
+            (None, json.dumps({"type": "response.completed",
+                               "response": {"status": "completed", "usage": {"input_tokens": 5, "output_tokens": 2}}})),
+        ]
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        msg = result["choices"][0]["message"]
+        self.assertEqual(msg["content"], "Hello")
+        self.assertNotIn("tool_calls", msg)
+        self.assertEqual(result["choices"][0]["finish_reason"], "completed")
+        self.assertEqual(result["usage"], {"input_tokens": 5, "output_tokens": 2})
+
+    def test_function_call_stream_assembled(self):
+        frames = [
+            (None, json.dumps({"type": "response.output_item.added", "output_index": 0,
+                               "item": {"type": "function_call", "call_id": "call_1", "name": "fetch"}})),
+            (None, json.dumps({"type": "response.function_call_arguments.delta", "output_index": 0,
+                               "delta": '{"url":'})),
+            (None, json.dumps({"type": "response.function_call_arguments.delta", "output_index": 0,
+                               "delta": ' "https://a.com"}'})),
+            (None, json.dumps({"type": "response.output_item.done", "output_index": 0,
+                               "item": {"type": "function_call", "call_id": "call_1", "name": "fetch",
+                                        "arguments": '{"url": "https://a.com"}'}})),
+            (None, json.dumps({"type": "response.completed",
+                               "response": {"status": "completed", "usage": {"input_tokens": 4}}})),
+        ]
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        msg = result["choices"][0]["message"]
+        self.assertEqual(len(msg["tool_calls"]), 1)
+        tc = msg["tool_calls"][0]
+        self.assertEqual(tc["id"], "call_1")
+        self.assertEqual(tc["function"]["name"], "fetch")
+        self.assertEqual(json.loads(tc["function"]["arguments"]), {"url": "https://a.com"})
+        self.assertEqual(result["choices"][0]["finish_reason"], "completed")
+
+
+class TestGeminiStreaming(unittest.TestCase):
+    """GeminiNativeGatewayClient._complete_streaming -- each SSE frame is a
+    full generateContent snapshot; parts accumulate, usage is the last frame's
+    usageMetadata, logical end is the candidate finishReason."""
+
+    def _client(self, sock=None):
+        return harvest.GeminiNativeGatewayClient(
+            "https://gw.example.com/v1", "key", "gemini-3.5-flash", 5, 16384,
+            stream_enabled=True, ttft_timeout=5, inter_token_timeout=5)
+
+    def test_text_snapshot_frames_assembled(self):
+        frames = [
+            (None, json.dumps({"candidates": [{"content": {"parts": [{"text": "Blue "}]}}],
+                               "usageMetadata": {"promptTokenCount": 10}})),
+            (None, json.dumps({"candidates": [{"content": {"parts": [{"text": "sky"}]}}],
+                               "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 2}})),
+            (None, json.dumps({"candidates": [{"content": {"parts": [{"text": "."}]}, "finishReason": "STOP"}],
+                               "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 3}})),
+        ]
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        msg = result["choices"][0]["message"]
+        self.assertEqual(msg["content"], "Blue sky.")
+        self.assertIsNone(msg["tool_calls"])
+        self.assertEqual(result["choices"][0]["finish_reason"], "stop")
+        self.assertEqual(result["usage"], {"promptTokenCount": 10, "candidatesTokenCount": 3})
+
+    def test_function_call_snapshot_frames_assembled(self):
+        frames = [
+            (None, json.dumps({"candidates": [{"content": {"parts": [
+                {"functionCall": {"name": "search", "args": {"query": "sky"}}}]}, "finishReason": "STOP"}],
+                "usageMetadata": {"promptTokenCount": 8}})),
+        ]
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        msg = result["choices"][0]["message"]
+        self.assertEqual(msg["content"], "")
+        self.assertEqual(len(msg["tool_calls"]), 1)
+        tc = msg["tool_calls"][0]
+        self.assertEqual(tc["function"]["name"], "search")
+        self.assertEqual(json.loads(tc["function"]["arguments"]), {"query": "sky"})
+        # A tool call forces finish_reason=tool_calls regardless of raw STOP.
+        self.assertEqual(result["choices"][0]["finish_reason"], "tool_calls")
+
+
+class TestGatewayStreaming(unittest.TestCase):
+    """GatewayClient._complete_streaming (OpenAI chat/completions SSE)."""
+
+    def _client(self, sock=None):
+        return harvest.GatewayClient(
+            "http://gw", "key", "model-x", 5,
+            stream_enabled=True, ttft_timeout=5, inter_token_timeout=5)
+
+    def test_content_deltas_then_done_sentinel(self):
+        frames = [
+            (None, json.dumps({"choices": [{"delta": {"content": "Hel"}}]})),
+            (None, json.dumps({"choices": [{"delta": {"content": "lo"}, "finish_reason": "stop"}]})),
+            (None, "[DONE]"),
+        ]
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        msg = result["choices"][0]["message"]
+        self.assertEqual(msg["content"], "Hello")
+        self.assertNotIn("tool_calls", msg)
+        self.assertEqual(result["choices"][0]["finish_reason"], "stop")
+
+    def test_usage_only_final_chunk_with_empty_choices(self):
+        # stream_options.include_usage yields a trailing choices:[] usage-only
+        # chunk after [DONE]-less finish -- usage must be captured, no crash on
+        # the empty choices list.
+        frames = [
+            (None, json.dumps({"choices": [{"delta": {"content": "hi"}, "finish_reason": "stop"}]})),
+            (None, json.dumps({"choices": [], "usage": {"prompt_tokens": 5, "completion_tokens": 1}})),
+            (None, "[DONE]"),
+        ]
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        self.assertEqual(result["choices"][0]["message"]["content"], "hi")
+        self.assertEqual(result["usage"], {"prompt_tokens": 5, "completion_tokens": 1})
+
+    def test_tool_call_delta_fragments_assembled(self):
+        frames = [
+            (None, json.dumps({"choices": [{"delta": {"tool_calls": [
+                {"index": 0, "id": "call_1", "function": {"name": "fetch", "arguments": '{"url":'}}]}}]})),
+            (None, json.dumps({"choices": [{"delta": {"tool_calls": [
+                {"index": 0, "function": {"arguments": ' "https://a.com"}'}}]}, "finish_reason": "tool_calls"}]})),
+            (None, "[DONE]"),
+        ]
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        tc = result["choices"][0]["message"]["tool_calls"][0]
+        self.assertEqual(tc["id"], "call_1")
+        self.assertEqual(tc["function"]["name"], "fetch")
+        self.assertEqual(json.loads(tc["function"]["arguments"]), {"url": "https://a.com"})
+
+
+def _no_retry(attempt_fn, backoffs=None):
+    """Passthrough replacement for _run_stream_attempt_with_retry that runs a
+    single attempt so a client's raw streaming exception (StreamConnectionLost
+    etc.) propagates uncaught -- lets a test assert the exact exception the
+    attempt raises instead of the RuntimeError the retry wrapper would wrap it
+    in after exhausting backoffs."""
+    return attempt_fn()
+
+
+class TestStreamWatchdog(unittest.TestCase):
+    """TTFT/inter-token fail-fast watchdog behavior."""
+
+    def test_ttft_timeout_retries_then_raises_runtime_error(self):
+        # A connect/first-frame timeout surfaces as socket.timeout when the
+        # client calls next(stream); it is retryable, so the wrapper follows
+        # the full _COMPLETION_RETRY_BACKOFFS schedule (4 sleeps, 5 attempts)
+        # and then raises RuntimeError rather than hanging.
+        client = harvest.GatewayClient("http://gw", "key", "model-x", 5,
+                                       stream_enabled=True, ttft_timeout=5, inter_token_timeout=5)
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_raising(socket.timeout("ttft"))), \
+             mock.patch("harvest.time.sleep") as sleep_mock:
+            with self.assertRaises(RuntimeError):
+                client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        self.assertEqual(sleep_mock.call_count, len(harvest._COMPLETION_RETRY_BACKOFFS))
+        self.assertEqual([c.args[0] for c in sleep_mock.call_args_list],
+                         list(harvest._COMPLETION_RETRY_BACKOFFS))
+
+    def test_inter_token_tightening_fires_once_after_first_content(self):
+        # Once the first content delta arrives, the client tightens the socket
+        # from the generous TTFT window to inter_token_timeout, exactly once.
+        sock = _RecordingSocket()
+        frames = [
+            (None, json.dumps({"choices": [{"delta": {"content": "a"}}]})),
+            (None, json.dumps({"choices": [{"delta": {"content": "b"}, "finish_reason": "stop"}]})),
+            (None, "[DONE]"),
+        ]
+        client = harvest.GatewayClient("http://gw", "key", "model-x", 5,
+                                       stream_enabled=True, ttft_timeout=30, inter_token_timeout=7)
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames, sock=sock)):
+            client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+        self.assertEqual(sock.timeouts, [7])
+
+
+class TestStreamLogicalEnd(unittest.TestCase):
+    """A stream that ends without its provider-specific logical-end marker must
+    raise StreamConnectionLost (retryable) rather than return a truncated
+    result. _run_stream_attempt_with_retry is stubbed to a single attempt so
+    the raw exception is observable."""
+
+    def test_gateway_missing_done_and_finish_reason(self):
+        frames = [(None, json.dumps({"choices": [{"delta": {"content": "partial"}}]}))]
+        client = harvest.GatewayClient("http://gw", "key", "model-x", 5,
+                                       stream_enabled=True, ttft_timeout=5, inter_token_timeout=5)
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)), \
+             mock.patch("harvest._run_stream_attempt_with_retry", side_effect=_no_retry):
+            with self.assertRaises(harvest.StreamConnectionLost):
+                client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+
+    def test_anthropic_missing_message_stop(self):
+        frames = [
+            ("content_block_start", json.dumps({"index": 0, "content_block": {"type": "text", "text": ""}})),
+            ("content_block_delta", json.dumps({"index": 0, "delta": {"type": "text_delta", "text": "hi"}})),
+        ]
+        client = harvest.AnthropicGatewayClient("http://gw", "key", "claude-sonnet-5", 5, 16384,
+                                                stream_enabled=True, ttft_timeout=5, inter_token_timeout=5)
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)), \
+             mock.patch("harvest._run_stream_attempt_with_retry", side_effect=_no_retry):
+            with self.assertRaises(harvest.StreamConnectionLost):
+                client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+
+    def test_responses_missing_completed(self):
+        frames = [(None, json.dumps({"type": "response.output_text.delta", "delta": "hi"}))]
+        client = harvest.ResponsesGatewayClient("http://gw", "key", "gpt-5.4", 5, 16384,
+                                                stream_enabled=True, ttft_timeout=5, inter_token_timeout=5)
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)), \
+             mock.patch("harvest._run_stream_attempt_with_retry", side_effect=_no_retry):
+            with self.assertRaises(harvest.StreamConnectionLost):
+                client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+
+    def test_gemini_missing_finish_reason(self):
+        frames = [(None, json.dumps({"candidates": [{"content": {"parts": [{"text": "hi"}]}}],
+                                     "usageMetadata": {"promptTokenCount": 3}}))]
+        client = harvest.GeminiNativeGatewayClient("https://gw.example.com/v1", "key", "gemini-3.5-flash", 5, 16384,
+                                                   stream_enabled=True, ttft_timeout=5, inter_token_timeout=5)
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)), \
+             mock.patch("harvest._run_stream_attempt_with_retry", side_effect=_no_retry):
+            with self.assertRaises(harvest.StreamConnectionLost):
+                client.complete(messages=[{"role": "user", "content": "x"}], tools=None)
+
+
+class TestStreamRetry(unittest.TestCase):
+    """_run_stream_attempt_with_retry classification: retryable transient
+    failures are retried under _COMPLETION_RETRY_BACKOFFS; StreamNotSupported
+    propagates immediately without a retry or a sleep."""
+
+    def test_retryable_failure_then_success(self):
+        attempts = []
+
+        def attempt_fn():
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise harvest.StreamConnectionLost("dropped")
+            return {"ok": True}
+
+        with mock.patch("harvest.time.sleep") as sleep_mock:
+            result = harvest._run_stream_attempt_with_retry(attempt_fn)
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(len(attempts), 2)
+        # First retry sleeps the first backoff in the shared schedule.
+        sleep_mock.assert_called_once_with(harvest._COMPLETION_RETRY_BACKOFFS[0])
+
+    def test_stream_not_supported_propagates_without_retry(self):
+        attempts = []
+
+        def attempt_fn():
+            attempts.append(1)
+            raise harvest.StreamNotSupportedError("plain json body, not SSE")
+
+        with mock.patch("harvest.time.sleep") as sleep_mock:
+            with self.assertRaises(harvest.StreamNotSupportedError):
+                harvest._run_stream_attempt_with_retry(attempt_fn)
+        self.assertEqual(len(attempts), 1)
+        sleep_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Supplementary streaming coverage: the fixtures above always terminate a
+# frame with a trailing blank line before EOF, so the "flush a buffered
+# partial frame at EOF" branch and the readline-level socket.timeout ->
+# StreamIdleTimeout translation inside _http_stream_post itself were never
+# exercised by a real (non-mocked-away) call. These classes close that gap
+# without touching any pre-existing test.
+# ---------------------------------------------------------------------------
+
+class _RaisingSSEHTTPResponse:
+    """Like FakeSSEHTTPResponse, but readline() raises `exc` once the
+    scripted lines are exhausted instead of returning b'' (EOF) -- exercises
+    _http_stream_post's own except clause around resp.readline(), rather than
+    a test that mocks _http_stream_post away and injects the exception at the
+    generator boundary."""
+
+    def __init__(self, lines, exc, content_type="text/event-stream"):
+        self._lines = list(lines)
+        self._exc = exc
+        self.headers = {"Content-Type": content_type}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self, *args):
+        return b""
+
+    def readline(self):
+        if self._lines:
+            return self._lines.pop(0)
+        raise self._exc
+
+
+class TestStreamPostEOFAndTimeout(unittest.TestCase):
+    """_http_stream_post: EOF-flush of an unterminated frame, and the
+    readline-level socket.timeout -> StreamIdleTimeout translation."""
+
+    def test_first_yield_is_the_response_object_itself(self):
+        fake = FakeSSEHTTPResponse([b"data: x\n", b"\n"])
+        with mock.patch("harvest.urllib.request.urlopen", return_value=fake):
+            stream = harvest._http_stream_post("http://gw/stream", {}, {}, 5)
+            resp = next(stream)
+        self.assertIs(resp, fake)
+
+    def test_eof_without_trailing_blank_line_flushes_buffered_frame(self):
+        # No terminating blank line before EOF (b"") -- the partial frame
+        # sitting in data_lines/event_type must still be yielded, not
+        # silently dropped.
+        fake = FakeSSEHTTPResponse([b"event: message\n", b"data: partial\n"])
+        with mock.patch("harvest.urllib.request.urlopen", return_value=fake):
+            stream = harvest._http_stream_post("http://gw/stream", {}, {}, 5)
+            next(stream)
+            frames = list(stream)
+        self.assertEqual(frames, [("message", "partial")])
+
+    def test_eof_with_no_buffered_content_yields_nothing(self):
+        # Clean EOF right after a terminated frame -- no extra empty frame.
+        fake = FakeSSEHTTPResponse([b"data: x\n", b"\n"])
+        with mock.patch("harvest.urllib.request.urlopen", return_value=fake):
+            stream = harvest._http_stream_post("http://gw/stream", {}, {}, 5)
+            next(stream)
+            frames = list(stream)
+        self.assertEqual(frames, [(None, "x")])
+
+    def test_readline_socket_timeout_raises_stream_idle_timeout(self):
+        # A real socket.timeout surfacing from readline() itself (e.g. the
+        # inter-token watchdog firing) is translated to StreamIdleTimeout at
+        # the _http_stream_post call site, not left as a bare socket.timeout.
+        fake = _RaisingSSEHTTPResponse([b"data: x\n", b"\n"], socket.timeout("idle"))
+        with mock.patch("harvest.urllib.request.urlopen", return_value=fake):
+            stream = harvest._http_stream_post("http://gw/stream", {}, {}, 5)
+            next(stream)
+            self.assertEqual(next(stream), (None, "x"))  # one complete frame, no raise yet
+            with self.assertRaises(harvest.StreamIdleTimeout):
+                next(stream)
+
+    def test_readline_connection_reset_raises_stream_idle_timeout(self):
+        # ConnectionResetError is in the same _STREAM_READ_EXCEPTIONS set and
+        # collapses to StreamIdleTimeout exactly like socket.timeout does --
+        # the caller's retry loop treats both as transient regardless of the
+        # underlying exception type.
+        fake = _RaisingSSEHTTPResponse([], ConnectionResetError("reset"))
+        with mock.patch("harvest.urllib.request.urlopen", return_value=fake):
+            stream = harvest._http_stream_post("http://gw/stream", {}, {}, 5)
+            next(stream)
+            with self.assertRaises(harvest.StreamIdleTimeout):
+                next(stream)
+
+
+class TestAnthropicStreamingErrorEvent(unittest.TestCase):
+    """AnthropicGatewayClient._complete_streaming: a mid-stream SSE `error`
+    event is a hard signal from the provider, not a malformed frame -- must
+    raise StreamConnectionLost so the retry wrapper reattempts rather than
+    returning a truncated result."""
+
+    def _client(self):
+        return harvest.AnthropicGatewayClient(
+            "http://gw", "key", "claude-sonnet-5", 5, 16384,
+            stream_enabled=True, ttft_timeout=5, inter_token_timeout=5)
+
+    def test_error_event_mid_stream_raises_stream_connection_lost(self):
+        frames = [
+            ("message_start", json.dumps({"message": {"usage": {"input_tokens": 5}}})),
+            ("content_block_start", json.dumps({"index": 0, "content_block": {"type": "text", "text": ""}})),
+            ("content_block_delta", json.dumps({"index": 0, "delta": {"type": "text_delta", "text": "hi"}})),
+            ("error", json.dumps({"type": "error", "error": {"type": "overloaded_error", "message": "boom"}})),
+        ]
+        with mock.patch("harvest._http_stream_post", side_effect=_stream_of(frames)), \
+             mock.patch("harvest._run_stream_attempt_with_retry", side_effect=_no_retry):
+            with self.assertRaises(harvest.StreamConnectionLost):
+                self._client().complete(messages=[{"role": "user", "content": "x"}], tools=None)
 
 
 if __name__ == "__main__":

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -5134,7 +5134,7 @@ class TestGeminiStreaming(unittest.TestCase):
             result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=None)
         msg = result["choices"][0]["message"]
         self.assertEqual(msg["content"], "Blue sky.")
-        self.assertIsNone(msg["tool_calls"])
+        self.assertNotIn("tool_calls", msg)
         self.assertEqual(result["choices"][0]["finish_reason"], "stop")
         self.assertEqual(result["usage"], {"promptTokenCount": 10, "candidatesTokenCount": 3})
 


### PR DESCRIPTION
## Summary

- 4 条 completion 路径（Anthropic/Responses/Gemini/GatewayClient）从非流式改为 SSE 流式传输
- 双阶段 socket 超时看门狗：TTFT 300s → 收到首字后收紧到 inter-token 90s
- 网关卡死时的失败检测从 600s 压缩到 90s 级别（fail-fast，非修复根因）
- 每 provider 可配置逃生开关回退非流式（`*_stream` config 键）
- 真实网关探针三路（claude/gpt/gemini）验证通过
- 417 测试全绿（原 387 + 新增 30 流式路径测试）

## Context

非流式请求在高 effort + 长推理场景下被网关卡死 ~241s（kiro.rs#67），流式不修复根因但能更快感知卡死并进入重试链。决策记录：research 仓 ADR-013。

## Test plan

- [x] 全量单测 417 green
- [x] 真实网关探针：claude-sonnet-5 (13s) / gpt-5.4 (1.9s) / gemini-3.5-flash (48.6s) 三路流式正常
- [x] gateway_stream_options=false 降级验证（当前网关不支持 stream_options）
- [x] 逃生开关验证：*_stream=false 时走原有非流式路径，现有 387 测试不受影响