### PR TITLE
fix(plan-review): 修复两个 Blocker — SSE 坏帧截断 + first_char SIGPIPE 崩溃

### DIFF
--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -937,7 +937,15 @@ else
       # response, not an SSE stream), must skip the SSE parser — feeding an error
       # JSON through the "data: " cleaning pipeline silently drops it and yields an
       # empty REVIEW with no diagnosis.
-      first_char=$(tr -d '[:space:]' < "$ENGINE_OUT" 2>/dev/null | head -c 1)
+      # SIGPIPE-safe first-char probe: `tr <big-file | head -c 1` lets head close
+      # the pipe after 1 byte while tr is still streaming the whole body, so tr
+      # dies with SIGPIPE (141). Under `set -o pipefail` the pipeline inherits 141
+      # and `set -e` then kills the hook mid-REST-fallback — before any decision
+      # JSON is emitted — on any sizable body (a normal long review response is
+      # enough). Bounding the read with a leading `head -c 100` means no stage
+      # faces an unbounded producer, so nothing gets SIGPIPE; 100 bytes is ample
+      # to find the first non-space char (leading whitespace before '{'/'data:').
+      first_char=$(head -c 100 "$ENGINE_OUT" 2>/dev/null | tr -d '[:space:]' | head -c 1)
       case "$rest_http_status" in
         2[0-9][0-9]) is_2xx=1 ;;
         *) is_2xx=0 ;;

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -957,13 +957,24 @@ else
           fi
         fi
       else
-        # SSE cleaning pipeline: strip the "data: " prefix, drop the non-JSON
-        # "[DONE]" terminator (feeding it to jq raw would abort the parse and lose
-        # every chunk after it), join delta.content across chunks.
-        # -rj: raw output, no per-value newline — O(1) memory, no giant array build.
-        # "// empty": role-only first frame / finish_reason-only last frame carry
-        # no content key; without this jq would emit a literal "null" per frame.
-        REVIEW=$(grep '^data: ' "$ENGINE_OUT" | sed 's/^data: //' | grep -v '^\[DONE\]' | jq -rj '.choices[0].delta.content // empty' 2>/dev/null || true)
+        # SSE cleaning pipeline: strip the "data: " prefix, then parse each frame
+        # in isolation and join delta.content across chunks.
+        #   -R  : read each line as a raw string (not pre-parsed JSON), so ONE
+        #         malformed frame cannot abort the whole parse.
+        #   fromjson? : parse the line to JSON, but the trailing "?" swallows a
+        #         parse error on that single line and skips it — a truncated /
+        #         garbled mid-stream frame (transient gateway hiccup) drops just
+        #         itself instead of discarding every chunk after it. The old
+        #         "-rj '.choices...'" form fed the whole stream to jq at once, so
+        #         a single bad frame aborted parsing and SILENTLY truncated the
+        #         review (2>/dev/null || true hid the exit 5) — a partial body can
+        #         carry a stale verdict and wrongly approve. fromjson? also makes
+        #         the non-JSON "[DONE]" terminator a no-op; the explicit grep -v
+        #         below is kept as belt-and-suspenders and to document intent.
+        #   -j  : join output, no per-value newline — O(1) memory, streaming.
+        #   "// empty": role-only first frame / finish_reason-only last frame /
+        #         empty-choices usage tail carry no content key — skip, don't emit "null".
+        REVIEW=$(grep '^data: ' "$ENGINE_OUT" | sed 's/^data: //' | grep -v '^\[DONE\]' | jq -j -R 'fromjson? | .choices[0].delta.content // empty' 2>/dev/null || true)
       fi
 
       raw_bytes=$(wc -c < "$ENGINE_OUT" | tr -d ' ')

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -1751,6 +1751,30 @@ SCRIPT_EOF
   assert_log_contains "rest-debug api_error=boom upstream"
 }
 
+# 86d-2. Large SSE body → first_char probe must not SIGPIPE-kill the hook
+@test "rest-sse: large body does not SIGPIPE-crash the first-char probe" {
+  create_failing_engine "agy" 1
+  export REVIEW_API_URL="http://localhost:9999"
+  export REVIEW_API_KEY="test-key"
+  # A big (~200KB) valid SSE body. The first_char probe `tr <file | head -c 1`
+  # would let head close the pipe after 1 byte while tr streams the whole body →
+  # tr dies with SIGPIPE (141); under set -o pipefail + set -e that killed the
+  # hook mid-fallback, emitting NO decision JSON. The bounded `head -c 100 | tr`
+  # form must survive and still parse the stream to a verdict.
+  local big_content
+  big_content="<verdict>APPROVE</verdict> $(printf 'y%.0s' $(seq 1 200000))"
+  create_mock_curl_sse "$big_content"
+  INPUT=$(build_input)
+
+  # Must NOT crash: a valid JSON decision must be emitted (assert_*_json checks
+  # exit 0 + parseable JSON — a SIGPIPE crash would fail both).
+  run_hook
+  assert_ack_approve_json
+
+  run_hook
+  assert_approve_json
+}
+
 # 86e. Oversized prompt (> 256KB) → skip agy, log agy-skip, fall to REST
 @test "rest-sse: oversized prompt → skip agy, REST fallback used" {
   # A plan body north of 256KB trips the ARG_MAX guard: agy is skipped (its prompt

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -1675,6 +1675,50 @@ SCRIPT_EOF
   [[ "$reason" == *"Survived the DONE terminator"* ]]
 }
 
+# 86b-2. Malformed mid-stream frame → isolated (fromjson?), later frames survive
+@test "rest-sse: malformed mid-stream frame does not truncate the review" {
+  create_failing_engine "agy" 1
+  export REVIEW_API_URL="http://localhost:9999"
+  export REVIEW_API_KEY="test-key"
+  # A truncated/garbled JSON frame sits BETWEEN two good frames. The old whole-
+  # stream `jq -rj '.choices...'` would abort at the bad frame and silently drop
+  # every chunk after it — here that would lose the [Critical] content following
+  # the verdict, risking a stale/misleading review. `jq -R 'fromjson?'` must skip
+  # only the bad frame and keep both good frames intact.
+  cat > "${MOCK_BIN}/curl" << 'SCRIPT_EOF'
+#!/bin/bash
+out_file=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out_file="$2"; shift 2 ;;
+    --speed-limit|--speed-time) shift 2 ;;
+    --no-buffer) shift ;;
+    *)  shift ;;
+  esac
+done
+[ -n "$out_file" ] && cat > "$out_file" << 'BODY'
+data: {"choices":[{"delta":{"content":"<verdict>CONCERNS</verdict>"}}]}
+
+data: {"choices":[{"delta":{"content":"truncated frame
+
+data: {"choices":[{"delta":{"content":"\n[Critical] survived the bad frame"}}]}
+
+data: [DONE]
+BODY
+printf '200'
+SCRIPT_EOF
+  chmod +x "${MOCK_BIN}/curl"
+  INPUT=$(build_input)
+
+  run_hook
+  assert_deny_json
+  local reason
+  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+  # Both the verdict AND the post-bad-frame content must survive.
+  [[ "$reason" == *"CONCERNS"* ]]
+  [[ "$reason" == *"survived the bad frame"* ]]
+}
+
 # 86c. curl exit 28 (stall watchdog) → not parsed, fail-deny with stall reason
 @test "rest-sse: curl exit 28 (stall) → fail-deny, not fed to parser" {
   create_failing_engine "agy" 1


### PR DESCRIPTION
## Summary

修复独立 code review 发现的**两个独立 Blocker**（均在 v1.1.0 REST SSE 路径，#90 引入）。

## Blocker 1：SSE 坏帧导致静默截断（可能误放行）

SSE 解析把整流一次性喂 `jq -rj '.choices[0].delta.content'`。网关中途吐一个坏 JSON 帧时 jq 在坏帧处 abort，丢弃其后所有内容，`2>/dev/null || true` 吞掉 exit 5 → 静默截断，正文可能只剩前半段 verdict、丢后续 Critical 意见 → 误放行。

**修复**：`jq -j -R 'fromjson? | .choices[0].delta.content // empty'`——`-R` 逐行读原始串，`fromjson?` 让坏帧只丢自己，单进程 O(1) 流式不变。

## Blocker 2：first_char 探测 SIGPIPE 崩溃

非 SSE 错误旁路探测 body 首字符：`tr -d '[:space:]' < "$ENGINE_OUT" | head -c 1`。head 读 1 字节即关管道，tr 仍在流式输出整个 body → tr 收 SIGPIPE 退 141；`set -o pipefail` + `set -e` 随即杀掉整个 hook，发生在 REST fallback 中途、任何决策 JSON 输出之前。**REST 响应体稍大（正常长审阅即足够）就崩**，崩后 ExitPlanMode 拿不到决策。实测 500KB body → 脚本 exit 141。

**修复**：`head -c 100 "$ENGINE_OUT" | tr -d '[:space:]' | head -c 1`——前置 head 钳读取上限到 100 字节，无 stage 面对无界生产者，无人吃 SIGPIPE。

## Tested

- 新增回归测试 86b-2（坏帧隔离）、86d-2（大 body 不 SIGPIPE）
- **两个测试均已验证：旧形式红（后者 exit 141）、新形式绿**（非假绿）
- 全套 **165** 用例通过（163 + 2 新增）；`bash -n` 通过

## 归属

Blocker 1 我独立复现；Blocker 2 由独立 review 报告（我漏了），已复现确认并修复。
