### PR TITLE
fix(harvest): gemini thought_signature 丢失导致多轮 400 (v1.10.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest_clients/gemini.py
+++ b/plugins/deep-research/scripts/harvest_clients/gemini.py
@@ -87,7 +87,11 @@ def _oai_messages_to_gemini(messages):
       messages are concatenated with '\\n\\n', never overwritten by a later
       one). None when there is no system message.
     - role=assistant -> role "model"; text content becomes a text part,
-      each tool_call becomes a functionCall part.
+      each tool_call becomes a functionCall part. When the internal
+      tool_call dict carries a `thought_signature` (captured by
+      _gemini_resp_to_oai off the response's sibling `thoughtSignature`
+      key), it is echoed back as a `thoughtSignature` sibling key on the
+      rebuilt part; when absent it is omitted, never fabricated.
     - role=tool      -> OpenAI's tool message carries no function name, but
       Gemini's functionResponse requires one, so a forward pass records
       {tool_call_id: function_name} from every assistant tool_call seen so
@@ -122,7 +126,10 @@ def _oai_messages_to_gemini(messages):
                     args = json.loads(fn.get("arguments") or "{}")
                 except json.JSONDecodeError:
                     args = {}
-                parts.append({"functionCall": {"name": name, "args": args}})
+                part = {"functionCall": {"name": name, "args": args}}
+                if tc.get("thought_signature") is not None:
+                    part["thoughtSignature"] = tc["thought_signature"]
+                parts.append(part)
             if not parts:
                 parts = [{"text": ""}]
             contents.append({"role": "model", "parts": parts})
@@ -167,7 +174,16 @@ def _gemini_resp_to_oai(resp):
     parsed tool_calls force "tool_calls" (highest priority, regardless of
     the raw finishReason); otherwise "STOP"->"stop", "MAX_TOKENS"->"length",
     and any other raw value is lowercased and passed through as-is (never
-    forged into "stop")."""
+    forged into "stop").
+
+    Gemini 3-series thinking models attach an opaque `thoughtSignature` to a
+    `functionCall` part as a sibling key (not a field of functionCall itself).
+    When present it is carried through onto the tool_call dict as
+    `thought_signature` (snake_case, matching this codebase's internal dict
+    convention) so `_oai_messages_to_gemini` can echo it back verbatim on
+    replay. It is per-part optional -- on parallel function calls only the
+    first part may carry a signature -- so absence means the key is omitted
+    entirely, never fabricated as None."""
     candidates = resp.get("candidates")
     if not candidates:
         block_reason = (resp.get("promptFeedback") or {}).get("blockReason")
@@ -186,14 +202,17 @@ def _gemini_resp_to_oai(resp):
             text_parts.append(part["text"])
         elif "functionCall" in part:
             fc = part["functionCall"]
-            tool_calls.append({
+            tc = {
                 "id": f"call_{uuid.uuid4().hex[:8]}",
                 "type": "function",
                 "function": {
                     "name": fc.get("name", ""),
                     "arguments": json.dumps(fc.get("args", {}), ensure_ascii=False),
                 },
-            })
+            }
+            if "thoughtSignature" in part:
+                tc["thought_signature"] = part["thoughtSignature"]
+            tool_calls.append(tc)
     message = {"role": "assistant", "content": "".join(text_parts)}
     if tool_calls:
         message["tool_calls"] = tool_calls
@@ -299,14 +318,17 @@ class GeminiNativeGatewayClient:
                             text_parts.append(part["text"])
                         elif "functionCall" in part:
                             fc = part["functionCall"]
-                            tool_calls.append({
+                            tc = {
                                 "id": f"call_{uuid.uuid4().hex[:8]}",
                                 "type": "function",
                                 "function": {
                                     "name": fc.get("name", ""),
                                     "arguments": json.dumps(fc.get("args", {}), ensure_ascii=False),
                                 },
-                            })
+                            }
+                            if "thoughtSignature" in part:
+                                tc["thought_signature"] = part["thoughtSignature"]
+                            tool_calls.append(tc)
                     raw_finish = candidate.get("finishReason")
                     if raw_finish:
                         seen_logical_end = True

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -3871,6 +3871,44 @@ class TestGeminiMessagesConversion(unittest.TestCase):
         self.assertEqual(parts[0], {"text": "thinking"})
         self.assertEqual(parts[1]["functionCall"], {"name": "search", "args": {"query": "q"}})
 
+    def test_assistant_function_call_with_signature_replayed_as_sibling_key(self):
+        msgs = [{"role": "assistant", "content": None,
+                 "tool_calls": [{"id": "t1", "function": {"name": "search",
+                                 "arguments": json.dumps({"query": "q"})},
+                                 "thought_signature": "sig-xyz"}]}]
+        _s, contents = harvest._oai_messages_to_gemini(msgs)
+        part = contents[0]["parts"][0]
+        self.assertEqual(part["functionCall"], {"name": "search", "args": {"query": "q"}})
+        self.assertEqual(part["thoughtSignature"], "sig-xyz")
+
+    def test_assistant_function_call_without_signature_omits_key(self):
+        msgs = [{"role": "assistant", "content": None,
+                 "tool_calls": [{"id": "t1", "function": {"name": "search",
+                                 "arguments": json.dumps({"query": "q"})}}]}]
+        _s, contents = harvest._oai_messages_to_gemini(msgs)
+        part = contents[0]["parts"][0]
+        self.assertNotIn("thoughtSignature", part)
+
+    def test_round_trip_response_to_replay_preserves_signature(self):
+        # Direct regression test for the "position 2" HTTP 400: the signature
+        # must survive raw response -> internal OAI shape -> replayed Gemini
+        # contents unbroken, or turn 2 of a multi-round tool-call conversation
+        # gets rejected server-side.
+        resp = {"candidates": [{"finishReason": "STOP", "content": {"parts": [
+            {"functionCall": {"name": "search", "args": {"q": "x"}}, "thoughtSignature": "sig-roundtrip"},
+        ]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        assistant_msg = oai["choices"][0]["message"]
+        messages = [
+            assistant_msg,
+            {"role": "tool", "tool_call_id": assistant_msg["tool_calls"][0]["id"],
+             "content": json.dumps({"result": "ok"})},
+        ]
+        _s, contents = harvest._oai_messages_to_gemini(messages)
+        model_turn = next(c for c in contents if c["role"] == "model")
+        fc_part = next(p for p in model_turn["parts"] if "functionCall" in p)
+        self.assertEqual(fc_part["thoughtSignature"], "sig-roundtrip")
+
     def test_tool_role_resolves_name_from_prior_assistant_call(self):
         msgs = [
             {"role": "assistant", "content": None,
@@ -3971,6 +4009,32 @@ class TestGeminiRespToOai(unittest.TestCase):
         self.assertEqual(len(tool_calls), 2)
         ids = [tc["id"] for tc in tool_calls]
         self.assertEqual(len(set(ids)), 2)
+
+    def test_function_call_with_thought_signature_captured(self):
+        resp = {"candidates": [{"content": {"parts": [
+            {"functionCall": {"name": "search", "args": {"q": "x"}}, "thoughtSignature": "sig-abc"},
+        ]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        tool_calls = oai["choices"][0]["message"]["tool_calls"]
+        self.assertEqual(tool_calls[0]["thought_signature"], "sig-abc")
+
+    def test_function_call_without_thought_signature_key_absent_not_none(self):
+        resp = {"candidates": [{"content": {"parts": [
+            {"functionCall": {"name": "search", "args": {"q": "x"}}},
+        ]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        tool_calls = oai["choices"][0]["message"]["tool_calls"]
+        self.assertNotIn("thought_signature", tool_calls[0])
+
+    def test_parallel_function_calls_only_first_has_signature(self):
+        resp = {"candidates": [{"content": {"parts": [
+            {"functionCall": {"name": "search", "args": {"q": "1"}}, "thoughtSignature": "sig-1"},
+            {"functionCall": {"name": "fetch", "args": {"url": "u"}}},
+        ]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        tool_calls = oai["choices"][0]["message"]["tool_calls"]
+        self.assertEqual(tool_calls[0]["thought_signature"], "sig-1")
+        self.assertNotIn("thought_signature", tool_calls[1])
 
     def test_max_tokens_maps_to_length(self):
         resp = {"candidates": [{"finishReason": "MAX_TOKENS",
@@ -5154,6 +5218,18 @@ class TestGeminiStreaming(unittest.TestCase):
         self.assertEqual(json.loads(tc["function"]["arguments"]), {"query": "sky"})
         # A tool call forces finish_reason=tool_calls regardless of raw STOP.
         self.assertEqual(result["choices"][0]["finish_reason"], "tool_calls")
+
+    def test_function_call_streaming_frame_captures_thought_signature(self):
+        frames = [
+            (None, json.dumps({"candidates": [{"content": {"parts": [
+                {"functionCall": {"name": "search", "args": {"query": "sky"}},
+                 "thoughtSignature": "sig-stream"}]}, "finishReason": "STOP"}],
+                "usageMetadata": {"promptTokenCount": 8}})),
+        ]
+        with mock.patch("harvest_clients.base._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        msg = result["choices"][0]["message"]
+        self.assertEqual(msg["tool_calls"][0]["thought_signature"], "sig-stream")
 
 
 class TestGatewayStreaming(unittest.TestCase):


### PR DESCRIPTION
## 背景

`m1`（gemini-3.5-flash 面板 worker）在真实调研任务中，第二轮工具调用稳定收到 HTTP 400：

```
HTTP 400 opening stream: Function call is missing a thought_signature in
functionCall parts. This is required for tools to work correctly...
function call `default_api:search`, position 2
```

根因：Gemini 3 系列思考模型的 `functionCall` part 会带一个不透明的 `thoughtSignature` sibling key，多轮重放历史时必须原样回传，否则服务端拒绝。`harvest_clients/gemini.py` 的三处协议转换都丢了这个字段。

## 改动

仅 `plugins/deep-research/scripts/harvest_clients/gemini.py`：

- `_gemini_resp_to_oai`：解析 `functionCall` part 时捕获 sibling `thoughtSignature`，写入 tool_call 的 `thought_signature`（snake_case），缺失时不写入（不伪造 None）
- `GeminiNativeGatewayClient._complete_streaming`：SSE 帧解析同样处理
- `_oai_messages_to_gemini`：重建 `functionCall` part 时，若内部 tool_call 带 `thought_signature` 则回填为 `thoughtSignature` sibling key

并行 function call 场景下，只有第一个 part 可能带签名，其余合法地没有——不伪造。

## 测试

`plugins/deep-research/tests/test_harvest.py` 新增 7 例，覆盖阻塞与流式两条路径：

- `TestGeminiRespToOai`：捕获签名 / 无签名时不伪造 / 并行调用仅首个带签名
- `TestGeminiMessagesConversion`：回填为 sibling key / 无签名时不回填 / **往返回归测试**（response → oai tool_call → 重放 messages → 签名不丢，直接复现本 bug）
- `TestGeminiStreaming`：SSE 帧同样捕获签名

`python3 -m unittest tests.test_harvest -v`：424 passed（baseline 417 + 7 新增），无回归。

## 版本

`plugins/deep-research/.claude-plugin/plugin.json` 与 `.claude-plugin/marketplace.json` 同步 bump `1.10.0` → `1.10.1`。

fix #92
