### PR TITLE
fix(doc-gate): 排除 intake/ — deep-research G0 产物免门禁

### DIFF
--- a/plugins/doc-gate/scripts/_doc_gate_exclude.sh
+++ b/plugins/doc-gate/scripts/_doc_gate_exclude.sh
@@ -6,9 +6,10 @@ doc_gate_is_excluded_path() {
   local fp="$1"
   # location 排除（prepend / 统一处理相对路径）
   # pipeline: deep-research 机器生成中间产物，doc-maintenance 工作流不适用。
+  # intake: deep-research G0 需求门产物（research-goal 等），Lead 半自动生成。
   # deliverables 刻意【不】排除——最终交付散文档受治理。
   case "/$fp" in
-    */.claude/*|*/.claude-plugin/*|*/.agents/directives/*|*/node_modules/*|*/.git/*|*/logs/*|*/pipeline/*) return 0 ;;
+    */.claude/*|*/.claude-plugin/*|*/.agents/directives/*|*/node_modules/*|*/.git/*|*/logs/*|*/pipeline/*|*/intake/*) return 0 ;;
   esac
   # 临时目录排除（绝对路径直配）
   case "$fp" in

--- a/plugins/doc-gate/tests/exclude.bats
+++ b/plugins/doc-gate/tests/exclude.bats
@@ -34,6 +34,16 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "excluded: intake/requirements/research-goal.md (deep-research G0 product)" {
+  run doc_gate_is_excluded_path "/project/intake/requirements/research-goal.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "excluded: intake/background/context.md (deep-research G0 product)" {
+  run doc_gate_is_excluded_path "/project/intake/background/context.md"
+  [ "$status" -eq 0 ]
+}
+
 # ============================================================
 # NOT excluded (return 1) — deliverables stays governed
 # ============================================================

--- a/plugins/doc-gate/tests/skill-gate.bats
+++ b/plugins/doc-gate/tests/skill-gate.bats
@@ -182,6 +182,13 @@ teardown() {
   [ -z "$HOOK_STDOUT" ]
 }
 
+@test "path exclude: intake/requirements/research-goal.md → silent allow (deep-research G0)" {
+  INPUT=$(build_edit_input file_path=/project/intake/requirements/research-goal.md)
+  run_gate
+  assert_allowed
+  [ -z "$HOOK_STDOUT" ]
+}
+
 @test "gate: deliverables/final/report.md without marker → deny (final deliverable, governed)" {
   INPUT=$(build_edit_input file_path=/project/deliverables/final/report.md)
   run_gate

--- a/plugins/doc-gate/tests/test_exclude.py
+++ b/plugins/doc-gate/tests/test_exclude.py
@@ -39,3 +39,25 @@ def test_pipeline_excluded_deliverables_and_docs_included(tmp_path):
 
     assert docs_rel in all_files
     assert docs_rel in corpus_paths
+
+
+def test_intake_excluded(tmp_path):
+    _write(tmp_path / "intake" / "requirements" / "research-goal.md", "G0 goal")
+    _write(tmp_path / "intake" / "background" / "context.md", "background")
+    _write(tmp_path / "deliverables" / "final" / "report.md", "final report")
+
+    corpus, all_files, _forward, _backward = build_corpus_and_graph(str(tmp_path))
+
+    corpus_paths = {doc["path"] for doc in corpus}
+
+    intake_goal = str(Path("intake") / "requirements" / "research-goal.md")
+    intake_bg = str(Path("intake") / "background" / "context.md")
+    deliverables_rel = str(Path("deliverables") / "final" / "report.md")
+
+    assert intake_goal not in all_files
+    assert intake_goal not in corpus_paths
+    assert intake_bg not in all_files
+    assert intake_bg not in corpus_paths
+
+    assert deliverables_rel in all_files
+    assert deliverables_rel in corpus_paths

--- a/plugins/doc-gate/tools/_doc_gate_common.py
+++ b/plugins/doc-gate/tools/_doc_gate_common.py
@@ -19,7 +19,7 @@ from pathlib import Path
 # pipeline 为 deep-research 机器生成中间产物，同样不应进文档引用图；
 # deliverables（最终交付）刻意不在此列——它仍需可被 recall 索引。
 EXCLUDED_DIRS = {'.git', '.agents', 'node_modules', '.venv', 'research',
-                 'docs-graph-tests', '.claude', 'logs', 'pipeline'}
+                 'docs-graph-tests', '.claude', 'logs', 'pipeline', 'intake'}
 
 # orphans 白名单（文件名匹配）：索引 / 入口文件天然无入链，不报孤儿。
 ORPHAN_WHITELIST = {'CLAUDE.md', 'README.md', 'MEMORY.md'}


### PR DESCRIPTION
## Summary
- `_doc_gate_exclude.sh` case 列表加 `*/intake/*`，shell 层硬门禁/软门禁共享
- `_doc_gate_common.py` EXCLUDED_DIRS 加 `'intake'`，Python recall-gate 层同步
- `deliverables/` 继续受治理不动

## Why
deep-research 的 `intake/requirements/research-goal.md` 等 G0 需求门产物由 Lead 半自动生成，性质同 pipeline 中间产物，doc-maintenance 工作流对其无意义，门禁只增加摩擦。

## Test plan
- [x] `bats plugins/doc-gate/tests/exclude.bats` — 10 passed（含新增 2 case）
- [x] `bats plugins/doc-gate/tests/skill-gate.bats` — 58 passed（含新增 1 case）
- [x] `pytest plugins/doc-gate/tests/test_exclude.py` — 2 passed（含新增 1 case）