### PR TITLE
fix(harvest): jina-reader 缺 User-Agent 致 r.jina.ai 403 (v1.10.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -855,7 +855,11 @@ def _fetch_tavily_extract(cfg, url, timeout, max_chars):
 
 def _fetch_jina_reader(cfg, url, timeout, max_chars):
     api_key = os.environ.get(cfg.get("api_key_env", ""), "")
-    headers = {"Accept": "text/plain", "Accept-Encoding": "identity"}
+    # r.jina.ai rejects urllib's default "Python-urllib/3.x" UA with HTTP 403
+    # (independent of the API key -- any non-default UA gets 200). Send the
+    # same UA as _fetch_urllib_ua so this backend isn't silently 403'd.
+    headers = {"User-Agent": "Mozilla/5.0 (compatible; harvest.py/1.0)",
+               "Accept": "text/plain", "Accept-Encoding": "identity"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     req = urllib.request.Request("https://r.jina.ai/" + url, headers=headers)

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -1748,6 +1748,20 @@ class TestJinaReaderAuthHeader(unittest.TestCase):
             req = self._fetch({})
         self.assertNotIn("Authorization", req.headers)
 
+    def test_user_agent_header_present_with_key(self):
+        # r.jina.ai 403s the default "Python-urllib/3.x" UA regardless of the
+        # API key -- the UA must be sent even when authenticated.
+        req = self._fetch({"JINA_API_KEY": "secret-key"})
+        self.assertEqual(req.headers.get("User-agent"),
+                         "Mozilla/5.0 (compatible; harvest.py/1.0)")
+
+    def test_user_agent_header_present_without_key(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JINA_API_KEY", None)
+            req = self._fetch({})
+        self.assertEqual(req.headers.get("User-agent"),
+                         "Mozilla/5.0 (compatible; harvest.py/1.0)")
+
 
 # ---------------------------------------------------------------------------
 # SSRF guard scope narrowing: only urllib-ua's direct, model-steered


### PR DESCRIPTION
## Summary

修复 deep-research harvest.py 的 jina-reader 后端因缺 `User-Agent` 头被 `r.jina.ai` 返回 HTTP 403 的问题。

根因：`_fetch_jina_reader` 未设 UA，urllib 默认发送 `Python-urllib/3.x`，被 r.jina.ai 拦截返回 403（与 API key 无关，实测任意 UA 均可 200）。同文件 `_fetch_urllib_ua` 早已带 UA，此后端漏了一行。

## Changes

- `harvest.py`: `_fetch_jina_reader` headers 加 `User-Agent: Mozilla/5.0 (compatible; harvest.py/1.0)`，与 urllib-ua 后端一致
- `test_harvest.py`: `TestJinaReaderAuthHeader` 补 2 个 UA 断言（带 key / 不带 key 均须发 UA）
- version 1.10.1 → 1.10.2（plugin.json + marketplace.json 双写）

## Tested

- 新增 2 个 UA 测试用例通过
- 全套 harvest 回归 426 tests OK

Closes #95
