### PR TITLE
fix(harvest): gemini 流式 thought_signature 分帧丢失致多轮 Corrupted (v1.10.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest_clients/gemini.py
+++ b/plugins/deep-research/scripts/harvest_clients/gemini.py
@@ -156,6 +156,80 @@ def _oai_messages_to_gemini(messages):
     return system_instruction, contents
 
 
+def _collect_gemini_parts(parts, text_parts, tool_calls, floating_sigs):
+    """Walk a list of Gemini content parts, accumulating text into
+    `text_parts`, functionCall parts into `tool_calls`, and any orphaned
+    `thoughtSignature` into `floating_sigs`. Shared by the blocking parser
+    (_gemini_resp_to_oai) and the streaming accumulator
+    (_complete_streaming) so both place signatures identically.
+
+    The signature is read INDEPENDENTLY of the text/functionCall branching.
+    Gemini 3 attaches it as a sibling key on the first functionCall part in
+    the aggregated (blocking) case, but a streamGenerateContent response may
+    instead deliver the thinking-state signature on a separate `thought`
+    part or a trailing empty-text part (per the official thought-signatures
+    guidance -- "the model may return the thought signature in a part with an
+    empty text content part"). The old `if "text" ... elif "functionCall"`
+    walk silently dropped any such part, so the signature never reached the
+    tool_call and the replayed functionCall was rejected server-side as a
+    corrupted/absent signature on the next turn. Capturing the signature per
+    part regardless of the part's other keys is what makes streaming behave
+    like the blocking path, which never saw a detached signature because the
+    server had already aggregated it onto the functionCall part.
+
+    A signature that rides its own functionCall part is attached to that
+    tool_call immediately (`sig = None` so it is not also double-counted as
+    floating); a signature with no functionCall in the same part is left in
+    `floating_sigs` for _attach_floating_sigs to place after the full part/
+    frame walk completes."""
+    for part in parts:
+        sig = part.get("thoughtSignature")
+        if "functionCall" in part:
+            fc = part["functionCall"]
+            tc = {
+                "id": f"call_{uuid.uuid4().hex[:8]}",
+                "type": "function",
+                "function": {
+                    "name": fc.get("name", ""),
+                    "arguments": json.dumps(fc.get("args", {}), ensure_ascii=False),
+                },
+            }
+            if sig is not None:
+                tc["thought_signature"] = sig
+                sig = None
+            tool_calls.append(tc)
+        elif "text" in part:
+            text_parts.append(part["text"])
+        if sig is not None:
+            floating_sigs.append(sig)
+
+
+def _attach_floating_sigs(tool_calls, floating_sigs):
+    """Bind a thought signature that arrived detached from its functionCall
+    part back onto the first tool_call -- and ONLY the first.
+
+    The Gemini 3 contract is strict: within one step the signature belongs to
+    the *first* functionCall part; subsequent parallel calls legitimately
+    carry none, and the server rejects a replay that puts a signature on a
+    call that should not have one. So a detached signature (delivered on a
+    separate `thought`/empty-text part, as streamGenerateContent may do) is
+    bound to tool_calls[0] only, and only when tool_calls[0] does not already
+    carry its own sibling signature. It is never spread across slots 1..N in
+    arrival order -- doing so would fabricate a signature in exactly the
+    position the contract forbids.
+
+    This is a no-op in the aggregated/blocking case, where every signature
+    already rode its functionCall part so floating_sigs is empty. Leftover
+    floating signatures (more than one, or one when slot 0 is already signed,
+    or any when there is no functionCall at all -- a pure-text turn) are
+    dropped: the run_worker loop never replays a pure-text turn to continue
+    tool calling, and the contract wants at most one signature on slot 0."""
+    if not floating_sigs or not tool_calls:
+        return
+    if "thought_signature" not in tool_calls[0]:
+        tool_calls[0]["thought_signature"] = floating_sigs[0]
+
+
 def _gemini_resp_to_oai(resp):
     """Gemini generateContent response -> OpenAI chat-completions shape so
     _extract_message and the run_worker/judge_clusters loops read it
@@ -176,14 +250,17 @@ def _gemini_resp_to_oai(resp):
     and any other raw value is lowercased and passed through as-is (never
     forged into "stop").
 
-    Gemini 3-series thinking models attach an opaque `thoughtSignature` to a
-    `functionCall` part as a sibling key (not a field of functionCall itself).
-    When present it is carried through onto the tool_call dict as
-    `thought_signature` (snake_case, matching this codebase's internal dict
-    convention) so `_oai_messages_to_gemini` can echo it back verbatim on
-    replay. It is per-part optional -- on parallel function calls only the
-    first part may carry a signature -- so absence means the key is omitted
-    entirely, never fabricated as None."""
+    Gemini 3-series thinking models attach an opaque `thoughtSignature` that
+    must be echoed back verbatim on replay (as `thought_signature`, snake_case
+    per this codebase's internal dict convention) or the next turn's replayed
+    functionCall is rejected server-side. In the aggregated response the
+    signature rides the first functionCall part as a sibling key; capture is
+    delegated to _collect_gemini_parts / _attach_floating_sigs (shared with
+    the streaming path) so a signature the server ever delivers on a separate
+    part is still bound to its tool_call rather than dropped. It is per-part
+    optional -- on parallel function calls only the first carries a signature
+    -- so absence means the key is omitted entirely, never fabricated as
+    None."""
     candidates = resp.get("candidates")
     if not candidates:
         block_reason = (resp.get("promptFeedback") or {}).get("blockReason")
@@ -197,22 +274,9 @@ def _gemini_resp_to_oai(resp):
     content_parts = (candidate.get("content") or {}).get("parts") or []
     text_parts = []
     tool_calls = []
-    for part in content_parts:
-        if "text" in part:
-            text_parts.append(part["text"])
-        elif "functionCall" in part:
-            fc = part["functionCall"]
-            tc = {
-                "id": f"call_{uuid.uuid4().hex[:8]}",
-                "type": "function",
-                "function": {
-                    "name": fc.get("name", ""),
-                    "arguments": json.dumps(fc.get("args", {}), ensure_ascii=False),
-                },
-            }
-            if "thoughtSignature" in part:
-                tc["thought_signature"] = part["thoughtSignature"]
-            tool_calls.append(tc)
+    floating_sigs = []
+    _collect_gemini_parts(content_parts, text_parts, tool_calls, floating_sigs)
+    _attach_floating_sigs(tool_calls, floating_sigs)
     message = {"role": "assistant", "content": "".join(text_parts)}
     if tool_calls:
         message["tool_calls"] = tool_calls
@@ -286,6 +350,12 @@ class GeminiNativeGatewayClient:
                 sock = _base._get_raw_socket(resp)
                 text_parts = []
                 tool_calls = []
+                # Accumulated across ALL frames, not per-frame: a thinking-
+                # state thoughtSignature can arrive on a `thought`/empty-text
+                # part in a frame after the functionCall part's frame, so
+                # detached signatures are collected stream-wide and bound to
+                # their tool_calls only once every frame has been consumed.
+                floating_sigs = []
                 usage = {}
                 finish_reason = None
                 prompt_block_reason = None
@@ -313,22 +383,7 @@ class GeminiNativeGatewayClient:
                     if content_parts and not tightened and sock is not None:
                         sock.settimeout(self.inter_token_timeout)
                         tightened = True
-                    for part in content_parts:
-                        if "text" in part:
-                            text_parts.append(part["text"])
-                        elif "functionCall" in part:
-                            fc = part["functionCall"]
-                            tc = {
-                                "id": f"call_{uuid.uuid4().hex[:8]}",
-                                "type": "function",
-                                "function": {
-                                    "name": fc.get("name", ""),
-                                    "arguments": json.dumps(fc.get("args", {}), ensure_ascii=False),
-                                },
-                            }
-                            if "thoughtSignature" in part:
-                                tc["thought_signature"] = part["thoughtSignature"]
-                            tool_calls.append(tc)
+                    _collect_gemini_parts(content_parts, text_parts, tool_calls, floating_sigs)
                     raw_finish = candidate.get("finishReason")
                     if raw_finish:
                         seen_logical_end = True
@@ -348,6 +403,11 @@ class GeminiNativeGatewayClient:
             # may arrive in frames after finishReason — see ADR-013 review #4).
             if tool_calls:
                 finish_reason = "tool_calls"
+
+            # Bind any detached signatures to their functionCalls only now,
+            # after the whole stream is consumed -- a signature frame can
+            # follow its functionCall frame.
+            _attach_floating_sigs(tool_calls, floating_sigs)
 
             message = {"role": "assistant", "content": "".join(text_parts)}
             if tool_calls:

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -4050,6 +4050,90 @@ class TestGeminiRespToOai(unittest.TestCase):
         self.assertEqual(tool_calls[0]["thought_signature"], "sig-1")
         self.assertNotIn("thought_signature", tool_calls[1])
 
+    def test_signature_on_detached_thought_part_bound_to_function_call(self):
+        # Robustness: a thinking-state signature delivered on its own part
+        # (no functionCall in that part) must still be bound to the
+        # functionCall's tool_call, not dropped. Guards the streaming layouts
+        # the official docs warn about, exercised here through the shared
+        # collector via the blocking parser.
+        resp = {"candidates": [{"content": {"parts": [
+            {"functionCall": {"name": "search", "args": {"q": "x"}}},
+            {"text": "", "thoughtSignature": "sig-detached"},
+        ]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        tool_calls = oai["choices"][0]["message"]["tool_calls"]
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["thought_signature"], "sig-detached")
+
+    def test_signature_on_standalone_part_no_text_no_fc_bound(self):
+        # A part carrying ONLY thoughtSignature (neither text nor
+        # functionCall) is not silently dropped -- its signature binds to the
+        # functionCall's tool_call.
+        resp = {"candidates": [{"content": {"parts": [
+            {"functionCall": {"name": "search", "args": {"q": "x"}}},
+            {"thoughtSignature": "sig-standalone"},
+        ]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        tool_calls = oai["choices"][0]["message"]["tool_calls"]
+        self.assertEqual(tool_calls[0]["thought_signature"], "sig-standalone")
+
+    def test_detached_signature_before_function_call_still_bound(self):
+        # Arrival order independence: a detached signature part that appears
+        # BEFORE its functionCall part is still attached (floating sigs are
+        # placed after the whole part walk completes).
+        resp = {"candidates": [{"content": {"parts": [
+            {"thoughtSignature": "sig-early"},
+            {"functionCall": {"name": "search", "args": {"q": "x"}}},
+        ]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        tool_calls = oai["choices"][0]["message"]["tool_calls"]
+        self.assertEqual(tool_calls[0]["thought_signature"], "sig-early")
+
+    def test_floating_signature_not_assigned_to_parallel_slot_when_first_signed(self):
+        # Gemini 3 contract: within a step only the FIRST functionCall carries
+        # a signature; parallel calls at slots 1..N legitimately have none and
+        # the server rejects a replay that puts a signature there. So when
+        # slot 0 already holds its own sibling signature, a stray detached
+        # signature must be DROPPED, never spilled onto the second call --
+        # doing so would fabricate a signature in the position the contract
+        # forbids.
+        resp = {"candidates": [{"content": {"parts": [
+            {"functionCall": {"name": "search", "args": {"q": "1"}}, "thoughtSignature": "sig-own"},
+            {"functionCall": {"name": "fetch", "args": {"url": "u"}}},
+            {"thoughtSignature": "sig-floating"},
+        ]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        tool_calls = oai["choices"][0]["message"]["tool_calls"]
+        self.assertEqual(tool_calls[0]["thought_signature"], "sig-own")
+        self.assertNotIn("thought_signature", tool_calls[1])
+
+    def test_floating_signature_binds_only_to_first_call_not_second(self):
+        # Detached signature + two parallel calls, neither with a sibling
+        # signature: the floating signature binds to slot 0 ONLY; slot 1 stays
+        # unsigned per contract.
+        resp = {"candidates": [{"content": {"parts": [
+            {"functionCall": {"name": "search", "args": {"q": "1"}}},
+            {"functionCall": {"name": "fetch", "args": {"url": "u"}}},
+            {"thoughtSignature": "sig-floating"},
+        ]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        tool_calls = oai["choices"][0]["message"]["tool_calls"]
+        self.assertEqual(tool_calls[0]["thought_signature"], "sig-floating")
+        self.assertNotIn("thought_signature", tool_calls[1])
+
+    def test_pure_text_turn_floating_signature_not_surfaced(self):
+        # A pure-text response (no functionCall) whose signature rides a
+        # trailing empty-text part has no tool_call to receive it; the message
+        # is plain text with no tool_calls, and nothing crashes.
+        resp = {"candidates": [{"finishReason": "STOP", "content": {"parts": [
+            {"text": "the answer"},
+            {"text": "", "thoughtSignature": "sig-orphan"},
+        ]}}]}
+        oai = harvest._gemini_resp_to_oai(resp)
+        msg = oai["choices"][0]["message"]
+        self.assertEqual(msg["content"], "the answer")
+        self.assertIsNone(msg["tool_calls"])
+
     def test_max_tokens_maps_to_length(self):
         resp = {"candidates": [{"finishReason": "MAX_TOKENS",
                                 "content": {"parts": [{"text": "cut off"}]}}]}
@@ -5244,6 +5328,87 @@ class TestGeminiStreaming(unittest.TestCase):
             result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
         msg = result["choices"][0]["message"]
         self.assertEqual(msg["tool_calls"][0]["thought_signature"], "sig-stream")
+
+    def test_signature_in_frame_after_function_call_frame_bound(self):
+        # Direct regression for the production "Corrupted thought signature."
+        # 400: streamGenerateContent may deliver the thinking-state signature
+        # on a LATER frame (an empty-text part) than the functionCall frame.
+        # The old per-frame `if text elif functionCall` walk dropped that
+        # part entirely, so the replayed functionCall carried no signature and
+        # was rejected on the next turn. The signature must bind across frames.
+        frames = [
+            (None, json.dumps({"candidates": [{"content": {"parts": [
+                {"functionCall": {"name": "search", "args": {"query": "france"}}}]}}]})),
+            (None, json.dumps({"candidates": [{"content": {"parts": [
+                {"text": "", "thoughtSignature": "sig-late-frame"}]}, "finishReason": "STOP"}],
+                "usageMetadata": {"promptTokenCount": 9}})),
+        ]
+        with mock.patch("harvest_clients.base._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        tcs = result["choices"][0]["message"]["tool_calls"]
+        self.assertEqual(len(tcs), 1)
+        self.assertEqual(tcs[0]["function"]["name"], "search")
+        self.assertEqual(tcs[0]["thought_signature"], "sig-late-frame")
+        self.assertEqual(result["choices"][0]["finish_reason"], "tool_calls")
+
+    def test_signature_on_standalone_part_frame_bound(self):
+        # A frame whose part carries ONLY thoughtSignature (no text, no
+        # functionCall) must not be dropped -- its signature binds to the
+        # earlier functionCall's tool_call.
+        frames = [
+            (None, json.dumps({"candidates": [{"content": {"parts": [
+                {"functionCall": {"name": "search", "args": {"query": "japan"}}}]}}]})),
+            (None, json.dumps({"candidates": [{"content": {"parts": [
+                {"thoughtSignature": "sig-standalone"}]}, "finishReason": "STOP"}]})),
+        ]
+        with mock.patch("harvest_clients.base._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        tcs = result["choices"][0]["message"]["tool_calls"]
+        self.assertEqual(tcs[0]["thought_signature"], "sig-standalone")
+
+    def test_streaming_round_trip_replays_cross_frame_signature(self):
+        # End-to-end guard against the #93-style self-证 gap: the signature
+        # must survive a REAL cross-frame streaming layout -> internal OAI
+        # shape -> replayed Gemini contents, so turn 2 of a multi-round tool
+        # conversation is accepted server-side. Mirrors the blocking
+        # round-trip test but drives the streaming accumulator with a
+        # detached-signature frame the old code would have dropped.
+        frames = [
+            (None, json.dumps({"candidates": [{"content": {"parts": [
+                {"functionCall": {"name": "search", "args": {"q": "x"}}}]}}]})),
+            (None, json.dumps({"candidates": [{"content": {"parts": [
+                {"text": "", "thoughtSignature": "sig-roundtrip-stream"}]}, "finishReason": "STOP"}]})),
+        ]
+        with mock.patch("harvest_clients.base._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        assistant_msg = result["choices"][0]["message"]
+        messages = [
+            assistant_msg,
+            {"role": "tool", "tool_call_id": assistant_msg["tool_calls"][0]["id"],
+             "content": json.dumps({"result": "ok"})},
+        ]
+        _s, contents = harvest._oai_messages_to_gemini(messages)
+        model_turn = next(c for c in contents if c["role"] == "model")
+        fc_part = next(p for p in model_turn["parts"] if "functionCall" in p)
+        self.assertEqual(fc_part["thoughtSignature"], "sig-roundtrip-stream")
+
+    def test_parallel_calls_first_frame_signature_second_frame_none(self):
+        # Parallel calls where only the first carries a signature (Gemini 3
+        # contract) split across frames: first tool_call keeps its signature,
+        # the second legitimately has none -- and no spurious floating
+        # signature is invented for it.
+        frames = [
+            (None, json.dumps({"candidates": [{"content": {"parts": [
+                {"functionCall": {"name": "search", "args": {"q": "1"}}, "thoughtSignature": "sig-first"}]}}]})),
+            (None, json.dumps({"candidates": [{"content": {"parts": [
+                {"functionCall": {"name": "fetch", "args": {"url": "u"}}}]}, "finishReason": "STOP"}]})),
+        ]
+        with mock.patch("harvest_clients.base._http_stream_post", side_effect=_stream_of(frames)):
+            result = self._client().complete(messages=[{"role": "user", "content": "x"}], tools=harvest.TOOL_SCHEMAS)
+        tcs = result["choices"][0]["message"]["tool_calls"]
+        self.assertEqual(len(tcs), 2)
+        self.assertEqual(tcs[0]["thought_signature"], "sig-first")
+        self.assertNotIn("thought_signature", tcs[1])
 
 
 class TestGatewayStreaming(unittest.TestCase):


### PR DESCRIPTION
## 根因

延续 #92 / #93。#93 修复后错误从 `missing` 变 `Corrupted thought signature.`，gemini-3.5-flash 面板 worker 走 SSE 流式多轮 function-calling 时**偶发** 400。

Gemini 3 流式下思考态签名可能落在**独立的 thought part / 空 text part**（官方 thought-signatures 文档明示），与 functionCall 分处不同 part 甚至不同 SSE 帧。旧代码 `if "text" elif "functionCall"` 逐 part 解析，**签名捕获嵌在 functionCall 分支内**——签名落在其他 part 时该 part 两分支都不进 → 签名整个丢弃 → 回放缺签名 → 上游判 Corrupted。非确定性来自服务端是否分帧交付。

`#93` 只覆盖阻塞路径 sibling-key 场景，绿测试是自证循环（fixture 喂臆想形状给自己解析器，从未碰真实流式 wire）。

## 修复（client 侧）

抽出共享 helper 让 blocking / streaming 行为等价：
- `_collect_gemini_parts`：签名捕获**独立于** text/functionCall 分支，detached 进 `floating_sigs`
- `_attach_floating_sigs`：流消费完后绑到 `tool_calls[0]`（且仅当 slot 0 无 sibling 签名），严格贴合「一个 step 只第一个 functionCall 带签名」契约，绝不在 slot≥1 造签名
- blocking `_gemini_resp_to_oai` 与 streaming `_complete_streaming` 共用

## 测试

- **确定性 mock**：3 种分帧形态修复前全丢签名、修复后全正确，对照组不变
- **回归**：436 单测全绿（+10：跨帧交付→回放往返、并行 slot-0-only 绑定、纯文本轮丢弃安全）
- **真实 API**：流式多轮 0 Corrupted；剥签名对照仍确定性报 missing（证明测试装置真能抓错）
- **独立对抗 review**：APPROVE + 1 CONCERN（floating 签名并行误配）已吸收 → 收紧 slot-0-only

## 影响范围

仅 gemini native 流式路径（`limits.gemini_stream=True` 默认）。gpt/claude 两路不含此字段，不受影响。

版本 1.10.2 → 1.10.3（plugin.json + marketplace.json 双写）。

Closes #97