### PR TITLE
fix(harvest): gemini 空 assistant turn 致 forced-synthesis 重试 400 (v1.10.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest_clients/gemini.py
+++ b/plugins/deep-research/scripts/harvest_clients/gemini.py
@@ -131,7 +131,15 @@ def _oai_messages_to_gemini(messages):
                     part["thoughtSignature"] = tc["thought_signature"]
                 parts.append(part)
             if not parts:
-                parts = [{"text": ""}]
+                # A degenerate assistant turn -- empty content AND no
+                # tool_calls (a thinking model that spent its whole output
+                # budget on thoughts, or a safety-stripped candidate). Gemini
+                # rejects an empty text part {"text": ""} as an uninitialized
+                # oneof ("parts[N].data: required oneof field 'data' must have
+                # one initialized field" -> HTTP 400), so fall back to a
+                # single space, mirroring _assistant_to_anthropic_content's
+                # "never emit an empty text block" rule.
+                parts = [{"text": " "}]
             contents.append({"role": "model", "parts": parts})
             continue
         if role == "tool":

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -3992,6 +3992,50 @@ class TestGeminiMessagesConversion(unittest.TestCase):
         self.assertEqual(len(user_turns), 1)
         self.assertEqual(len(user_turns[0]["parts"]), 2)
 
+    def test_empty_assistant_turn_yields_nonempty_part_not_empty_text(self):
+        # Regression for #43: a degenerate assistant message -- empty content
+        # AND no tool_calls (a thinking model that spent its whole output
+        # budget on thoughts, or a safety-stripped candidate whose only
+        # product is content="") -- must NOT serialize to {"text": ""}.
+        # Gemini rejects an empty text part as an uninitialized oneof
+        # (contents[N].parts[0].data: required oneof field 'data' must have
+        # one initialized field -> HTTP 400), which crashed the forced-
+        # synthesis retry. The fallback part must carry a non-empty field,
+        # mirroring anthropic's non-empty-content fallback.
+        for empty in ("", None):
+            _s, contents = harvest._oai_messages_to_gemini([{"role": "assistant", "content": empty}])
+            self.assertEqual(len(contents), 1)
+            self.assertEqual(contents[0]["role"], "model")
+            parts = contents[0]["parts"]
+            self.assertEqual(len(parts), 1)
+            self.assertNotEqual(parts[0].get("text"), "",
+                                f"empty content={empty!r} produced an empty text part (rejected by Gemini)")
+            self.assertTrue(parts[0].get("text"), "fallback part must be a non-empty text oneof")
+
+    def test_forced_synthesis_retry_history_produces_no_empty_parts(self):
+        # Scenario reproduction of #43's exact failure: the forced-synthesis
+        # else-branch (harvest.py) keeps a parse-failed assistant message in
+        # history then appends a user reminder. When that assistant message
+        # is empty (content=""), the replayed contents must contain no empty
+        # text part anywhere -- otherwise Gemini 400s on the retry request.
+        messages = [
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "goal"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "c1", "function": {"name": "search", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": json.dumps({"r": "A"})},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "c2", "function": {"name": "search", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c2", "content": json.dumps({"r": "B"})},
+            {"role": "assistant", "content": ""},  # forced-synthesis empty attempt
+            {"role": "user", "content": "JSON parse error: ... Re-output valid findings JSON."},
+        ]
+        _s, contents = harvest._oai_messages_to_gemini(messages)
+        for i, c in enumerate(contents):
+            for j, part in enumerate(c["parts"]):
+                self.assertNotEqual(part.get("text"), "",
+                                    f"contents[{i}].parts[{j}] is an empty text oneof: {c}")
+
 
 class TestGeminiRespToOai(unittest.TestCase):
     def test_plain_text_stop_maps_to_stop(self):

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -3992,32 +3992,54 @@ class TestGeminiMessagesConversion(unittest.TestCase):
         self.assertEqual(len(user_turns), 1)
         self.assertEqual(len(user_turns[0]["parts"]), 2)
 
-    def test_empty_assistant_turn_yields_nonempty_part_not_empty_text(self):
-        # Regression for #43: a degenerate assistant message -- empty content
+    def _assert_valid_gemini_part(self, part, where):
+        # A Gemini content part is a oneof: exactly one of text / functionCall /
+        # functionResponse must be present AND initialized. The original #99
+        # 400 ("parts[N].data: required oneof field 'data' must have one
+        # initialized field") is precisely the shape this guards against, so
+        # the assertion checks oneof presence directly rather than only
+        # `part.get("text") != ""` -- the latter passes vacuously for a part
+        # that carries NO oneof key at all (e.g. a degenerate {}), which is the
+        # exact uninitialized-oneof shape Gemini rejects. Verified against the
+        # live gateway (aapi.tbps.one, gemini-3.5-flash): {"text": ""} -> HTTP
+        # 400 with that exact message, {"text": " "} -> HTTP 200.
+        oneof_keys = [k for k in ("text", "functionCall", "functionResponse") if k in part]
+        self.assertEqual(len(oneof_keys), 1,
+                         f"{where}: part must carry exactly one oneof key, got {list(part)}: {part}")
+        key = oneof_keys[0]
+        if key == "text":
+            # An empty string is an *uninitialized* text oneof to Gemini.
+            self.assertNotEqual(part["text"], "", f"{where}: empty text oneof (rejected by Gemini): {part}")
+        else:
+            self.assertTrue(part[key], f"{where}: empty {key} oneof: {part}")
+
+    def test_empty_assistant_turn_yields_valid_nonempty_oneof_part(self):
+        # Regression for #99: a degenerate assistant message -- empty content
         # AND no tool_calls (a thinking model that spent its whole output
         # budget on thoughts, or a safety-stripped candidate whose only
         # product is content="") -- must NOT serialize to {"text": ""}.
         # Gemini rejects an empty text part as an uninitialized oneof
         # (contents[N].parts[0].data: required oneof field 'data' must have
         # one initialized field -> HTTP 400), which crashed the forced-
-        # synthesis retry. The fallback part must carry a non-empty field,
-        # mirroring anthropic's non-empty-content fallback.
+        # synthesis retry. The fallback part must be a valid, non-empty oneof,
+        # mirroring anthropic's non-empty-content fallback (anthropic.py:82).
         for empty in ("", None):
             _s, contents = harvest._oai_messages_to_gemini([{"role": "assistant", "content": empty}])
             self.assertEqual(len(contents), 1)
             self.assertEqual(contents[0]["role"], "model")
             parts = contents[0]["parts"]
-            self.assertEqual(len(parts), 1)
-            self.assertNotEqual(parts[0].get("text"), "",
-                                f"empty content={empty!r} produced an empty text part (rejected by Gemini)")
-            self.assertTrue(parts[0].get("text"), "fallback part must be a non-empty text oneof")
+            self.assertEqual(len(parts), 1, f"empty content={empty!r} must yield exactly one placeholder part")
+            self._assert_valid_gemini_part(parts[0], f"empty content={empty!r}")
 
-    def test_forced_synthesis_retry_history_produces_no_empty_parts(self):
-        # Scenario reproduction of #43's exact failure: the forced-synthesis
-        # else-branch (harvest.py) keeps a parse-failed assistant message in
-        # history then appends a user reminder. When that assistant message
-        # is empty (content=""), the replayed contents must contain no empty
-        # text part anywhere -- otherwise Gemini 400s on the retry request.
+    def test_forced_synthesis_retry_history_produces_only_valid_oneof_parts(self):
+        # Scenario reproduction of #99's exact failure (see also the live-
+        # gateway E2E recorded in the issue): the forced-synthesis else-branch
+        # (harvest.py) keeps a parse-failed assistant message in history then
+        # appends a user reminder. When that assistant message is empty
+        # (content=""), EVERY replayed part must be a valid non-empty oneof --
+        # not just "no empty text part": a content entry with zero parts, or a
+        # part missing all oneof keys, is rejected by Gemini identically to an
+        # empty text part, so the whole payload is validated part-by-part.
         messages = [
             {"role": "system", "content": "SYS"},
             {"role": "user", "content": "goal"},
@@ -4032,9 +4054,9 @@ class TestGeminiMessagesConversion(unittest.TestCase):
         ]
         _s, contents = harvest._oai_messages_to_gemini(messages)
         for i, c in enumerate(contents):
+            self.assertTrue(c["parts"], f"contents[{i}] has zero parts (rejected by Gemini): {c}")
             for j, part in enumerate(c["parts"]):
-                self.assertNotEqual(part.get("text"), "",
-                                    f"contents[{i}].parts[{j}] is an empty text oneof: {c}")
+                self._assert_valid_gemini_part(part, f"contents[{i}].parts[{j}]")
 
 
 class TestGeminiRespToOai(unittest.TestCase):


### PR DESCRIPTION
## 摘要

修复 deep-research harvest 的 Gemini-native 客户端在 forced-synthesis 重试路径下的 HTTP 400。

`_oai_messages_to_gemini` 对空 assistant turn（content 为空且无 tool_calls）的兜底 `{"text": ""}` 生成空 text part，Gemini 的 part 是 oneof，空字符串 text 被判为无已初始化字段，上游 400 拒绝，收敛重试直接 FAILED。

## 根因

空 assistant turn 经 forced-synthesis 重试分支 + 主循环 parse-retry 多路汇入 message history，`_oai_messages_to_gemini` 是单一收口点也是非法 wire format 产生处。兜底改单空格 `{"text": " "}`，与 anthropic.py `_assistant_to_anthropic_content` 的"never emit an empty text block"约定一致。

该 bug 是上游研究仓库 E2E 复测 Gemini thought_signature 修复时撞见的独立问题，与 thought_signature 无关。

## 变更

- `gemini.py`: 空 parts 兜底 `{"text": ""}` → `{"text": " "}` + 因果注释指向 anthropic 兄弟实现
- `test_harvest.py`: 新增 2 回归测试（空 assistant 非空 part / 重试 history 无空 part）
- `plugin.json` + `marketplace.json`: 1.10.3 → 1.10.4

## 测试

- 新增 2 回归测试先 Red 后 Green
- 全量 438 passed（deterministic，`pytest-randomly` 未安装）
- 修改前后各跑 3 次确认无 flake

Closes #99