### PR TITLE
refactor(harvest): backend 子包抽取，harvest.py 2451→1632 行零循环 DAG (v1.11.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.10.4",
+      "version": "1.11.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/CLAUDE.md
+++ b/plugins/deep-research/CLAUDE.md
@@ -1,0 +1,26 @@
+# deep-research 插件
+
+多模型研究采集插件。核心是 `scripts/harvest.py` 及其子模块，跑多模型 panel 采集 → judge → merge → 引用验证 pipeline。
+
+## 代码结构（改代码前必读）
+
+`scripts/harvest.py`（主编排层）+ 三个子模块，单向无环依赖 DAG：
+
+| 模块 | 职责 |
+|------|------|
+| `scripts/harvest.py` | 主编排：pipeline / worker / judge / merge / verify / CLI |
+| `scripts/harvest_safety.py` | SSRF 守卫 / 域黑名单 / 路径沙箱 / 限流 / URL 规范化（零外部依赖叶子） |
+| `scripts/harvest_search/` | 4 个 web search backend + do_search 编排 |
+| `scripts/harvest_fetch/` | 4 个 URL fetch backend + do_fetch 编排 |
+| `scripts/harvest_clients/base.py` | HTTP/SSE 原语 + curl_cffi 传输能力 |
+
+**铁律**：search 与 fetch 严格平级互不 import；safety 与 clients.base 是叶子，不 import 主模块。加 backend、改安全策略、改测试 patch（facade mock 穿透规则）前，先读完整代码地图——模块地图、依赖 DAG、维护决策树、mock 穿透约束都在其中：
+
+@../../../../research/docs/architecture/harvest-code-structure.md
+
+运行时行为 / 数据流 / 产物 schema / verify.json 状态机是另一篇正交文档（67KB，按需读，不常驻）：`research/docs/architecture/harvest-architecture.md`。
+
+## 版本
+
+功能性变更（scripts/、skills/、hooks/ 的 bug fix / feature / 重构改外部行为）须同步 bump 两处版本号：
+`.claude-plugin/plugin.json` 与仓库根 `.claude-plugin/marketplace.json` 的 deep-research 条目。两处不一致禁止 push。

--- a/plugins/deep-research/CLAUDE.md
+++ b/plugins/deep-research/CLAUDE.md
@@ -14,11 +14,11 @@
 | `scripts/harvest_fetch/` | 4 个 URL fetch backend + do_fetch 编排 |
 | `scripts/harvest_clients/base.py` | HTTP/SSE 原语 + curl_cffi 传输能力 |
 
-**铁律**：search 与 fetch 严格平级互不 import；safety 与 clients.base 是叶子，不 import 主模块。加 backend、改安全策略、改测试 patch（facade mock 穿透规则）前，先读完整代码地图——模块地图、依赖 DAG、维护决策树、mock 穿透约束都在其中：
+**铁律**：search 与 fetch 严格平级互不 import；safety 与 clients.base 是叶子，不 import 主模块。加 backend、改安全策略、改测试 patch（facade mock 穿透规则）前，先读上表模块地图 + 本节铁律。
 
-@../../../../research/docs/architecture/harvest-code-structure.md
+**mock 穿透约束**：测试 patch 必须打在符号的真实使用点（`harvest_search.*` / `harvest_fetch.*` / `harvest_clients.base.*`），不要打 `harvest.*` re-export 面——后者靠 stdlib 单例巧合生效，清死 import 后会静默失效。
 
-运行时行为 / 数据流 / 产物 schema / verify.json 状态机是另一篇正交文档（67KB，按需读，不常驻）：`research/docs/architecture/harvest-architecture.md`。
+延伸阅读（本机 research 仓，非安装依赖，缺失不影响插件运行）：完整依赖 DAG 与维护决策树见 `research/docs/architecture/harvest-code-structure.md`；运行时行为 / 数据流 / 产物 schema / verify.json 状态机见 `research/docs/architecture/harvest-architecture.md`。
 
 ## 版本
 

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -41,21 +41,6 @@ from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-# curl_cffi is an optional soft dependency (the "curl-cffi" fetch backend
-# only): the core pipeline stays stdlib-only and degrades cleanly to the
-# next fetch backend when it isn't installed. Never import it at module
-# scope unconditionally -- that would turn a missing optional package into
-# a hard crash for every consumer of this module (including the
-# SubagentStop hook, which imports harvest.py on every turn).
-try:
-    from curl_cffi import requests as curl_cffi_requests
-    from curl_cffi.const import CurlOpt as CurlCffiOpt
-    _HAS_CURL_CFFI = True
-except ImportError:
-    curl_cffi_requests = None
-    CurlCffiOpt = None
-    _HAS_CURL_CFFI = False
-
 VERIFY_FILE = "harvest-verify.json"
 LEGACY_EXEMPTION_FILE = "legacy-exemption.md"
 MERGED_FINDINGS_FILE = "merged-findings.json"
@@ -129,133 +114,18 @@ def _emit(event, **kw):
         pass
 
 
-# ---------------------------------------------------------------------------
-# Rate limiting
-# ---------------------------------------------------------------------------
-
-class RateLimiter:
-    """One lock-protected timestamp per backend instance. Critical section is
-    timestamp-only; sleep and the actual call happen outside the lock."""
-
-    def __init__(self, min_interval_s):
-        self._min_interval = min_interval_s
-        self._lock = threading.Lock()
-        self._next_allowed = 0.0
-
-    def acquire(self):
-        with self._lock:
-            now = time.monotonic()
-            wait = max(0.0, self._next_allowed - now)
-            self._next_allowed = max(now, self._next_allowed) + self._min_interval
-        if wait > 0:
-            time.sleep(wait)
-
-
-# ---------------------------------------------------------------------------
-# SSRF guard: process-level getaddrinfo wrapper + thread-local tool context.
-# No TOCTOU window (resolution and connection are the same call), no
-# whitelist while the tool-context flag is set.
-# ---------------------------------------------------------------------------
-
-class SSRFBlocked(Exception):
-    pass
-
-
-_tool_ctx = threading.local()
-_real_getaddrinfo = socket.getaddrinfo
-
-
-def _is_blocked_ip(ip_str):
-    try:
-        ip = ipaddress.ip_address(ip_str)
-    except ValueError:
-        return True
-    return (ip.is_private or ip.is_loopback or ip.is_link_local
-            or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
-
-
-def _guarded_getaddrinfo(host, *args, **kwargs):
-    result = _real_getaddrinfo(host, *args, **kwargs)
-    if getattr(_tool_ctx, "active", False):
-        for item in result:
-            ip = item[4][0]
-            if _is_blocked_ip(ip):
-                raise SSRFBlocked(f"blocked address for host {host}: {ip}")
-    return result
-
-
-def install_ssrf_guard():
-    """Monkeypatch socket.getaddrinfo. Called at run-start, not at import
-    time, so importing this module (e.g. from the SubagentStop hook) stays
-    side-effect free."""
-    socket.getaddrinfo = _guarded_getaddrinfo
-
-
-class tool_request_guard:
-    """Context manager marking the current thread as executing a tool call
-    whose network target may be attacker/model controlled. Only active
-    inside this context does the guard reject private/loopback/reserved
-    addresses -- gateway chat-completion calls are made outside it."""
-
-    def __enter__(self):
-        self._prev = getattr(_tool_ctx, "active", False)
-        _tool_ctx.active = True
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        _tool_ctx.active = self._prev
-        return False
-
-
-def _ssrf_validate_and_resolve(url):
-    """Shared SSRF validation: scheme + host-presence checks, then a single
-    guarded socket.getaddrinfo() call (raises SSRFBlocked if any returned
-    address is private/loopback/reserved). Returns (host, port, first_ip)
-    so callers that need the actual resolved address -- not just a pass/
-    fail check -- don't have to resolve a second time."""
-    parts = urllib.parse.urlsplit(url)
-    if parts.scheme not in ("http", "https"):
-        raise SSRFBlocked(f"unsupported scheme: {parts.scheme}")
-    host = parts.hostname
-    if not host:
-        raise SSRFBlocked("no host in URL")
-    port = parts.port or (443 if parts.scheme == "https" else 80)
-    results = socket.getaddrinfo(host, port)
-    return host, port, results[0][4][0]
-
-
-def _ssrf_precheck(url):
-    _ssrf_validate_and_resolve(url)
-
-
-# ---------------------------------------------------------------------------
-# Domain blacklist / path sandbox
-# ---------------------------------------------------------------------------
-
-def is_blacklisted(url, blacklist_domains):
-    try:
-        host = urllib.parse.urlsplit(url).hostname
-    except ValueError:
-        return True
-    if not host:
-        return False
-    # .hostname (not manual "@"/":" splitting) correctly strips userinfo,
-    # port, and IPv6 brackets -- manual colon-splitting breaks on IPv6
-    # literals, which contain colons inside the address itself.
-    host = host.lower().rstrip(".")
-    for domain in blacklist_domains:
-        domain = domain.lower().rstrip(".")
-        if host == domain or host.endswith("." + domain):
-            return True
-    return False
-
-
-def _is_relative_to(path, base):
-    try:
-        path.relative_to(base)
-        return True
-    except ValueError:
-        return False
+from harvest_safety import (  # re-export: safety layer moved to its own module
+    RateLimiter,
+    SSRFBlocked,
+    install_ssrf_guard,
+    tool_request_guard,
+    _ssrf_validate_and_resolve,
+    _ssrf_precheck,
+    is_blacklisted,
+    _is_relative_to,
+    normalize_url,
+    _guarded_getaddrinfo,
+)
 
 
 def resolve_local_path(local_dir, rel_path):
@@ -266,28 +136,6 @@ def resolve_local_path(local_dir, rel_path):
     if not _is_relative_to(target, base):
         return None
     return target
-
-
-# ---------------------------------------------------------------------------
-# URL / whitespace normalization for citation matching
-# ---------------------------------------------------------------------------
-
-def normalize_url(url):
-    url = (url or "").strip()
-    if url.startswith("local://"):
-        return "local://" + url[len("local://"):].strip("/")
-    try:
-        parts = urllib.parse.urlsplit(url)
-        netloc = parts.netloc.lower()
-        path = parts.path.rstrip("/")
-        return urllib.parse.urlunsplit((parts.scheme.lower(), netloc, path, parts.query, ""))
-    except ValueError:
-        # Malformed URL (e.g. a broken IPv6 literal) from model output or a
-        # search backend result -- treat as non-normalizable rather than
-        # crashing the worker. Returning it unnormalized just means it
-        # won't match any journal-derived key, which correctly fails
-        # citation validation instead of taking down the whole run.
-        return url
 
 
 # ---------------------------------------------------------------------------
@@ -420,6 +268,7 @@ def build_rejected_claims(invalid):
 # refactor, zero behavior change). Re-imported here so every existing
 # harvest.<name> call site and test reference keeps working unchanged.
 # ---------------------------------------------------------------------------
+import harvest_clients.base
 from harvest_clients import (
     GatewayClient,
     AnthropicGatewayClient,
@@ -443,6 +292,10 @@ from harvest_clients.base import (
     _http_stream_post,
     _STREAM_RETRYABLE_EXCEPTIONS,
     _run_stream_attempt_with_retry,
+    curl_cffi_requests,
+    CurlCffiOpt,
+    _HAS_CURL_CFFI,
+    _check_curl_cffi_available,
 )
 from harvest_clients.anthropic import (
     _anthropic_post_with_retry,
@@ -472,692 +325,20 @@ from harvest_clients.gemini import (
 )
 
 
-# ---------------------------------------------------------------------------
-# Search backends (degrade in config order)
-# ---------------------------------------------------------------------------
-
-def _search_gemini_cli(cfg, query, timeout):
-    try:
-        proc = subprocess.run(
-            ["gemini", "-m", cfg.get("model", "gemini-3.5-flash"), "-p", query],
-            capture_output=True, timeout=timeout, stdin=subprocess.DEVNULL, text=True,
-        )
-    except subprocess.TimeoutExpired:
-        return None, "gemini-cli: timed out"
-    except OSError as e:
-        return None, f"gemini-cli: failed to launch subprocess: {e}"
-    if proc.returncode != 0:
-        detail = (proc.stderr or "").strip()[:200]
-        return None, f"gemini-cli: exited with code {proc.returncode}" + (f": {detail}" if detail else "")
-    text = proc.stdout or ""
-    if not text.strip():
-        return None, "gemini-cli: empty output"
-    urls = list(dict.fromkeys(re.findall(r'https?://[^\s\)\]\'"<>]+', text)))
-    if not urls:
-        return None, "gemini-cli: no URLs found in output"
-    return [{"url": u, "title": "", "snippet": text[:500]} for u in urls], None
-
-
-_DDG_ANCHOR_RE = re.compile(r'<a\b([^>]*)>(.*?)</a>', re.IGNORECASE | re.DOTALL)
-_DDG_HREF_RE = re.compile(r'href="([^"]*)"')
-_HTML_TAG_RE = re.compile(r'<[^>]+>')
-# Markers observed in html.duckduckgo.com's anti-bot interstitial ("Select
-# all squares containing a duck") -- used to distinguish a genuine
-# zero-results page from an IP-reputation block, for observability only.
-_DDG_BOT_CHECK_MARKERS = ("anomaly-modal", "challenge-form")
-
-
-def _ddg_extract_target_url(href):
-    # html.duckduckgo.com wraps result links in a same-site redirect
-    # (//duckduckgo.com/l/?uddg=<url-encoded target>&rut=...); unwrap it to
-    # get the real target URL. Non-redirect hrefs pass through unchanged.
-    parsed = urllib.parse.urlsplit(href)
-    host = (parsed.hostname or "").lower().rstrip(".")
-    # Suffix/equality match, not substring containment -- "in" would also
-    # match an unrelated host like "duckduckgo.com.evil.com" (same class of
-    # anti-pattern is_blacklisted() already guards against elsewhere in
-    # this file).
-    if host == "duckduckgo.com" or host.endswith(".duckduckgo.com"):
-        qs = urllib.parse.parse_qs(parsed.query)
-        if "uddg" in qs and qs["uddg"]:
-            # parse_qs() already percent-decodes query values once; a second
-            # unquote() here double-decodes and corrupts any target URL that
-            # itself contains a literal "%" escape sequence.
-            return qs["uddg"][0]
-    return href
-
-
-def _search_duckduckgo(cfg, query, timeout):
-    url = "https://html.duckduckgo.com/html/?q=" + urllib.parse.quote(query)
-
-    if _HAS_CURL_CFFI:
-        try:
-            resp = curl_cffi_requests.get(
-                url, impersonate=(cfg or {}).get("impersonate", "chrome"),
-                timeout=timeout, allow_redirects=True,
-            )
-            if resp.status_code != 200:
-                return None, f"duckduckgo: HTTP {resp.status_code}"
-            page = resp.text
-        except Exception as e:
-            return None, f"duckduckgo: curl-cffi request failed: {e}"
-    else:
-        headers = {"User-Agent": "Mozilla/5.0 (compatible; harvest.py/1.0)",
-                   "Accept-Encoding": "identity"}
-        req = urllib.request.Request(url, headers=headers)
-        try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
-                raw = _maybe_decompress(resp.read(), resp)
-        except (urllib.error.URLError, OSError) as e:
-            return None, f"duckduckgo: request failed: {e}"
-        try:
-            page = raw.decode("utf-8", errors="replace")
-        except Exception as e:
-            return None, f"duckduckgo: failed to decode response body: {e}"
-
-    results = []
-    for attrs, inner in _DDG_ANCHOR_RE.findall(page):
-        if "result__a" not in attrs:
-            continue
-        href_match = _DDG_HREF_RE.search(attrs)
-        if not href_match:
-            continue
-        target = _ddg_extract_target_url(html.unescape(href_match.group(1)))
-        if not target:
-            continue
-        title = html.unescape(_HTML_TAG_RE.sub("", inner)).strip()
-        results.append({"url": target, "title": title, "snippet": ""})
-    if results:
-        return results, None
-    if any(marker in page for marker in _DDG_BOT_CHECK_MARKERS):
-        return None, ("duckduckgo: bot-check challenge page returned instead of results "
-                       "(IP-reputation block, not a parsing bug)")
-    return None, "duckduckgo: no result links found in response"
-
-
-def _search_tavily(cfg, query, timeout):
-    api_key = os.environ.get(cfg.get("api_key_env", ""), "")
-    if not api_key:
-        return None, f"tavily: {cfg.get('api_key_env') or '(no api_key_env configured)'} not set"
-    payload = {"api_key": api_key, "query": query}
-    try:
-        data = _http_json_post("https://api.tavily.com/search", payload, {"Content-Type": "application/json"}, timeout)
-    except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError) as e:
-        return None, f"tavily: request failed: {e}"
-    items = data.get("results") or []
-    results = [{"url": r.get("url", ""), "title": r.get("title", ""), "snippet": r.get("content", "")}
-               for r in items if r.get("url")]
-    if not results:
-        return None, "tavily: empty results"
-    return results, None
-
-
-# Gemini's grounding chunks never carry the real source URL directly -- each
-# web.uri is a Google redirect short link on this fixed host. It is the ONLY
-# host _resolve_grounding_redirect is ever allowed to connect to; anything
-# else (a hallucinated/injected uri like http://169.254.169.254/) is rejected
-# before a byte leaves the process.
-_GROUNDING_REDIRECT_HOST = "vertexaisearch.cloud.google.com"
-_GROUNDING_REDIRECT_STATUSES = (301, 302, 303, 307, 308)
-_GROUNDING_REDIRECT_TIMEOUT_S = 10
-
-# Grounding is a real live search, so (unlike the old fake gateway-gemini) the
-# prompt doesn't ask the model to invent URLs -- it just steers the query and
-# mirrors the repo-wide content-farm exclusion. The exclusion line is a
-# courtesy only -- prompting the model to skip a domain does not stop it
-# appearing in groundingChunks (those are raw retrieval results the prompt
-# text has no control over); is_blacklisted() in do_search() is the actual
-# enforcement. No SEARCH_FAILED sentinel: whether retrieval happened is read
-# structurally from groundingMetadata, not parsed out of free text.
-#
-# The "cite EVERY source ... COMPLETE set ... do not truncate" line is
-# load-bearing, not decoration. Debugging against the raw API showed the
-# model already searches even on a MISS (groundingMetadata/webSearchQueries/
-# 9-15 chunks all present) -- the miss was this prompt only asking to search
-# "the live web" and the model then under-reporting which sources it
-# actually consulted. Adding this sentence took a repeatedly-empty-chunks
-# Chinese query from 0 to 21 chunks and this backend's measured hit rate
-# from ~60% to 100%. Deliberately NOT adding a "you MUST call google_search"
-# hard constraint -- tested too, no measured gain and it adds thinking-token
-# latency.
-_GROUNDING_SEARCH_PROMPT = (
-    "Search the live web for: {query}\n"
-    "Cite EVERY source you actually consulted -- return the COMPLETE set of "
-    "source URLs, do not truncate or summarize the list.\n"
-    "Exclude results from content-farm hosts: csdn.net, cloud.baidu.com, "
-    "cloud.tencent.com, huaweicloud.com, aliyun.com, volcengine.com, juejin.cn."
+from harvest_search import (
+    _search_gemini_cli, _ddg_extract_target_url, _search_duckduckgo,
+    _search_tavily, _resolve_grounding_redirect, _search_gemini_grounding,
+    _no_redirect_opener, call_search_backend, do_search,
 )
+import harvest_search  # for qualified do_search() calls in body (facade-penetration guard)
 
 
-class _NoRedirect(urllib.request.HTTPRedirectHandler):
-    """Intercept every 30x so urllib never auto-follows a grounding redirect
-    to its real target. urllib.request.urlopen installs an HTTPRedirectHandler
-    by default that transparently connects to the Location host -- that would
-    defeat the host-allowlist check in _resolve_grounding_redirect entirely
-    (the guard vets the redirect host, not the target). Returning None here
-    turns the 302 into a raised HTTPError whose Location header we read WITHOUT
-    ever connecting to it."""
-
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        return None
-
-
-_no_redirect_opener = urllib.request.build_opener(_NoRedirect)
-
-
-def _resolve_grounding_redirect(uri, timeout):
-    """Resolve a grounding-api-redirect short link to its real landing URL by
-    reading the 302 Location header without following it. Connects ONLY to the
-    fixed, trusted grounding host -- any other host is rejected before a single
-    byte goes out (so this is not an SSRF surface even though the uri
-    originates from model output). Returns the real URL, or None (caller drops
-    the chunk) on a malformed uri, a non-grounding host, a non-redirect
-    response, or any network error."""
-    try:
-        # uri is model/provider-controlled grounding output; a malformed value
-        # (e.g. an unterminated IPv6 literal) makes urlsplit raise ValueError.
-        # Treat it as a droppable bad chunk -- same guard is_blacklisted() puts
-        # on this exact call -- so one bad uri can't abort the whole backend
-        # and discard every other valid chunk.
-        host = urllib.parse.urlsplit(uri).hostname
-    except ValueError:
-        return None
-    if host != _GROUNDING_REDIRECT_HOST:
-        return None
-    req = urllib.request.Request(
-        uri, headers={"User-Agent": "Mozilla/5.0 (compatible; harvest.py/1.0)"})
-    try:
-        # A genuine 200 (no redirect) means the short link resolved to nothing
-        # citable -- close it and drop. The redirect case below is the norm.
-        resp = _no_redirect_opener.open(req, timeout=timeout)
-        resp.close()
-        return None
-    except urllib.error.HTTPError as e:
-        if e.code in _GROUNDING_REDIRECT_STATUSES:
-            return e.headers.get("Location")
-        return None
-    except (urllib.error.URLError, OSError):
-        return None
-
-
-def _search_gemini_grounding(cfg, query, timeout, config):
-    """Real grounded web search via the gateway's Gemini-native
-    generateContent endpoint + built-in google_search tool. Replaces the old
-    fake gateway-gemini backend, which asked an OpenAI-compat /chat/completions
-    to 'list some URLs' and got model-recalled (hallucinated) links with no
-    live retrieval -- and, worse, since do_search stops at the first backend
-    that returns any non-blacklisted URL, that fake result permanently masked
-    the real tavily/duckduckgo backends behind it. Here the model actually
-    searches; grounding chunks carry real (redirect-wrapped) source URLs that
-    we resolve to true landing pages before returning them to the
-    citation-verifiable pipeline."""
-    gw = config["gateway"]
-    api_key = os.environ.get(gw["api_key_env"], "")
-    if not api_key:
-        return None, f"gemini-grounding: {gw.get('api_key_env') or '(no api_key_env configured)'} not set"
-    # Native endpoint is <origin>/v1beta/models/<model>:generateContent. Derive
-    # origin via urlsplit -- NOT base_url.rstrip('/v1'), which strips a char
-    # SET not a suffix and would mangle '.../v1' unpredictably. This makes a
-    # base_url of '.../v1', '.../v1/', or a bare origin all resolve correctly.
-    parts = urllib.parse.urlsplit(gw["base_url"])
-    url = f"{parts.scheme}://{parts.netloc}/v1beta/models/{cfg.get('model', '')}:generateContent"
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
-    payload = {
-        "contents": [{"role": "user", "parts": [{"text": _GROUNDING_SEARCH_PROMPT.format(query=query)}]}],
-        "tools": [{"google_search": {}}],
-    }
-    # thinkingBudget is opt-in and back-compat-strict: only add
-    # generationConfig at all when the config explicitly sets it, so a
-    # config predating this key sends byte-for-byte the same payload as
-    # before (no generationConfig with an implicit default sneaking in).
-    # Measured: thinkingBudget=0 does not lower the hit rate (google_search
-    # is a tool call, not something reasoning/thinking gates) and cuts
-    # latency to ~11-16s from the un-budgeted baseline.
-    if "thinking_budget" in cfg:
-        payload["generationConfig"] = {"thinkingConfig": {"thinkingBudget": cfg["thinking_budget"]}}
-    try:
-        data = _http_json_post(url, payload, headers, timeout)
-    except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError) as e:
-        return None, f"gemini-grounding: request failed: {e}"
-    try:
-        chunks = data["candidates"][0]["groundingMetadata"]["groundingChunks"]
-    except (KeyError, IndexError, TypeError):
-        # No groundingMetadata/chunks -> the model chose not to search
-        # (grounding is model-discretionary, never guaranteed). Degrade to the
-        # next backend rather than mining plain text for URLs.
-        return None, "gemini-grounding: no grounding chunks (model did not search)"
-    redirect_timeout = min(timeout, _GROUNDING_REDIRECT_TIMEOUT_S)
-    # Redirect resolution is a network round-trip per chunk with no data
-    # dependency between chunks -- resolving serially measured 18.2s for 16
-    # chunks vs 2.5s in parallel. Same index-preallocate + future-to-index +
-    # as_completed-fills-by-original-index pattern as
-    # _run_fetch_calls_parallel (as_completed only picks scheduling order,
-    # never the order results land in `resolved`) so chunk-submission order
-    # -- which the dedup/citation-mapping below depends on -- survives
-    # regardless of which redirect answers first.
-    resolved = [None] * len(chunks)
-    with ThreadPoolExecutor(max_workers=min(len(chunks), _PARALLEL_FETCH_MAX_WORKERS) or 1) as pool:
-        future_to_index = {
-            pool.submit(_resolve_grounding_redirect, (ch.get("web") or {}).get("uri", ""), redirect_timeout): i
-            for i, ch in enumerate(chunks)
-        }
-        for fut in as_completed(future_to_index):
-            i = future_to_index[fut]
-            try:
-                resolved[i] = fut.result()
-            except Exception:
-                # A single bad uri (malformed/hostile/network blip) must not
-                # take down the whole grounding backend -- drop just this
-                # chunk, same as a normal unresolvable-redirect result.
-                resolved[i] = None
-    results, seen = [], set()
-    for ch, real_url in zip(chunks, resolved):
-        web = ch.get("web") or {}
-        uri = web.get("uri", "")
-        if not uri:
-            continue
-        if not real_url or real_url in seen:
-            continue
-        seen.add(real_url)
-        title = web.get("title", "")
-        # snippet = title (usually just the domain); blacklist filtering is
-        # do_search's job, kept out of here to avoid duplicating that concern.
-        results.append({"url": real_url, "title": title, "snippet": title})
-    if not results:
-        return None, "gemini-grounding: no resolvable source URLs in grounding chunks"
-    return results, None
-
-
-def call_search_backend(backend_cfg, limiter, query, lang, config, attempts=None):
-    limiter.acquire()
-    timeout = config["limits"]["call_timeout_s"]
-    btype = backend_cfg["type"]
-    try:
-        if btype == "gemini-cli":
-            result, reason = _search_gemini_cli(backend_cfg, query, timeout)
-        elif btype == "tavily":
-            result, reason = _search_tavily(backend_cfg, query, timeout)
-        elif btype == "duckduckgo":
-            result, reason = _search_duckduckgo(backend_cfg, query, timeout)
-        elif btype == "gemini-grounding":
-            result, reason = _search_gemini_grounding(backend_cfg, query, timeout, config)
-        else:
-            result, reason = None, f"unknown search backend type: {btype}"
-    except Exception as e:
-        result, reason = None, f"unexpected error: {e}"
-    if not result and attempts is not None:
-        attempts.append({"backend": btype, "error": reason or "no results"})
-    return result
-
-
-def do_search(query, lang, search_backends, journal, config):
-    # Search backends only ever connect to a fixed, developer-configured
-    # host (api.tavily.com / html.duckduckgo.com / our own gateway) -- the model's
-    # query text does not steer the connection destination, so this is not
-    # an SSRF surface and is not wrapped in tool_request_guard().
-    blacklist = config.get("blacklist_domains", [])
-    attempts = []
-    for backend_cfg, limiter in search_backends:
-        results = call_search_backend(backend_cfg, limiter, query, lang, config, attempts)
-        if results:
-            filtered = [r for r in results if not is_blacklisted(r["url"], blacklist)]
-            if not filtered:
-                # Every result from this backend was blacklisted -- that's a
-                # degrade-worthy failure, not a genuine "no results" answer;
-                # try the next backend instead of returning an empty set.
-                attempts.append({"backend": backend_cfg["type"], "error": "all results filtered by blacklist"})
-                continue
-            if backend_cfg["type"] == "gemini-grounding":
-                for r in filtered:
-                    # NOT "fetch": grounding gives us a URL the model *saw* in
-                    # search results, not full page text -- content here is
-                    # only a title/domain string. Using a distinct tool type
-                    # keeps build_fetch_index() (which only recognizes
-                    # "fetch"/"read_local") from treating this title string as
-                    # verified full-text content, while build_journal_url_set()
-                    # still recognizes "search_grounding" so a claim citing
-                    # this URL without an explicit fetch() call correctly
-                    # fails as url_not_fetched (real citation retry required)
-                    # rather than url_not_in_journal (worse: implies the model
-                    # never even saw the URL) or silently passing.
-                    journal.append({"tool": "search_grounding", "url": r["url"],
-                                    "backend": "grounding", "content": None,
-                                    "title": r.get("title") or r["url"]})
-            journal.append({"tool": "search", "query": query, "lang": lang,
-                             "backend": backend_cfg["type"], "urls": [r["url"] for r in filtered],
-                             "attempts": attempts})
-            return json.dumps({"results": filtered}, ensure_ascii=False)
-    journal.append({"tool": "search", "query": query, "lang": lang, "backend": None, "urls": [], "attempts": attempts})
-    return json.dumps({"results": [], "error": "all search backends failed"})
-
-
-# ---------------------------------------------------------------------------
-# Fetch backends (degrade in config order)
-# ---------------------------------------------------------------------------
-
-def _fetch_tavily_extract(cfg, url, timeout, max_chars):
-    api_key = os.environ.get(cfg.get("api_key_env", ""), "")
-    if not api_key:
-        return None, f"tavily-extract: {cfg.get('api_key_env') or '(no api_key_env configured)'} not set"
-    payload = {"api_key": api_key, "urls": [url]}
-    try:
-        data = _http_json_post("https://api.tavily.com/extract", payload, {"Content-Type": "application/json"}, timeout)
-    except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError) as e:
-        return None, f"tavily-extract: request failed: {e}"
-    results = data.get("results") or []
-    if not results:
-        return None, "tavily-extract: empty results"
-    content = results[0].get("raw_content") or results[0].get("content")
-    if not content:
-        return None, "tavily-extract: empty content in result"
-    return content, None
-
-
-def _fetch_jina_reader(cfg, url, timeout, max_chars):
-    api_key = os.environ.get(cfg.get("api_key_env", ""), "")
-    # r.jina.ai rejects urllib's default "Python-urllib/3.x" UA with HTTP 403
-    # (independent of the API key -- any non-default UA gets 200). Send the
-    # same UA as _fetch_urllib_ua so this backend isn't silently 403'd.
-    headers = {"User-Agent": "Mozilla/5.0 (compatible; harvest.py/1.0)",
-               "Accept": "text/plain", "Accept-Encoding": "identity"}
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
-    req = urllib.request.Request("https://r.jina.ai/" + url, headers=headers)
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            raw = _maybe_decompress(resp.read(max_chars * 4), resp)
-    except (urllib.error.URLError, OSError) as e:
-        return None, f"jina-reader: request failed: {e}"
-    try:
-        return raw.decode("utf-8", errors="replace"), None
-    except Exception as e:
-        return None, f"jina-reader: failed to decode response body: {e}"
-
-
-_HTML_SCRIPT_STYLE_RE = re.compile(r'<(script|style)\b[^>]*>.*?</\1>', re.IGNORECASE | re.DOTALL)
-
-
-def _strip_html_to_text(raw_html):
-    # urllib-ua and curl-cffi are the backends that return raw page source
-    # (tavily-extract/jina-reader already return clean text) -- without
-    # this, the fetch_max_chars budget is spent on markup instead of prose,
-    # and an excerpt that spans an inline tag (e.g. "...the <a href=...>WAL
-    # </a> file...") fails substring matching against the untouched HTML
-    # even though it's a real verbatim quote of the rendered text. Strip
-    # script/style blocks first (their contents aren't page text at all),
-    # then every remaining tag, then resolve entities, then fold whitespace
-    # -- in that order so truncation to fetch_max_chars (done by the
-    # caller, after this returns) spends the budget on prose, not tags.
-    text = _HTML_SCRIPT_STYLE_RE.sub(" ", raw_html)
-    text = _HTML_TAG_RE.sub(" ", text)
-    text = html.unescape(text)
-    return re.sub(r"\s+", " ", text).strip()
-
-
-_CURL_CFFI_MAX_REDIRECT_HOPS = 3
-_CURL_CFFI_REDIRECT_STATUSES = (301, 302, 303, 307, 308)
-
-# curl_cffi impersonates a real browser's TLS/HTTP fingerprint but cannot
-# execute JavaScript -- so when a WAF (Cloudflare/DataDome/PerimeterX/
-# Imperva) serves a JS challenge ("holding page"), curl_cffi gets exactly
-# that holding page back as its final response, not the article. Without
-# this check, that holding page's body (often HTTP 200, sometimes 403/503)
-# is silently stripped-to-text and returned as if it were real page
-# content, poisoning the downstream citation-verification pipeline with
-# challenge-script prose that happens to contain no obvious HTTP error.
-# See issue #81.
-#
-# Markers are deliberately script paths / JS globals / DOM ids / CDN
-# domains -- unique implementation artifacts of the challenge widgets
-# themselves -- rather than human-readable phrases like "checking your
-# browser" or "just a moment". Human phrases appear verbatim in ordinary
-# prose (news articles about Cloudflare outages, blog posts explaining
-# Turnstile, this very code review) and would cause false positives;
-# the literal script/DOM/CDN artifacts below only ever appear when the
-# actual vendor widget markup is present on the page.
-_CHALLENGE_PAGE_MARKERS = (
-    # Cloudflare (challenge-platform script, browser-verification banner,
-    # the cf_chl_opt JS config object, Turnstile widget, _cf_chl JS global)
-    "/cdn-cgi/challenge-platform/",
-    "cf-browser-verification",
-    "_cf_chl_opt",
-    "cf-turnstile",
-    "window._cf_chl",
-    # DataDome (captcha delivery CDN the challenge script loads from)
-    "captcha-delivery.com",
-    # PerimeterX / HUMAN (captcha widget id, JS app-id global)
-    "px-captcha",
-    "window._pxappid",
-    # Imperva / Incapsula (challenge resource endpoint)
-    "_incapsula_resource",
+from harvest_fetch import (
+    _fetch_tavily_extract, _fetch_jina_reader, _strip_html_to_text,
+    _looks_like_challenge_page, _fetch_curl_cffi, _fetch_urllib_ua,
+    call_fetch_backend, do_fetch,
 )
-
-# Challenge/holding pages are minimal (a script tag, a spinner, a couple
-# of divs) -- always tiny, never anywhere near fetch_max_chars territory.
-# Real long-form content that happens to discuss these vendors (e.g. a
-# deep-research task investigating WAF/Turnstile bypass techniques, or an
-# article with an embedded code sample) can legitimately contain these
-# same artifact strings inside tens of KB of genuine prose. This gate lets
-# such long-form pages through unconditionally while still catching even
-# a bloated/verbose challenge page, since real-world challenge HTML has
-# never been observed anywhere close to 100KB.
-_CHALLENGE_MAX_PAGE_CHARS = 100 * 1024
-
-
-def _looks_like_challenge_page(raw_html):
-    # resp.text can be None or "" (empty body, e.g. a HEAD-like 204, or a
-    # decode that yielded nothing) -- guard first, since .lower() on None
-    # would raise AttributeError and take curl-cffi out of rotation via
-    # call_fetch_backend's broad except instead of cleanly degrading.
-    if not raw_html:
-        return False
-    if len(raw_html) >= _CHALLENGE_MAX_PAGE_CHARS:
-        return False
-    lowered = raw_html.lower()
-    return any(marker in lowered for marker in _CHALLENGE_PAGE_MARKERS)
-
-
-def _fetch_curl_cffi(cfg, url, timeout, max_chars, config):
-    # libcurl (which curl_cffi wraps via C bindings) does its own DNS
-    # resolution entirely inside libcurl's C layer -- it never calls back
-    # into Python's socket.getaddrinfo, so the process-level SSRF guard
-    # (install_ssrf_guard()'s monkeypatch) provides ZERO protection here.
-    # The fix: resolve each hop ourselves through the guarded
-    # getaddrinfo (via _ssrf_validate_and_resolve, which raises
-    # SSRFBlocked on any private/reserved address), then pin libcurl to
-    # that exact, already-vetted IP with CURLOPT_RESOLVE. This closes the
-    # TOCTOU window entirely -- libcurl is never allowed to resolve the
-    # host itself, only to connect to the address we already validated.
-    # Redirects are followed manually (allow_redirects=False) so every hop
-    # gets its own independent guard + blacklist check; libcurl's built-in
-    # redirect-following would silently reuse the pinned IP for whatever
-    # Location header a compromised/malicious first hop returned.
-    #
-    # No "not installed -> skip" branch here: _check_curl_cffi_available()
-    # already fail-fast-exits cmd_run() before any fetch happens if this
-    # backend is configured but curl_cffi isn't importable, so by the time
-    # this function runs, _HAS_CURL_CFFI is guaranteed True.
-    #
-    # `timeout` is the total budget for this call *across all redirect
-    # hops*, not per-hop -- without this, a tarpit (slow-drip response)
-    # combined with a redirect chain could burn hops * timeout wall clock.
-    # `.get(key, default)` (not `config["limits"][key]`) is deliberate:
-    # these three keys are new, and a config that predates them must keep
-    # working with these defaults rather than KeyError -> get swallowed by
-    # call_fetch_backend's broad except into a silent, permanent
-    # "unexpected error" that takes curl-cffi out of rotation for good.
-    limits = config.get("limits", {})
-    connect_timeout_s = limits.get("fetch_connect_timeout_s", 5)
-    low_speed_bytes_s = limits.get("fetch_low_speed_bytes_s", 512)
-    low_speed_window_s = limits.get("fetch_low_speed_window_s", 10)
-    blacklist = config.get("blacklist_domains", [])
-    impersonate = cfg.get("impersonate", "chrome")
-    current_url = url
-    deadline = time.monotonic() + timeout
-    for hop in range(_CURL_CFFI_MAX_REDIRECT_HOPS + 1):
-        # < 1, not <= 0: curl_cffi converts seconds to milliseconds via
-        # int(x * 1000), and libcurl treats a 0ms timeout as *no limit*.
-        # A remaining budget inside that sub-millisecond window would
-        # otherwise round down to 0 and silently reopen the hang this
-        # deadline exists to close.
-        remaining = deadline - time.monotonic()
-        if remaining < 1:
-            return None, "curl-cffi: total fetch deadline exceeded across redirects"
-        if is_blacklisted(current_url, blacklist):
-            return None, f"curl-cffi: redirect target domain blacklisted: {current_url}"
-        try:
-            host, port, ip = _ssrf_validate_and_resolve(current_url)
-        except (socket.gaierror, OSError) as e:
-            return None, f"curl-cffi: DNS resolution failed: {e}"
-        pin = f"{host}:{port}:{ip}"
-        # curl_cffi 0.15.0 sets CURLOPT_TIMEOUT_MS = connect + read for a
-        # tuple timeout (it sums the two components, it doesn't treat
-        # `read` as the total) -- so to cap this hop's total at exactly
-        # `remaining`, the read component must be `remaining - conn`, not
-        # `remaining` itself. `- 0.1` keeps a strictly positive read
-        # component even when remaining is barely above the connect cap.
-        conn = min(connect_timeout_s, remaining - 0.1)
-        try:
-            resp = curl_cffi_requests.get(
-                current_url, timeout=(conn, remaining - conn), impersonate=impersonate,
-                allow_redirects=False, headers={"Accept-Encoding": "identity"},
-                curl_options={
-                    CurlCffiOpt.RESOLVE: [pin],
-                    CurlCffiOpt.MAXFILESIZE_LARGE: max_chars * 4,
-                    CurlCffiOpt.LOW_SPEED_LIMIT: low_speed_bytes_s,
-                    CurlCffiOpt.LOW_SPEED_TIME: low_speed_window_s,
-                },
-            )
-        except Exception as e:
-            return None, f"curl-cffi: request failed: {e}"
-        if resp.status_code in _CURL_CFFI_REDIRECT_STATUSES:
-            location = resp.headers.get("location")
-            if not location:
-                return None, f"curl-cffi: redirect status {resp.status_code} missing Location header"
-            current_url = urllib.parse.urljoin(current_url, location)
-            continue
-        try:
-            text = resp.text
-        except Exception as e:
-            return None, f"curl-cffi: failed to decode response body: {e}"
-        # Gate 1: challenge page first, regardless of status code -- a
-        # Cloudflare/DataDome/etc holding page served with 403/503 must be
-        # reported as a challenge, not swallowed by the generic HTTP-error
-        # gate below (which would lose the actual root cause from
-        # telemetry: "anti-bot challenge" vs. "some 403").
-        if _looks_like_challenge_page(text):
-            return None, "curl-cffi: anti-bot JS challenge page (needs a JS-capable backend)"
-        # Gate 2: an ordinary error page (403/404/5xx, no challenge marker)
-        # is also not article content -- refuse to return its body too.
-        if not (200 <= resp.status_code < 300):
-            return None, f"curl-cffi: HTTP {resp.status_code}"
-        return _strip_html_to_text(text), None
-    return None, f"curl-cffi: exceeded max redirect hops ({_CURL_CFFI_MAX_REDIRECT_HOPS})"
-
-
-_CURL_CFFI_MISSING_MSG = (
-    "ERROR: fetch backend 'curl-cffi' is configured but curl_cffi is not "
-    "installed. Run: pip3 install --user curl_cffi"
-)
-
-
-def _check_curl_cffi_available(config):
-    # Config declares the backend -> it must be installed, fail fast before
-    # touching any state (cleanup/tombstone) or spending an API call. Config
-    # doesn't declare it -> curl_cffi is never imported at runtime and the
-    # pipeline stays exactly as stdlib-only as it always has been.
-    types = [b.get("type") for b in config.get("fetch_backends", [])]
-    if "curl-cffi" in types and not _HAS_CURL_CFFI:
-        print(_CURL_CFFI_MISSING_MSG, file=sys.stderr)
-        sys.exit(4)
-
-
-def _fetch_urllib_ua(cfg, url, timeout, max_chars):
-    headers = {"User-Agent": "Mozilla/5.0 (compatible; harvest.py/1.0)",
-               "Accept-Encoding": "identity"}
-    req = urllib.request.Request(url, headers=headers)
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            raw = _maybe_decompress(resp.read(max_chars * 4), resp)
-    except (urllib.error.URLError, OSError) as e:
-        return None, f"urllib-ua: request failed: {e}"
-    try:
-        text = raw.decode("utf-8", errors="replace")
-    except Exception as e:
-        return None, f"urllib-ua: failed to decode response body: {e}"
-    return _strip_html_to_text(text), None
-
-
-def call_fetch_backend(backend_cfg, limiter, url, config, attempts=None):
-    limiter.acquire()
-    # Per-backend timeout_s override, falling back to the shared
-    # call_timeout_s -- .get() means backends that don't declare timeout_s
-    # (or a config predating this field) keep the old 180s behavior.
-    timeout = backend_cfg.get("timeout_s", config["limits"]["call_timeout_s"])
-    max_chars = config["limits"]["fetch_max_chars"]
-    btype = backend_cfg["type"]
-    try:
-        if btype == "tavily-extract":
-            content, reason = _fetch_tavily_extract(backend_cfg, url, timeout, max_chars)
-        elif btype == "jina-reader":
-            content, reason = _fetch_jina_reader(backend_cfg, url, timeout, max_chars)
-        elif btype == "curl-cffi":
-            content, reason = _fetch_curl_cffi(backend_cfg, url, timeout, max_chars, config)
-        elif btype == "urllib-ua":
-            content, reason = _fetch_urllib_ua(backend_cfg, url, timeout, max_chars)
-        else:
-            content, reason = None, f"unknown fetch backend type: {btype}"
-    except SSRFBlocked:
-        raise
-    except Exception as e:
-        content, reason = None, f"unexpected error: {e}"
-    if not content and attempts is not None:
-        attempts.append({"backend": btype, "error": reason or "no content"})
-    return content
-
-
-def do_fetch(url, fetch_backends, journal, config):
-    # SSRF guard scope: only the connection whose destination host is
-    # derived from model-controlled input is a real SSRF surface -- that is
-    # urllib-ua's and curl-cffi's direct connection to `url` (and any
-    # redirects they follow). tavily-extract/jina-reader take `url` as a
-    # request *parameter* to a fixed, trusted API host; the actual fetch of
-    # that URL happens on their servers, not on this machine, so guarding
-    # them here would only false-positive-block a legitimate internally-
-    # hosted gateway/API without adding any real protection. The domain
-    # blacklist still applies to `url` regardless of which backend ends up
-    # serving it. (curl-cffi additionally re-validates + re-pins every
-    # redirect hop internally, since libcurl's own DNS resolution bypasses
-    # this guard entirely -- see _fetch_curl_cffi().)
-    blacklist = config.get("blacklist_domains", [])
-    if is_blacklisted(url, blacklist):
-        journal.append({"tool": "fetch", "url": url, "blocked": "blacklist", "content": None})
-        return json.dumps({"error": "domain blacklisted"})
-
-    max_chars = config["limits"]["fetch_max_chars"]
-    attempts = []
-    for backend_cfg, limiter in fetch_backends:
-        guarded = backend_cfg["type"] in ("urllib-ua", "curl-cffi")
-        try:
-            if guarded:
-                with tool_request_guard():
-                    _ssrf_precheck(url)
-                    content = call_fetch_backend(backend_cfg, limiter, url, config, attempts)
-            else:
-                content = call_fetch_backend(backend_cfg, limiter, url, config, attempts)
-        except SSRFBlocked as e:
-            journal.append({"tool": "fetch", "url": url, "blocked": "ssrf", "content": None, "attempts": attempts})
-            return json.dumps({"error": f"blocked by SSRF guard: {e}"})
-        except Exception as e:
-            content = None
-            attempts.append({"backend": backend_cfg["type"], "error": f"unexpected error: {e}"})
-        if content:
-            truncated = content[:max_chars]
-            journal.append({"tool": "fetch", "url": url, "backend": backend_cfg["type"], "content": truncated,
-                             "attempts": attempts})
-            return truncated
-    journal.append({"tool": "fetch", "url": url, "backend": None, "content": None, "attempts": attempts})
-    return json.dumps({"error": "all fetch backends failed"})
+import harvest_fetch  # for qualified do_fetch() calls in body (facade-penetration guard)
 
 
 # ---------------------------------------------------------------------------
@@ -1196,9 +377,9 @@ def execute_tool_call(tc, search_backends, fetch_backends, journal, config, loca
     except json.JSONDecodeError:
         args = {}
     if name == "search":
-        return do_search(args.get("query", ""), args.get("lang", ""), search_backends, journal, config)
+        return harvest_search.do_search(args.get("query", ""), args.get("lang", ""), search_backends, journal, config)
     if name == "fetch":
-        return do_fetch(args.get("url", ""), fetch_backends, journal, config)
+        return harvest_fetch.do_fetch(args.get("url", ""), fetch_backends, journal, config)
     if name == "read_local":
         return do_read_local(args.get("path", ""), args.get("offset", 0), journal, config, local_dir)
     return json.dumps({"error": f"unknown tool {name}"})
@@ -1993,7 +1174,7 @@ def cmd_run_local(args, config):
     journal = []
     all_urls = []
     for query in queries:
-        result_json = do_search(query, "auto", search_backends, journal, config)
+        result_json = harvest_search.do_search(query, "auto", search_backends, journal, config)
         results = json.loads(result_json).get("results", [])
         for r in results:
             all_urls.append((r["url"], r.get("title", "")))
@@ -2025,7 +1206,7 @@ def cmd_run_local(args, config):
         # with "{"), so read the journal entry do_fetch just appended
         # instead; its "content" field uses the same None-on-failure
         # convention build_fetch_index() already relies on elsewhere.
-        do_fetch(item["url"], fetch_backends, journal, config)
+        harvest_fetch.do_fetch(item["url"], fetch_backends, journal, config)
         content = journal[-1].get("content")
         if content:
             page_file = fetched_dir / f"page_{i + 1:03d}.txt"
@@ -2082,29 +1263,14 @@ def cmd_run_local(args, config):
     print(f"harvest local mode complete: {len(fetched_pages)} pages fetched")
 
 
-def cmd_run(args):
-    config = load_config(args.config)
-    _check_curl_cffi_available(config)
+def _resolve_run_paths(args):
+    """Derive all run directories + resolve/validate the goal file for a
+    normal (API) harvest run. Extracted verbatim from cmd_run -- the sys.exit
+    validation paths and every comment are unchanged, so behavior is identical.
 
-    # getattr(...) rather than args.no_api/args.queries_json: same
-    # back-compat rationale as args.project_dir above -- older test/caller
-    # code building an args namespace without these new attributes must
-    # keep working, taking the normal-mode path unchanged.
-    no_api = getattr(args, "no_api", False)
-    queries_json = getattr(args, "queries_json", None)
-    if no_api:
-        if not queries_json:
-            print("error: local mode requires --queries-json", file=sys.stderr)
-            sys.exit(1)
-        cmd_run_local(args, config)
-        return
-    gw_api_key_env = config.get("gateway", {}).get("api_key_env", "")
-    has_gateway_key = bool(os.environ.get(gw_api_key_env, ""))
-    if not has_gateway_key:
-        print("error: Gateway API key missing. To run in local mode, pass "
-              "--no-api --queries-json <file>.", file=sys.stderr)
-        sys.exit(3)
-
+    Returns: (raw_dir, project_dir, pipeline_dir, verify_dir, is_supplementary,
+              verify_filename, goal_text, goal_hash)
+    """
     raw_dir = Path(args.out)
     # getattr(...) rather than args.project_dir: keeps this importable by
     # older test/caller code that builds an args namespace without the new
@@ -2189,6 +1355,54 @@ def cmd_run(args):
     goal_text = run_goal_file.read_text(encoding="utf-8")
     goal_hash = hashlib.sha256(run_goal_file.read_bytes()).hexdigest()
 
+    return (raw_dir, project_dir, pipeline_dir, verify_dir, is_supplementary,
+            verify_filename, goal_text, goal_hash)
+
+
+def _persist_worker_outputs(raw_dir, results):
+    """Write each worker's findings.json / journal_<alias>.jsonl /
+    rejected_claims.json under raw_dir/HARVEST_SUBDIR/<alias>/. Extracted
+    verbatim from cmd_run -- pure disk IO, no behavior change."""
+    harvest_dir = raw_dir / HARVEST_SUBDIR
+    harvest_dir.mkdir(parents=True, exist_ok=True)
+    for r in results:
+        model_dir = harvest_dir / r.alias
+        model_dir.mkdir(parents=True, exist_ok=True)
+        findings_out = r.findings if r.findings is not None else {"claims": [], "status": r.status, "reason": r.reason}
+        (model_dir / "findings.json").write_text(json.dumps(findings_out, ensure_ascii=False, indent=2), encoding="utf-8")
+        with (model_dir / f"journal_{r.alias}.jsonl").open("w", encoding="utf-8") as f:
+            for entry in r.journal:
+                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        (model_dir / "rejected_claims.json").write_text(
+            json.dumps(r.rejected_claims, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def cmd_run(args):
+    config = load_config(args.config)
+    harvest_clients.base._check_curl_cffi_available(config)
+
+    # getattr(...) rather than args.no_api/args.queries_json: same
+    # back-compat rationale as args.project_dir above -- older test/caller
+    # code building an args namespace without these new attributes must
+    # keep working, taking the normal-mode path unchanged.
+    no_api = getattr(args, "no_api", False)
+    queries_json = getattr(args, "queries_json", None)
+    if no_api:
+        if not queries_json:
+            print("error: local mode requires --queries-json", file=sys.stderr)
+            sys.exit(1)
+        cmd_run_local(args, config)
+        return
+    gw_api_key_env = config.get("gateway", {}).get("api_key_env", "")
+    has_gateway_key = bool(os.environ.get(gw_api_key_env, ""))
+    if not has_gateway_key:
+        print("error: Gateway API key missing. To run in local mode, pass "
+              "--no-api --queries-json <file>.", file=sys.stderr)
+        sys.exit(3)
+
+    (raw_dir, project_dir, pipeline_dir, verify_dir, is_supplementary,
+     verify_filename, goal_text, goal_hash) = _resolve_run_paths(args)
+
     if is_supplementary:
         # Never cleanup_stale_state() here -- that function unconditionally
         # unlinks the PRIMARY VERIFY_FILE/EXEMPTION, which would erase the
@@ -2222,18 +1436,7 @@ def cmd_run(args):
               wall_clock_s=config["limits"]["wall_clock_s"])
         results, alive, quorum_met = run_panel(config, goal_text, local_manifest, local_dir, client_factory)
 
-        harvest_dir = raw_dir / HARVEST_SUBDIR
-        harvest_dir.mkdir(parents=True, exist_ok=True)
-        for r in results:
-            model_dir = harvest_dir / r.alias
-            model_dir.mkdir(parents=True, exist_ok=True)
-            findings_out = r.findings if r.findings is not None else {"claims": [], "status": r.status, "reason": r.reason}
-            (model_dir / "findings.json").write_text(json.dumps(findings_out, ensure_ascii=False, indent=2), encoding="utf-8")
-            with (model_dir / f"journal_{r.alias}.jsonl").open("w", encoding="utf-8") as f:
-                for entry in r.journal:
-                    f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-            (model_dir / "rejected_claims.json").write_text(
-                json.dumps(r.rejected_claims, ensure_ascii=False, indent=2), encoding="utf-8")
+        _persist_worker_outputs(raw_dir, results)
 
         if not quorum_met:
             abort_unavailable(verify_dir, goal_hash, "quorum not met",

--- a/plugins/deep-research/scripts/harvest_clients/base.py
+++ b/plugins/deep-research/scripts/harvest_clients/base.py
@@ -10,9 +10,42 @@ import http.client
 import json
 import socket
 import ssl
+import sys
 import time
 import urllib.error
 import urllib.request
+
+# curl_cffi is an optional soft dependency (the "curl-cffi" fetch backend
+# only): the core pipeline stays stdlib-only and degrades cleanly to the
+# next fetch backend when it isn't installed. Never import it at module
+# scope unconditionally -- that would turn a missing optional package into
+# a hard crash for every consumer of this module (including the
+# SubagentStop hook, which imports harvest.py on every turn).
+try:
+    from curl_cffi import requests as curl_cffi_requests
+    from curl_cffi.const import CurlOpt as CurlCffiOpt
+    _HAS_CURL_CFFI = True
+except ImportError:
+    curl_cffi_requests = None
+    CurlCffiOpt = None
+    _HAS_CURL_CFFI = False
+
+
+_CURL_CFFI_MISSING_MSG = (
+    "ERROR: fetch backend 'curl-cffi' is configured but curl_cffi is not "
+    "installed. Run: pip3 install --user curl_cffi"
+)
+
+
+def _check_curl_cffi_available(config):
+    # Config declares the backend -> it must be installed, fail fast before
+    # touching any state (cleanup/tombstone) or spending an API call. Config
+    # doesn't declare it -> curl_cffi is never imported at runtime and the
+    # pipeline stays exactly as stdlib-only as it always has been.
+    types = [b.get("type") for b in config.get("fetch_backends", [])]
+    if "curl-cffi" in types and not _HAS_CURL_CFFI:
+        print(_CURL_CFFI_MISSING_MSG, file=sys.stderr)
+        sys.exit(4)
 
 
 def _read_http_error_body(e):

--- a/plugins/deep-research/scripts/harvest_fetch/__init__.py
+++ b/plugins/deep-research/scripts/harvest_fetch/__init__.py
@@ -1,0 +1,336 @@
+"""harvest_fetch - URL fetch backends (tavily-extract, jina-reader, curl-cffi,
+urllib-ua) + orchestration (call_fetch_backend/do_fetch). Depends on
+harvest_safety (SSRF/blacklist) and harvest_clients.base (HTTP primitives +
+curl_cffi capability); never imports harvest_search (strict siblings)."""
+import html
+import json
+import os
+import re
+import socket
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import harvest_safety
+import harvest_clients.base
+
+__all__ = [
+    "_fetch_tavily_extract", "_fetch_jina_reader", "_strip_html_to_text",
+    "_looks_like_challenge_page", "_fetch_curl_cffi", "_fetch_urllib_ua",
+    "call_fetch_backend", "do_fetch",
+]
+
+_HTML_TAG_RE = re.compile(r'<[^>]+>')
+
+
+# ---------------------------------------------------------------------------
+# Fetch backends (degrade in config order)
+# ---------------------------------------------------------------------------
+
+def _fetch_tavily_extract(cfg, url, timeout, max_chars):
+    api_key = os.environ.get(cfg.get("api_key_env", ""), "")
+    if not api_key:
+        return None, f"tavily-extract: {cfg.get('api_key_env') or '(no api_key_env configured)'} not set"
+    payload = {"api_key": api_key, "urls": [url]}
+    try:
+        data = harvest_clients.base._http_json_post("https://api.tavily.com/extract", payload, {"Content-Type": "application/json"}, timeout)
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError) as e:
+        return None, f"tavily-extract: request failed: {e}"
+    results = data.get("results") or []
+    if not results:
+        return None, "tavily-extract: empty results"
+    content = results[0].get("raw_content") or results[0].get("content")
+    if not content:
+        return None, "tavily-extract: empty content in result"
+    return content, None
+
+
+def _fetch_jina_reader(cfg, url, timeout, max_chars):
+    api_key = os.environ.get(cfg.get("api_key_env", ""), "")
+    # r.jina.ai rejects urllib's default "Python-urllib/3.x" UA with HTTP 403
+    # (independent of the API key -- any non-default UA gets 200). Send the
+    # same UA as _fetch_urllib_ua so this backend isn't silently 403'd.
+    headers = {"User-Agent": "Mozilla/5.0 (compatible; harvest.py/1.0)",
+               "Accept": "text/plain", "Accept-Encoding": "identity"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request("https://r.jina.ai/" + url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = harvest_clients.base._maybe_decompress(resp.read(max_chars * 4), resp)
+    except (urllib.error.URLError, OSError) as e:
+        return None, f"jina-reader: request failed: {e}"
+    try:
+        return raw.decode("utf-8", errors="replace"), None
+    except Exception as e:
+        return None, f"jina-reader: failed to decode response body: {e}"
+
+
+_HTML_SCRIPT_STYLE_RE = re.compile(r'<(script|style)\b[^>]*>.*?</\1>', re.IGNORECASE | re.DOTALL)
+
+
+def _strip_html_to_text(raw_html):
+    # urllib-ua and curl-cffi are the backends that return raw page source
+    # (tavily-extract/jina-reader already return clean text) -- without
+    # this, the fetch_max_chars budget is spent on markup instead of prose,
+    # and an excerpt that spans an inline tag (e.g. "...the <a href=...>WAL
+    # </a> file...") fails substring matching against the untouched HTML
+    # even though it's a real verbatim quote of the rendered text. Strip
+    # script/style blocks first (their contents aren't page text at all),
+    # then every remaining tag, then resolve entities, then fold whitespace
+    # -- in that order so truncation to fetch_max_chars (done by the
+    # caller, after this returns) spends the budget on prose, not tags.
+    text = _HTML_SCRIPT_STYLE_RE.sub(" ", raw_html)
+    text = _HTML_TAG_RE.sub(" ", text)
+    text = html.unescape(text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+_CURL_CFFI_MAX_REDIRECT_HOPS = 3
+_CURL_CFFI_REDIRECT_STATUSES = (301, 302, 303, 307, 308)
+
+# curl_cffi impersonates a real browser's TLS/HTTP fingerprint but cannot
+# execute JavaScript -- so when a WAF (Cloudflare/DataDome/PerimeterX/
+# Imperva) serves a JS challenge ("holding page"), curl_cffi gets exactly
+# that holding page back as its final response, not the article. Without
+# this check, that holding page's body (often HTTP 200, sometimes 403/503)
+# is silently stripped-to-text and returned as if it were real page
+# content, poisoning the downstream citation-verification pipeline with
+# challenge-script prose that happens to contain no obvious HTTP error.
+# See issue #81.
+#
+# Markers are deliberately script paths / JS globals / DOM ids / CDN
+# domains -- unique implementation artifacts of the challenge widgets
+# themselves -- rather than human-readable phrases like "checking your
+# browser" or "just a moment". Human phrases appear verbatim in ordinary
+# prose (news articles about Cloudflare outages, blog posts explaining
+# Turnstile, this very code review) and would cause false positives;
+# the literal script/DOM/CDN artifacts below only ever appear when the
+# actual vendor widget markup is present on the page.
+_CHALLENGE_PAGE_MARKERS = (
+    # Cloudflare (challenge-platform script, browser-verification banner,
+    # the cf_chl_opt JS config object, Turnstile widget, _cf_chl JS global)
+    "/cdn-cgi/challenge-platform/",
+    "cf-browser-verification",
+    "_cf_chl_opt",
+    "cf-turnstile",
+    "window._cf_chl",
+    # DataDome (captcha delivery CDN the challenge script loads from)
+    "captcha-delivery.com",
+    # PerimeterX / HUMAN (captcha widget id, JS app-id global)
+    "px-captcha",
+    "window._pxappid",
+    # Imperva / Incapsula (challenge resource endpoint)
+    "_incapsula_resource",
+)
+
+# Challenge/holding pages are minimal (a script tag, a spinner, a couple
+# of divs) -- always tiny, never anywhere near fetch_max_chars territory.
+# Real long-form content that happens to discuss these vendors (e.g. a
+# deep-research task investigating WAF/Turnstile bypass techniques, or an
+# article with an embedded code sample) can legitimately contain these
+# same artifact strings inside tens of KB of genuine prose. This gate lets
+# such long-form pages through unconditionally while still catching even
+# a bloated/verbose challenge page, since real-world challenge HTML has
+# never been observed anywhere close to 100KB.
+_CHALLENGE_MAX_PAGE_CHARS = 100 * 1024
+
+
+def _looks_like_challenge_page(raw_html):
+    # resp.text can be None or "" (empty body, e.g. a HEAD-like 204, or a
+    # decode that yielded nothing) -- guard first, since .lower() on None
+    # would raise AttributeError and take curl-cffi out of rotation via
+    # call_fetch_backend's broad except instead of cleanly degrading.
+    if not raw_html:
+        return False
+    if len(raw_html) >= _CHALLENGE_MAX_PAGE_CHARS:
+        return False
+    lowered = raw_html.lower()
+    return any(marker in lowered for marker in _CHALLENGE_PAGE_MARKERS)
+
+
+def _fetch_curl_cffi(cfg, url, timeout, max_chars, config):
+    # libcurl (which curl_cffi wraps via C bindings) does its own DNS
+    # resolution entirely inside libcurl's C layer -- it never calls back
+    # into Python's socket.getaddrinfo, so the process-level SSRF guard
+    # (install_ssrf_guard()'s monkeypatch) provides ZERO protection here.
+    # The fix: resolve each hop ourselves through the guarded
+    # getaddrinfo (via _ssrf_validate_and_resolve, which raises
+    # SSRFBlocked on any private/reserved address), then pin libcurl to
+    # that exact, already-vetted IP with CURLOPT_RESOLVE. This closes the
+    # TOCTOU window entirely -- libcurl is never allowed to resolve the
+    # host itself, only to connect to the address we already validated.
+    # Redirects are followed manually (allow_redirects=False) so every hop
+    # gets its own independent guard + blacklist check; libcurl's built-in
+    # redirect-following would silently reuse the pinned IP for whatever
+    # Location header a compromised/malicious first hop returned.
+    #
+    # No "not installed -> skip" branch here: _check_curl_cffi_available()
+    # already fail-fast-exits cmd_run() before any fetch happens if this
+    # backend is configured but curl_cffi isn't importable, so by the time
+    # this function runs, _HAS_CURL_CFFI is guaranteed True.
+    #
+    # `timeout` is the total budget for this call *across all redirect
+    # hops*, not per-hop -- without this, a tarpit (slow-drip response)
+    # combined with a redirect chain could burn hops * timeout wall clock.
+    # `.get(key, default)` (not `config["limits"][key]`) is deliberate:
+    # these three keys are new, and a config that predates them must keep
+    # working with these defaults rather than KeyError -> get swallowed by
+    # call_fetch_backend's broad except into a silent, permanent
+    # "unexpected error" that takes curl-cffi out of rotation for good.
+    limits = config.get("limits", {})
+    connect_timeout_s = limits.get("fetch_connect_timeout_s", 5)
+    low_speed_bytes_s = limits.get("fetch_low_speed_bytes_s", 512)
+    low_speed_window_s = limits.get("fetch_low_speed_window_s", 10)
+    blacklist = config.get("blacklist_domains", [])
+    impersonate = cfg.get("impersonate", "chrome")
+    current_url = url
+    deadline = time.monotonic() + timeout
+    for hop in range(_CURL_CFFI_MAX_REDIRECT_HOPS + 1):
+        # < 1, not <= 0: curl_cffi converts seconds to milliseconds via
+        # int(x * 1000), and libcurl treats a 0ms timeout as *no limit*.
+        # A remaining budget inside that sub-millisecond window would
+        # otherwise round down to 0 and silently reopen the hang this
+        # deadline exists to close.
+        remaining = deadline - time.monotonic()
+        if remaining < 1:
+            return None, "curl-cffi: total fetch deadline exceeded across redirects"
+        if harvest_safety.is_blacklisted(current_url, blacklist):
+            return None, f"curl-cffi: redirect target domain blacklisted: {current_url}"
+        try:
+            host, port, ip = harvest_safety._ssrf_validate_and_resolve(current_url)
+        except (socket.gaierror, OSError) as e:
+            return None, f"curl-cffi: DNS resolution failed: {e}"
+        pin = f"{host}:{port}:{ip}"
+        # curl_cffi 0.15.0 sets CURLOPT_TIMEOUT_MS = connect + read for a
+        # tuple timeout (it sums the two components, it doesn't treat
+        # `read` as the total) -- so to cap this hop's total at exactly
+        # `remaining`, the read component must be `remaining - conn`, not
+        # `remaining` itself. `- 0.1` keeps a strictly positive read
+        # component even when remaining is barely above the connect cap.
+        conn = min(connect_timeout_s, remaining - 0.1)
+        try:
+            resp = harvest_clients.base.curl_cffi_requests.get(
+                current_url, timeout=(conn, remaining - conn), impersonate=impersonate,
+                allow_redirects=False, headers={"Accept-Encoding": "identity"},
+                curl_options={
+                    harvest_clients.base.CurlCffiOpt.RESOLVE: [pin],
+                    harvest_clients.base.CurlCffiOpt.MAXFILESIZE_LARGE: max_chars * 4,
+                    harvest_clients.base.CurlCffiOpt.LOW_SPEED_LIMIT: low_speed_bytes_s,
+                    harvest_clients.base.CurlCffiOpt.LOW_SPEED_TIME: low_speed_window_s,
+                },
+            )
+        except Exception as e:
+            return None, f"curl-cffi: request failed: {e}"
+        if resp.status_code in _CURL_CFFI_REDIRECT_STATUSES:
+            location = resp.headers.get("location")
+            if not location:
+                return None, f"curl-cffi: redirect status {resp.status_code} missing Location header"
+            current_url = urllib.parse.urljoin(current_url, location)
+            continue
+        try:
+            text = resp.text
+        except Exception as e:
+            return None, f"curl-cffi: failed to decode response body: {e}"
+        # Gate 1: challenge page first, regardless of status code -- a
+        # Cloudflare/DataDome/etc holding page served with 403/503 must be
+        # reported as a challenge, not swallowed by the generic HTTP-error
+        # gate below (which would lose the actual root cause from
+        # telemetry: "anti-bot challenge" vs. "some 403").
+        if _looks_like_challenge_page(text):
+            return None, "curl-cffi: anti-bot JS challenge page (needs a JS-capable backend)"
+        # Gate 2: an ordinary error page (403/404/5xx, no challenge marker)
+        # is also not article content -- refuse to return its body too.
+        if not (200 <= resp.status_code < 300):
+            return None, f"curl-cffi: HTTP {resp.status_code}"
+        return _strip_html_to_text(text), None
+    return None, f"curl-cffi: exceeded max redirect hops ({_CURL_CFFI_MAX_REDIRECT_HOPS})"
+
+
+def _fetch_urllib_ua(cfg, url, timeout, max_chars):
+    headers = {"User-Agent": "Mozilla/5.0 (compatible; harvest.py/1.0)",
+               "Accept-Encoding": "identity"}
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = harvest_clients.base._maybe_decompress(resp.read(max_chars * 4), resp)
+    except (urllib.error.URLError, OSError) as e:
+        return None, f"urllib-ua: request failed: {e}"
+    try:
+        text = raw.decode("utf-8", errors="replace")
+    except Exception as e:
+        return None, f"urllib-ua: failed to decode response body: {e}"
+    return _strip_html_to_text(text), None
+
+
+def call_fetch_backend(backend_cfg, limiter, url, config, attempts=None):
+    limiter.acquire()
+    # Per-backend timeout_s override, falling back to the shared
+    # call_timeout_s -- .get() means backends that don't declare timeout_s
+    # (or a config predating this field) keep the old 180s behavior.
+    timeout = backend_cfg.get("timeout_s", config["limits"]["call_timeout_s"])
+    max_chars = config["limits"]["fetch_max_chars"]
+    btype = backend_cfg["type"]
+    try:
+        if btype == "tavily-extract":
+            content, reason = _fetch_tavily_extract(backend_cfg, url, timeout, max_chars)
+        elif btype == "jina-reader":
+            content, reason = _fetch_jina_reader(backend_cfg, url, timeout, max_chars)
+        elif btype == "curl-cffi":
+            content, reason = _fetch_curl_cffi(backend_cfg, url, timeout, max_chars, config)
+        elif btype == "urllib-ua":
+            content, reason = _fetch_urllib_ua(backend_cfg, url, timeout, max_chars)
+        else:
+            content, reason = None, f"unknown fetch backend type: {btype}"
+    except harvest_safety.SSRFBlocked:
+        raise
+    except Exception as e:
+        content, reason = None, f"unexpected error: {e}"
+    if not content and attempts is not None:
+        attempts.append({"backend": btype, "error": reason or "no content"})
+    return content
+
+
+def do_fetch(url, fetch_backends, journal, config):
+    # SSRF guard scope: only the connection whose destination host is
+    # derived from model-controlled input is a real SSRF surface -- that is
+    # urllib-ua's and curl-cffi's direct connection to `url` (and any
+    # redirects they follow). tavily-extract/jina-reader take `url` as a
+    # request *parameter* to a fixed, trusted API host; the actual fetch of
+    # that URL happens on their servers, not on this machine, so guarding
+    # them here would only false-positive-block a legitimate internally-
+    # hosted gateway/API without adding any real protection. The domain
+    # blacklist still applies to `url` regardless of which backend ends up
+    # serving it. (curl-cffi additionally re-validates + re-pins every
+    # redirect hop internally, since libcurl's own DNS resolution bypasses
+    # this guard entirely -- see _fetch_curl_cffi().)
+    blacklist = config.get("blacklist_domains", [])
+    if harvest_safety.is_blacklisted(url, blacklist):
+        journal.append({"tool": "fetch", "url": url, "blocked": "blacklist", "content": None})
+        return json.dumps({"error": "domain blacklisted"})
+
+    max_chars = config["limits"]["fetch_max_chars"]
+    attempts = []
+    for backend_cfg, limiter in fetch_backends:
+        guarded = backend_cfg["type"] in ("urllib-ua", "curl-cffi")
+        try:
+            if guarded:
+                with harvest_safety.tool_request_guard():
+                    harvest_safety._ssrf_precheck(url)
+                    content = call_fetch_backend(backend_cfg, limiter, url, config, attempts)
+            else:
+                content = call_fetch_backend(backend_cfg, limiter, url, config, attempts)
+        except harvest_safety.SSRFBlocked as e:
+            journal.append({"tool": "fetch", "url": url, "blocked": "ssrf", "content": None, "attempts": attempts})
+            return json.dumps({"error": f"blocked by SSRF guard: {e}"})
+        except Exception as e:
+            content = None
+            attempts.append({"backend": backend_cfg["type"], "error": f"unexpected error: {e}"})
+        if content:
+            truncated = content[:max_chars]
+            journal.append({"tool": "fetch", "url": url, "backend": backend_cfg["type"], "content": truncated,
+                             "attempts": attempts})
+            return truncated
+    journal.append({"tool": "fetch", "url": url, "backend": None, "content": None, "attempts": attempts})
+    return json.dumps({"error": "all fetch backends failed"})

--- a/plugins/deep-research/scripts/harvest_safety.py
+++ b/plugins/deep-research/scripts/harvest_safety.py
@@ -1,0 +1,147 @@
+"""Safety layer: SSRF guard, domain blacklist, path sandbox, rate limiter,
+URL normalization. Zero dependency on the rest of harvest -- importable
+side-effect free (install_ssrf_guard() is explicit, not import-time)."""
+import ipaddress
+import socket
+import threading
+import time
+import urllib.parse
+
+__all__ = [
+    "RateLimiter", "SSRFBlocked", "install_ssrf_guard", "tool_request_guard",
+    "_ssrf_validate_and_resolve", "_ssrf_precheck", "is_blacklisted",
+    "_is_relative_to", "normalize_url", "_guarded_getaddrinfo",
+]
+
+
+class RateLimiter:
+    """One lock-protected timestamp per backend instance. Critical section is
+    timestamp-only; sleep and the actual call happen outside the lock."""
+
+    def __init__(self, min_interval_s):
+        self._min_interval = min_interval_s
+        self._lock = threading.Lock()
+        self._next_allowed = 0.0
+
+    def acquire(self):
+        with self._lock:
+            now = time.monotonic()
+            wait = max(0.0, self._next_allowed - now)
+            self._next_allowed = max(now, self._next_allowed) + self._min_interval
+        if wait > 0:
+            time.sleep(wait)
+
+
+class SSRFBlocked(Exception):
+    pass
+
+
+_tool_ctx = threading.local()
+_real_getaddrinfo = socket.getaddrinfo
+
+
+def _is_blocked_ip(ip_str):
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return True
+    return (ip.is_private or ip.is_loopback or ip.is_link_local
+            or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
+
+
+def _guarded_getaddrinfo(host, *args, **kwargs):
+    result = _real_getaddrinfo(host, *args, **kwargs)
+    if getattr(_tool_ctx, "active", False):
+        for item in result:
+            ip = item[4][0]
+            if _is_blocked_ip(ip):
+                raise SSRFBlocked(f"blocked address for host {host}: {ip}")
+    return result
+
+
+def install_ssrf_guard():
+    """Monkeypatch socket.getaddrinfo. Called at run-start, not at import
+    time, so importing this module (e.g. from the SubagentStop hook) stays
+    side-effect free."""
+    socket.getaddrinfo = _guarded_getaddrinfo
+
+
+class tool_request_guard:
+    """Context manager marking the current thread as executing a tool call
+    whose network target may be attacker/model controlled. Only active
+    inside this context does the guard reject private/loopback/reserved
+    addresses -- gateway chat-completion calls are made outside it."""
+
+    def __enter__(self):
+        self._prev = getattr(_tool_ctx, "active", False)
+        _tool_ctx.active = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        _tool_ctx.active = self._prev
+        return False
+
+
+def _ssrf_validate_and_resolve(url):
+    """Shared SSRF validation: scheme + host-presence checks, then a single
+    guarded socket.getaddrinfo() call (raises SSRFBlocked if any returned
+    address is private/loopback/reserved). Returns (host, port, first_ip)
+    so callers that need the actual resolved address -- not just a pass/
+    fail check -- don't have to resolve a second time."""
+    parts = urllib.parse.urlsplit(url)
+    if parts.scheme not in ("http", "https"):
+        raise SSRFBlocked(f"unsupported scheme: {parts.scheme}")
+    host = parts.hostname
+    if not host:
+        raise SSRFBlocked("no host in URL")
+    port = parts.port or (443 if parts.scheme == "https" else 80)
+    results = socket.getaddrinfo(host, port)
+    return host, port, results[0][4][0]
+
+
+def _ssrf_precheck(url):
+    _ssrf_validate_and_resolve(url)
+
+
+def is_blacklisted(url, blacklist_domains):
+    try:
+        host = urllib.parse.urlsplit(url).hostname
+    except ValueError:
+        return True
+    if not host:
+        return False
+    # .hostname (not manual "@"/":" splitting) correctly strips userinfo,
+    # port, and IPv6 brackets -- manual colon-splitting breaks on IPv6
+    # literals, which contain colons inside the address itself.
+    host = host.lower().rstrip(".")
+    for domain in blacklist_domains:
+        domain = domain.lower().rstrip(".")
+        if host == domain or host.endswith("." + domain):
+            return True
+    return False
+
+
+def _is_relative_to(path, base):
+    try:
+        path.relative_to(base)
+        return True
+    except ValueError:
+        return False
+
+
+def normalize_url(url):
+    url = (url or "").strip()
+    if url.startswith("local://"):
+        return "local://" + url[len("local://"):].strip("/")
+    try:
+        parts = urllib.parse.urlsplit(url)
+        netloc = parts.netloc.lower()
+        path = parts.path.rstrip("/")
+        return urllib.parse.urlunsplit((parts.scheme.lower(), netloc, path, parts.query, ""))
+    except ValueError:
+        # Malformed URL (e.g. a broken IPv6 literal) from model output or a
+        # search backend result -- treat as non-normalizable rather than
+        # crashing the worker. Returning it unnormalized just means it
+        # won't match any journal-derived key, which correctly fails
+        # citation validation instead of taking down the whole run.
+        return url

--- a/plugins/deep-research/scripts/harvest_search/__init__.py
+++ b/plugins/deep-research/scripts/harvest_search/__init__.py
@@ -1,0 +1,390 @@
+"""harvest_search - web search backends (gemini-cli, duckduckgo, tavily,
+gemini-grounding) + orchestration (call_search_backend/do_search). Depends on
+harvest_safety (blacklist) and harvest_clients.base (HTTP primitives +
+curl_cffi capability); never imports harvest_fetch (strict siblings)."""
+import html
+import json
+import os
+import re
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import harvest_safety
+import harvest_clients.base
+
+__all__ = [
+    "_search_gemini_cli", "_ddg_extract_target_url", "_search_duckduckgo",
+    "_search_tavily", "_resolve_grounding_redirect", "_search_gemini_grounding",
+    "_no_redirect_opener", "call_search_backend", "do_search",
+]
+# (_NoRedirect / _DDG_* / _GROUNDING_* / _HTML_TAG_RE are internal implementation,
+# not listed in __all__ -- but tests referencing them go through qualified
+# harvest_search.X access, see contract §3)
+
+# Parallel redirect resolution in _search_gemini_grounding needs a worker cap.
+# harvest.py's own _PARALLEL_FETCH_MAX_WORKERS (fetch-domain driver, not moved
+# here) is a sibling constant for the same purpose -- kept as a trivial local
+# duplicate rather than a cross-package import, same rationale as _HTML_TAG_RE.
+_PARALLEL_FETCH_MAX_WORKERS = 3
+
+
+# ---------------------------------------------------------------------------
+# Search backends (degrade in config order)
+# ---------------------------------------------------------------------------
+
+def _search_gemini_cli(cfg, query, timeout):
+    try:
+        proc = subprocess.run(
+            ["gemini", "-m", cfg.get("model", "gemini-3.5-flash"), "-p", query],
+            capture_output=True, timeout=timeout, stdin=subprocess.DEVNULL, text=True,
+        )
+    except subprocess.TimeoutExpired:
+        return None, "gemini-cli: timed out"
+    except OSError as e:
+        return None, f"gemini-cli: failed to launch subprocess: {e}"
+    if proc.returncode != 0:
+        detail = (proc.stderr or "").strip()[:200]
+        return None, f"gemini-cli: exited with code {proc.returncode}" + (f": {detail}" if detail else "")
+    text = proc.stdout or ""
+    if not text.strip():
+        return None, "gemini-cli: empty output"
+    urls = list(dict.fromkeys(re.findall(r'https?://[^\s\)\]\'"<>]+', text)))
+    if not urls:
+        return None, "gemini-cli: no URLs found in output"
+    return [{"url": u, "title": "", "snippet": text[:500]} for u in urls], None
+
+
+_DDG_ANCHOR_RE = re.compile(r'<a\b([^>]*)>(.*?)</a>', re.IGNORECASE | re.DOTALL)
+_DDG_HREF_RE = re.compile(r'href="([^"]*)"')
+_HTML_TAG_RE = re.compile(r'<[^>]+>')
+# Markers observed in html.duckduckgo.com's anti-bot interstitial ("Select
+# all squares containing a duck") -- used to distinguish a genuine
+# zero-results page from an IP-reputation block, for observability only.
+_DDG_BOT_CHECK_MARKERS = ("anomaly-modal", "challenge-form")
+
+
+def _ddg_extract_target_url(href):
+    # html.duckduckgo.com wraps result links in a same-site redirect
+    # (//duckduckgo.com/l/?uddg=<url-encoded target>&rut=...); unwrap it to
+    # get the real target URL. Non-redirect hrefs pass through unchanged.
+    parsed = urllib.parse.urlsplit(href)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    # Suffix/equality match, not substring containment -- "in" would also
+    # match an unrelated host like "duckduckgo.com.evil.com" (same class of
+    # anti-pattern is_blacklisted() already guards against elsewhere in
+    # this file).
+    if host == "duckduckgo.com" or host.endswith(".duckduckgo.com"):
+        qs = urllib.parse.parse_qs(parsed.query)
+        if "uddg" in qs and qs["uddg"]:
+            # parse_qs() already percent-decodes query values once; a second
+            # unquote() here double-decodes and corrupts any target URL that
+            # itself contains a literal "%" escape sequence.
+            return qs["uddg"][0]
+    return href
+
+
+def _search_duckduckgo(cfg, query, timeout):
+    url = "https://html.duckduckgo.com/html/?q=" + urllib.parse.quote(query)
+
+    if harvest_clients.base._HAS_CURL_CFFI:
+        try:
+            resp = harvest_clients.base.curl_cffi_requests.get(
+                url, impersonate=(cfg or {}).get("impersonate", "chrome"),
+                timeout=timeout, allow_redirects=True,
+            )
+            if resp.status_code != 200:
+                return None, f"duckduckgo: HTTP {resp.status_code}"
+            page = resp.text
+        except Exception as e:
+            return None, f"duckduckgo: curl-cffi request failed: {e}"
+    else:
+        headers = {"User-Agent": "Mozilla/5.0 (compatible; harvest.py/1.0)",
+                   "Accept-Encoding": "identity"}
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                raw = harvest_clients.base._maybe_decompress(resp.read(), resp)
+        except (urllib.error.URLError, OSError) as e:
+            return None, f"duckduckgo: request failed: {e}"
+        try:
+            page = raw.decode("utf-8", errors="replace")
+        except Exception as e:
+            return None, f"duckduckgo: failed to decode response body: {e}"
+
+    results = []
+    for attrs, inner in _DDG_ANCHOR_RE.findall(page):
+        if "result__a" not in attrs:
+            continue
+        href_match = _DDG_HREF_RE.search(attrs)
+        if not href_match:
+            continue
+        target = _ddg_extract_target_url(html.unescape(href_match.group(1)))
+        if not target:
+            continue
+        title = html.unescape(_HTML_TAG_RE.sub("", inner)).strip()
+        results.append({"url": target, "title": title, "snippet": ""})
+    if results:
+        return results, None
+    if any(marker in page for marker in _DDG_BOT_CHECK_MARKERS):
+        return None, ("duckduckgo: bot-check challenge page returned instead of results "
+                       "(IP-reputation block, not a parsing bug)")
+    return None, "duckduckgo: no result links found in response"
+
+
+def _search_tavily(cfg, query, timeout):
+    api_key = os.environ.get(cfg.get("api_key_env", ""), "")
+    if not api_key:
+        return None, f"tavily: {cfg.get('api_key_env') or '(no api_key_env configured)'} not set"
+    payload = {"api_key": api_key, "query": query}
+    try:
+        data = harvest_clients.base._http_json_post("https://api.tavily.com/search", payload, {"Content-Type": "application/json"}, timeout)
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError) as e:
+        return None, f"tavily: request failed: {e}"
+    items = data.get("results") or []
+    results = [{"url": r.get("url", ""), "title": r.get("title", ""), "snippet": r.get("content", "")}
+               for r in items if r.get("url")]
+    if not results:
+        return None, "tavily: empty results"
+    return results, None
+
+
+# Gemini's grounding chunks never carry the real source URL directly -- each
+# web.uri is a Google redirect short link on this fixed host. It is the ONLY
+# host _resolve_grounding_redirect is ever allowed to connect to; anything
+# else (a hallucinated/injected uri like http://169.254.169.254/) is rejected
+# before a byte leaves the process.
+_GROUNDING_REDIRECT_HOST = "vertexaisearch.cloud.google.com"
+_GROUNDING_REDIRECT_STATUSES = (301, 302, 303, 307, 308)
+_GROUNDING_REDIRECT_TIMEOUT_S = 10
+
+# Grounding is a real live search, so (unlike the old fake gateway-gemini) the
+# prompt doesn't ask the model to invent URLs -- it just steers the query and
+# mirrors the repo-wide content-farm exclusion. The exclusion line is a
+# courtesy only -- prompting the model to skip a domain does not stop it
+# appearing in groundingChunks (those are raw retrieval results the prompt
+# text has no control over); is_blacklisted() in do_search() is the actual
+# enforcement. No SEARCH_FAILED sentinel: whether retrieval happened is read
+# structurally from groundingMetadata, not parsed out of free text.
+#
+# The "cite EVERY source ... COMPLETE set ... do not truncate" line is
+# load-bearing, not decoration. Debugging against the raw API showed the
+# model already searches even on a MISS (groundingMetadata/webSearchQueries/
+# 9-15 chunks all present) -- the miss was this prompt only asking to search
+# "the live web" and the model then under-reporting which sources it
+# actually consulted. Adding this sentence took a repeatedly-empty-chunks
+# Chinese query from 0 to 21 chunks and this backend's measured hit rate
+# from ~60% to 100%. Deliberately NOT adding a "you MUST call google_search"
+# hard constraint -- tested too, no measured gain and it adds thinking-token
+# latency.
+_GROUNDING_SEARCH_PROMPT = (
+    "Search the live web for: {query}\n"
+    "Cite EVERY source you actually consulted -- return the COMPLETE set of "
+    "source URLs, do not truncate or summarize the list.\n"
+    "Exclude results from content-farm hosts: csdn.net, cloud.baidu.com, "
+    "cloud.tencent.com, huaweicloud.com, aliyun.com, volcengine.com, juejin.cn."
+)
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Intercept every 30x so urllib never auto-follows a grounding redirect
+    to its real target. urllib.request.urlopen installs an HTTPRedirectHandler
+    by default that transparently connects to the Location host -- that would
+    defeat the host-allowlist check in _resolve_grounding_redirect entirely
+    (the guard vets the redirect host, not the target). Returning None here
+    turns the 302 into a raised HTTPError whose Location header we read WITHOUT
+    ever connecting to it."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_no_redirect_opener = urllib.request.build_opener(_NoRedirect)
+
+
+def _resolve_grounding_redirect(uri, timeout):
+    """Resolve a grounding-api-redirect short link to its real landing URL by
+    reading the 302 Location header without following it. Connects ONLY to the
+    fixed, trusted grounding host -- any other host is rejected before a single
+    byte goes out (so this is not an SSRF surface even though the uri
+    originates from model output). Returns the real URL, or None (caller drops
+    the chunk) on a malformed uri, a non-grounding host, a non-redirect
+    response, or any network error."""
+    try:
+        # uri is model/provider-controlled grounding output; a malformed value
+        # (e.g. an unterminated IPv6 literal) makes urlsplit raise ValueError.
+        # Treat it as a droppable bad chunk -- same guard is_blacklisted() puts
+        # on this exact call -- so one bad uri can't abort the whole backend
+        # and discard every other valid chunk.
+        host = urllib.parse.urlsplit(uri).hostname
+    except ValueError:
+        return None
+    if host != _GROUNDING_REDIRECT_HOST:
+        return None
+    req = urllib.request.Request(
+        uri, headers={"User-Agent": "Mozilla/5.0 (compatible; harvest.py/1.0)"})
+    try:
+        # A genuine 200 (no redirect) means the short link resolved to nothing
+        # citable -- close it and drop. The redirect case below is the norm.
+        resp = _no_redirect_opener.open(req, timeout=timeout)
+        resp.close()
+        return None
+    except urllib.error.HTTPError as e:
+        if e.code in _GROUNDING_REDIRECT_STATUSES:
+            return e.headers.get("Location")
+        return None
+    except (urllib.error.URLError, OSError):
+        return None
+
+
+def _search_gemini_grounding(cfg, query, timeout, config):
+    """Real grounded web search via the gateway's Gemini-native
+    generateContent endpoint + built-in google_search tool. Replaces the old
+    fake gateway-gemini backend, which asked an OpenAI-compat /chat/completions
+    to 'list some URLs' and got model-recalled (hallucinated) links with no
+    live retrieval -- and, worse, since do_search stops at the first backend
+    that returns any non-blacklisted URL, that fake result permanently masked
+    the real tavily/duckduckgo backends behind it. Here the model actually
+    searches; grounding chunks carry real (redirect-wrapped) source URLs that
+    we resolve to true landing pages before returning them to the
+    citation-verifiable pipeline."""
+    gw = config["gateway"]
+    api_key = os.environ.get(gw["api_key_env"], "")
+    if not api_key:
+        return None, f"gemini-grounding: {gw.get('api_key_env') or '(no api_key_env configured)'} not set"
+    # Native endpoint is <origin>/v1beta/models/<model>:generateContent. Derive
+    # origin via urlsplit -- NOT base_url.rstrip('/v1'), which strips a char
+    # SET not a suffix and would mangle '.../v1' unpredictably. This makes a
+    # base_url of '.../v1', '.../v1/', or a bare origin all resolve correctly.
+    parts = urllib.parse.urlsplit(gw["base_url"])
+    url = f"{parts.scheme}://{parts.netloc}/v1beta/models/{cfg.get('model', '')}:generateContent"
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    payload = {
+        "contents": [{"role": "user", "parts": [{"text": _GROUNDING_SEARCH_PROMPT.format(query=query)}]}],
+        "tools": [{"google_search": {}}],
+    }
+    # thinkingBudget is opt-in and back-compat-strict: only add
+    # generationConfig at all when the config explicitly sets it, so a
+    # config predating this key sends byte-for-byte the same payload as
+    # before (no generationConfig with an implicit default sneaking in).
+    # Measured: thinkingBudget=0 does not lower the hit rate (google_search
+    # is a tool call, not something reasoning/thinking gates) and cuts
+    # latency to ~11-16s from the un-budgeted baseline.
+    if "thinking_budget" in cfg:
+        payload["generationConfig"] = {"thinkingConfig": {"thinkingBudget": cfg["thinking_budget"]}}
+    try:
+        data = harvest_clients.base._http_json_post(url, payload, headers, timeout)
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError) as e:
+        return None, f"gemini-grounding: request failed: {e}"
+    try:
+        chunks = data["candidates"][0]["groundingMetadata"]["groundingChunks"]
+    except (KeyError, IndexError, TypeError):
+        # No groundingMetadata/chunks -> the model chose not to search
+        # (grounding is model-discretionary, never guaranteed). Degrade to the
+        # next backend rather than mining plain text for URLs.
+        return None, "gemini-grounding: no grounding chunks (model did not search)"
+    redirect_timeout = min(timeout, _GROUNDING_REDIRECT_TIMEOUT_S)
+    # Redirect resolution is a network round-trip per chunk with no data
+    # dependency between chunks -- resolving serially measured 18.2s for 16
+    # chunks vs 2.5s in parallel. Same index-preallocate + future-to-index +
+    # as_completed-fills-by-original-index pattern as
+    # _run_fetch_calls_parallel (as_completed only picks scheduling order,
+    # never the order results land in `resolved`) so chunk-submission order
+    # -- which the dedup/citation-mapping below depends on -- survives
+    # regardless of which redirect answers first.
+    resolved = [None] * len(chunks)
+    with ThreadPoolExecutor(max_workers=min(len(chunks), _PARALLEL_FETCH_MAX_WORKERS) or 1) as pool:
+        future_to_index = {
+            pool.submit(_resolve_grounding_redirect, (ch.get("web") or {}).get("uri", ""), redirect_timeout): i
+            for i, ch in enumerate(chunks)
+        }
+        for fut in as_completed(future_to_index):
+            i = future_to_index[fut]
+            try:
+                resolved[i] = fut.result()
+            except Exception:
+                # A single bad uri (malformed/hostile/network blip) must not
+                # take down the whole grounding backend -- drop just this
+                # chunk, same as a normal unresolvable-redirect result.
+                resolved[i] = None
+    results, seen = [], set()
+    for ch, real_url in zip(chunks, resolved):
+        web = ch.get("web") or {}
+        uri = web.get("uri", "")
+        if not uri:
+            continue
+        if not real_url or real_url in seen:
+            continue
+        seen.add(real_url)
+        title = web.get("title", "")
+        # snippet = title (usually just the domain); blacklist filtering is
+        # do_search's job, kept out of here to avoid duplicating that concern.
+        results.append({"url": real_url, "title": title, "snippet": title})
+    if not results:
+        return None, "gemini-grounding: no resolvable source URLs in grounding chunks"
+    return results, None
+
+
+def call_search_backend(backend_cfg, limiter, query, lang, config, attempts=None):
+    limiter.acquire()
+    timeout = config["limits"]["call_timeout_s"]
+    btype = backend_cfg["type"]
+    try:
+        if btype == "gemini-cli":
+            result, reason = _search_gemini_cli(backend_cfg, query, timeout)
+        elif btype == "tavily":
+            result, reason = _search_tavily(backend_cfg, query, timeout)
+        elif btype == "duckduckgo":
+            result, reason = _search_duckduckgo(backend_cfg, query, timeout)
+        elif btype == "gemini-grounding":
+            result, reason = _search_gemini_grounding(backend_cfg, query, timeout, config)
+        else:
+            result, reason = None, f"unknown search backend type: {btype}"
+    except Exception as e:
+        result, reason = None, f"unexpected error: {e}"
+    if not result and attempts is not None:
+        attempts.append({"backend": btype, "error": reason or "no results"})
+    return result
+
+
+def do_search(query, lang, search_backends, journal, config):
+    # Search backends only ever connect to a fixed, developer-configured
+    # host (api.tavily.com / html.duckduckgo.com / our own gateway) -- the model's
+    # query text does not steer the connection destination, so this is not
+    # an SSRF surface and is not wrapped in tool_request_guard().
+    blacklist = config.get("blacklist_domains", [])
+    attempts = []
+    for backend_cfg, limiter in search_backends:
+        results = call_search_backend(backend_cfg, limiter, query, lang, config, attempts)
+        if results:
+            filtered = [r for r in results if not harvest_safety.is_blacklisted(r["url"], blacklist)]
+            if not filtered:
+                # Every result from this backend was blacklisted -- that's a
+                # degrade-worthy failure, not a genuine "no results" answer;
+                # try the next backend instead of returning an empty set.
+                attempts.append({"backend": backend_cfg["type"], "error": "all results filtered by blacklist"})
+                continue
+            if backend_cfg["type"] == "gemini-grounding":
+                for r in filtered:
+                    # NOT "fetch": grounding gives us a URL the model *saw* in
+                    # search results, not full page text -- content here is
+                    # only a title/domain string. Using a distinct tool type
+                    # keeps build_fetch_index() (which only recognizes
+                    # "fetch"/"read_local") from treating this title string as
+                    # verified full-text content, while build_journal_url_set()
+                    # still recognizes "search_grounding" so a claim citing
+                    # this URL without an explicit fetch() call correctly
+                    # fails as url_not_fetched (real citation retry required)
+                    # rather than url_not_in_journal (worse: implies the model
+                    # never even saw the URL) or silently passing.
+                    journal.append({"tool": "search_grounding", "url": r["url"],
+                                    "backend": "grounding", "content": None,
+                                    "title": r.get("title") or r["url"]})
+            journal.append({"tool": "search", "query": query, "lang": lang,
+                             "backend": backend_cfg["type"], "urls": [r["url"] for r in filtered],
+                             "attempts": attempts})
+            return json.dumps({"results": filtered}, ensure_ascii=False)
+    journal.append({"tool": "search", "query": query, "lang": lang, "backend": None, "urls": [], "attempts": attempts})
+    return json.dumps({"results": [], "error": "all search backends failed"})

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -14,6 +14,10 @@ from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 import harvest  # noqa: E402
+import harvest_fetch  # noqa: E402
+import harvest_safety  # noqa: E402
+import harvest_search  # noqa: E402
+import harvest_clients.base  # noqa: E402
 
 _FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 
@@ -234,14 +238,14 @@ class TestRunFetchCallsParallel(unittest.TestCase):
 class TestSSRFGuard(unittest.TestCase):
     def setUp(self):
         self._orig_getaddrinfo = socket.getaddrinfo
-        self._orig_real = harvest._real_getaddrinfo
+        self._orig_real = harvest_safety._real_getaddrinfo
 
     def tearDown(self):
         socket.getaddrinfo = self._orig_getaddrinfo
-        harvest._real_getaddrinfo = self._orig_real
+        harvest_safety._real_getaddrinfo = self._orig_real
 
     def _install_fake_dns(self, ip):
-        harvest._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", (ip, 0))]
+        harvest_safety._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", (ip, 0))]
 
     def test_private_ip_blocked_inside_tool_context(self):
         self._install_fake_dns("127.0.0.1")
@@ -585,7 +589,7 @@ _DDG_SAMPLE_HTML = """
 class TestDuckDuckGoSearch(unittest.TestCase):
     def setUp(self):
         # Force urllib path so HTML-parsing tests stay isolated from curl-cffi.
-        self._patch = mock.patch.object(harvest, "_HAS_CURL_CFFI", False)
+        self._patch = mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", False)
         self._patch.start()
 
     def tearDown(self):
@@ -594,7 +598,7 @@ class TestDuckDuckGoSearch(unittest.TestCase):
     def test_parses_result_links_and_unwraps_uddg_redirect(self):
         with mock.patch("harvest.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
-            results, reason = harvest._search_duckduckgo({}, "query", 5)
+            results, reason = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertIsNone(reason)
         urls = [r["url"] for r in results]
         self.assertIn("https://example.com/page?a=1", urls)
@@ -603,26 +607,26 @@ class TestDuckDuckGoSearch(unittest.TestCase):
     def test_title_html_entities_and_tags_stripped(self):
         with mock.patch("harvest.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
-            results, _ = harvest._search_duckduckgo({}, "query", 5)
+            results, _ = harvest_search._search_duckduckgo({}, "query", 5)
         titles = [r["title"] for r in results]
         self.assertTrue(any("Example & Title highlighted" == t for t in titles))
 
     def test_non_result_anchor_ignored(self):
         with mock.patch("harvest.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
-            results, _ = harvest._search_duckduckgo({}, "query", 5)
+            results, _ = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertEqual(len(results), 2)  # the result__snippet anchor is not counted
 
     def test_empty_page_returns_none_with_no_result_links_reason(self):
         with mock.patch("harvest.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(b"<html><body>no results</body></html>")):
-            result, reason = harvest._search_duckduckgo({}, "query", 5)
+            result, reason = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertIsNone(result)
         self.assertIn("no result links found", reason)
 
     def test_network_failure_returns_none_with_reason(self):
         with mock.patch("harvest.urllib.request.urlopen", side_effect=OSError("network down")):
-            result, reason = harvest._search_duckduckgo({}, "query", 5)
+            result, reason = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertIsNone(result)
         self.assertIn("request failed", reason)
 
@@ -630,14 +634,18 @@ class TestDuckDuckGoSearch(unittest.TestCase):
         # cfg has no api_key_env at all -- must not raise or require one.
         with mock.patch("harvest.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
-            results, _ = harvest._search_duckduckgo({}, "query", 5)
+            results, _ = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertIsNotNone(results)
 
     def test_full_do_search_filters_ddg_results_by_blacklist(self):
         journal = []
         cfg = base_config()
         backends = [({"type": "duckduckgo"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.urllib.request.urlopen",
+        # _HAS_CURL_CFFI pinned False so duckduckgo takes the mocked urllib
+        # path instead of curl_cffi_requests.get (real network) -- otherwise
+        # flaky on any machine with curl_cffi installed.
+        with mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", False), \
+             mock.patch("harvest.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
             result = harvest.do_search("query", "en", backends, journal, cfg)
         data = json.loads(result)
@@ -657,11 +665,11 @@ class TestDuckDuckGoSearch(unittest.TestCase):
         target = "https://example.com/search?q=100%25done"
         wire_value = urllib.parse.quote(target, safe="")
         href = f"//duckduckgo.com/l/?uddg={wire_value}&rut=abc123"
-        self.assertEqual(harvest._ddg_extract_target_url(href), target)
+        self.assertEqual(harvest_search._ddg_extract_target_url(href), target)
 
     def test_extract_target_url_passes_through_non_redirect_href(self):
         href = "https://example.com/direct-link"
-        self.assertEqual(harvest._ddg_extract_target_url(href), href)
+        self.assertEqual(harvest_search._ddg_extract_target_url(href), href)
 
     def test_extract_target_url_does_not_match_lookalike_host_via_substring(self):
         # copilot review round 5 on #25: "duckduckgo.com" in netloc was a
@@ -669,13 +677,13 @@ class TestDuckDuckGoSearch(unittest.TestCase):
         # "duckduckgo.com.evil.com" would also be (wrongly) treated as a
         # genuine DDG redirect wrapper. Must pass through unchanged.
         href = "https://duckduckgo.com.evil.com/l/?uddg=https%3A%2F%2Fattacker.example%2Fx"
-        self.assertEqual(harvest._ddg_extract_target_url(href), href)
+        self.assertEqual(harvest_search._ddg_extract_target_url(href), href)
 
     def test_extract_target_url_matches_duckduckgo_subdomain(self):
         target = "https://example.com/page"
         wire_value = urllib.parse.quote(target, safe="")
         href = f"//lite.duckduckgo.com/l/?uddg={wire_value}"
-        self.assertEqual(harvest._ddg_extract_target_url(href), target)
+        self.assertEqual(harvest_search._ddg_extract_target_url(href), target)
 
     def test_real_bot_check_page_detected_and_distinguished(self):
         # Real HTML snapshot captured from https://html.duckduckgo.com/html/?q=sqlite+wal
@@ -686,7 +694,7 @@ class TestDuckDuckGoSearch(unittest.TestCase):
         fixture = _FIXTURES_DIR / "ddg_anomaly_real.html"
         raw = fixture.read_bytes()
         with mock.patch("harvest.urllib.request.urlopen", return_value=FakeHTTPResponse(raw)):
-            result, reason = harvest._search_duckduckgo({}, "sqlite wal", 5)
+            result, reason = harvest_search._search_duckduckgo({}, "sqlite wal", 5)
         self.assertIsNone(result)
         self.assertIn("bot-check challenge page", reason)
         self.assertIn("IP-reputation block", reason)
@@ -699,10 +707,10 @@ class TestDuckDuckGoSearchCurlCffi(unittest.TestCase):
         fake_resp = mock.Mock()
         fake_resp.status_code = 200
         fake_resp.text = _DDG_SAMPLE_HTML
-        with mock.patch.object(harvest, "_HAS_CURL_CFFI", True), \
-             mock.patch("harvest.curl_cffi_requests") as mock_curl:
+        with mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", True), \
+             mock.patch("harvest_clients.base.curl_cffi_requests") as mock_curl:
             mock_curl.get.return_value = fake_resp
-            results, reason = harvest._search_duckduckgo({}, "query", 5)
+            results, reason = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertIsNone(reason)
         self.assertTrue(len(results) > 0)
         mock_curl.get.assert_called_once()
@@ -710,18 +718,18 @@ class TestDuckDuckGoSearchCurlCffi(unittest.TestCase):
     def test_curl_cffi_non_200_returns_error(self):
         fake_resp = mock.Mock()
         fake_resp.status_code = 403
-        with mock.patch.object(harvest, "_HAS_CURL_CFFI", True), \
-             mock.patch("harvest.curl_cffi_requests") as mock_curl:
+        with mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", True), \
+             mock.patch("harvest_clients.base.curl_cffi_requests") as mock_curl:
             mock_curl.get.return_value = fake_resp
-            result, reason = harvest._search_duckduckgo({}, "query", 5)
+            result, reason = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertIsNone(result)
         self.assertIn("HTTP 403", reason)
 
     def test_curl_cffi_exception_returns_error(self):
-        with mock.patch.object(harvest, "_HAS_CURL_CFFI", True), \
-             mock.patch("harvest.curl_cffi_requests") as mock_curl:
+        with mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", True), \
+             mock.patch("harvest_clients.base.curl_cffi_requests") as mock_curl:
             mock_curl.get.side_effect = RuntimeError("connection reset")
-            result, reason = harvest._search_duckduckgo({}, "query", 5)
+            result, reason = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertIsNone(result)
         self.assertIn("curl-cffi request failed", reason)
 
@@ -729,24 +737,24 @@ class TestDuckDuckGoSearchCurlCffi(unittest.TestCase):
         fake_resp = mock.Mock()
         fake_resp.status_code = 200
         fake_resp.text = "<html></html>"
-        with mock.patch.object(harvest, "_HAS_CURL_CFFI", True), \
-             mock.patch("harvest.curl_cffi_requests") as mock_curl:
+        with mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", True), \
+             mock.patch("harvest_clients.base.curl_cffi_requests") as mock_curl:
             mock_curl.get.return_value = fake_resp
-            harvest._search_duckduckgo({"impersonate": "safari"}, "q", 5)
+            harvest_search._search_duckduckgo({"impersonate": "safari"}, "q", 5)
         call_kwargs = mock_curl.get.call_args[1]
         self.assertEqual(call_kwargs["impersonate"], "safari")
 
 
 class TestSearchBackendMissingKeySkips(unittest.TestCase):
     def test_tavily_missing_key_returns_none_not_raise(self):
-        result, reason = harvest._search_tavily({"api_key_env": "NONEXISTENT_TAVILY_KEY_VAR"}, "q", 5)
+        result, reason = harvest_search._search_tavily({"api_key_env": "NONEXISTENT_TAVILY_KEY_VAR"}, "q", 5)
         self.assertIsNone(result)
         self.assertIn("not set", reason)
 
     def test_gemini_grounding_missing_key_returns_none_not_raise(self):
         cfg = base_config()
         cfg["gateway"]["api_key_env"] = "NONEXISTENT_GATEWAY_KEY_VAR"
-        result, reason = harvest._search_gemini_grounding({"model": "g"}, "q", 5, cfg)
+        result, reason = harvest_search._search_gemini_grounding({"model": "g"}, "q", 5, cfg)
         self.assertIsNone(result)
         self.assertIn("not set", reason)
         self.assertIn("gemini-grounding", reason)
@@ -758,7 +766,11 @@ class TestSearchBackendMissingKeySkips(unittest.TestCase):
             ({"type": "tavily", "api_key_env": "NONEXISTENT_TAVILY_KEY_VAR"}, harvest.RateLimiter(0)),
             ({"type": "duckduckgo"}, harvest.RateLimiter(0)),
         ]
-        with mock.patch("harvest.urllib.request.urlopen",
+        # _HAS_CURL_CFFI pinned False so duckduckgo takes the mocked urllib
+        # path instead of curl_cffi_requests.get (real network) -- otherwise
+        # flaky on any machine with curl_cffi installed.
+        with mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", False), \
+             mock.patch("harvest.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
             result = harvest.do_search("query", "en", backends, journal, cfg)
         data = json.loads(result)
@@ -790,10 +802,10 @@ class TestGeminiGroundingSearch(unittest.TestCase):
             _grounding_chunk("https://vertexaisearch.cloud.google.com/grounding-api-redirect/2", "other.com"),
         ]
         with mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"}), \
-             mock.patch("harvest._http_json_post", return_value=_grounding_response(chunks)), \
-             mock.patch("harvest._resolve_grounding_redirect",
+             mock.patch("harvest_clients.base._http_json_post", return_value=_grounding_response(chunks)), \
+             mock.patch("harvest_search._resolve_grounding_redirect",
                          side_effect=["https://example.com/real", "https://other.com/real"]):
-            results, reason = harvest._search_gemini_grounding({"model": "gemini-3.5-flash"}, "q", 5, cfg)
+            results, reason = harvest_search._search_gemini_grounding({"model": "gemini-3.5-flash"}, "q", 5, cfg)
         self.assertIsNone(reason)
         self.assertEqual([r["url"] for r in results], ["https://example.com/real", "https://other.com/real"])
         self.assertEqual(results[0]["title"], "example.com")
@@ -810,9 +822,9 @@ class TestGeminiGroundingSearch(unittest.TestCase):
         chunks = [_grounding_chunk(
             "https://vertexaisearch.cloud.google.com/grounding-api-redirect/1", "example.com")]
         with mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"}), \
-             mock.patch("harvest._http_json_post", return_value=_grounding_response(chunks)) as post_mock, \
-             mock.patch("harvest._resolve_grounding_redirect", return_value="https://example.com/real"):
-            harvest._search_gemini_grounding({"model": "gemini-3.5-flash"}, "q", 5, cfg)
+             mock.patch("harvest_clients.base._http_json_post", return_value=_grounding_response(chunks)) as post_mock, \
+             mock.patch("harvest_search._resolve_grounding_redirect", return_value="https://example.com/real"):
+            harvest_search._search_gemini_grounding({"model": "gemini-3.5-flash"}, "q", 5, cfg)
         sent_url, sent_payload = post_mock.call_args.args[0], post_mock.call_args.args[1]
         self.assertEqual(
             sent_url, "https://gw.example.com/v1beta/models/gemini-3.5-flash:generateContent")
@@ -822,8 +834,8 @@ class TestGeminiGroundingSearch(unittest.TestCase):
     def test_missing_grounding_metadata_degrades_with_reason(self):
         cfg = base_config()
         with mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"}), \
-             mock.patch("harvest._http_json_post", return_value={"candidates": [{"content": {}}]}):
-            result, reason = harvest._search_gemini_grounding({"model": "g"}, "q", 5, cfg)
+             mock.patch("harvest_clients.base._http_json_post", return_value={"candidates": [{"content": {}}]}):
+            result, reason = harvest_search._search_gemini_grounding({"model": "g"}, "q", 5, cfg)
         self.assertIsNone(result)
         self.assertIn("no grounding chunks", reason)
 
@@ -834,9 +846,9 @@ class TestGeminiGroundingSearch(unittest.TestCase):
             _grounding_chunk("https://vertexaisearch.cloud.google.com/grounding-api-redirect/2", "alive.com"),
         ]
         with mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"}), \
-             mock.patch("harvest._http_json_post", return_value=_grounding_response(chunks)), \
-             mock.patch("harvest._resolve_grounding_redirect", side_effect=[None, "https://alive.com/real"]):
-            results, reason = harvest._search_gemini_grounding({"model": "g"}, "q", 5, cfg)
+             mock.patch("harvest_clients.base._http_json_post", return_value=_grounding_response(chunks)), \
+             mock.patch("harvest_search._resolve_grounding_redirect", side_effect=[None, "https://alive.com/real"]):
+            results, reason = harvest_search._search_gemini_grounding({"model": "g"}, "q", 5, cfg)
         self.assertIsNone(reason)
         self.assertEqual([r["url"] for r in results], ["https://alive.com/real"])
 
@@ -844,17 +856,17 @@ class TestGeminiGroundingSearch(unittest.TestCase):
         cfg = base_config()
         chunks = [_grounding_chunk("https://vertexaisearch.cloud.google.com/grounding-api-redirect/1", "dead.com")]
         with mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"}), \
-             mock.patch("harvest._http_json_post", return_value=_grounding_response(chunks)), \
-             mock.patch("harvest._resolve_grounding_redirect", return_value=None):
-            result, reason = harvest._search_gemini_grounding({"model": "g"}, "q", 5, cfg)
+             mock.patch("harvest_clients.base._http_json_post", return_value=_grounding_response(chunks)), \
+             mock.patch("harvest_search._resolve_grounding_redirect", return_value=None):
+            result, reason = harvest_search._search_gemini_grounding({"model": "g"}, "q", 5, cfg)
         self.assertIsNone(result)
         self.assertIn("no resolvable source URLs", reason)
 
     def test_missing_key_returns_none_not_raise(self):
         cfg = base_config()
         cfg["gateway"]["api_key_env"] = "NONEXISTENT_GATEWAY_KEY_VAR"
-        with mock.patch("harvest._http_json_post") as m:
-            result, reason = harvest._search_gemini_grounding({"model": "g"}, "q", 5, cfg)
+        with mock.patch("harvest_clients.base._http_json_post") as m:
+            result, reason = harvest_search._search_gemini_grounding({"model": "g"}, "q", 5, cfg)
         self.assertIsNone(result)
         self.assertIn("not set", reason)
         m.assert_not_called()
@@ -862,14 +874,14 @@ class TestGeminiGroundingSearch(unittest.TestCase):
 
 class TestResolveGroundingRedirect(unittest.TestCase):
     def test_non_grounding_host_rejected_without_any_network_call(self):
-        with mock.patch("harvest._no_redirect_opener.open") as m:
-            result = harvest._resolve_grounding_redirect("http://169.254.169.254/", 5)
+        with mock.patch("harvest_search._no_redirect_opener.open") as m:
+            result = harvest_search._resolve_grounding_redirect("http://169.254.169.254/", 5)
         self.assertIsNone(result)
         m.assert_not_called()
 
     def test_localhost_host_rejected_without_any_network_call(self):
-        with mock.patch("harvest._no_redirect_opener.open") as m:
-            result = harvest._resolve_grounding_redirect("http://127.0.0.1/", 5)
+        with mock.patch("harvest_search._no_redirect_opener.open") as m:
+            result = harvest_search._resolve_grounding_redirect("http://127.0.0.1/", 5)
         self.assertIsNone(result)
         m.assert_not_called()
 
@@ -878,23 +890,23 @@ class TestResolveGroundingRedirect(unittest.TestCase):
         err = harvest.urllib.error.HTTPError(
             url=uri, code=302, msg="Found",
             hdrs={"Location": "https://real.example.com/article"}, fp=io.BytesIO(b""))
-        with mock.patch("harvest._no_redirect_opener.open", side_effect=err):
-            result = harvest._resolve_grounding_redirect(uri, 5)
+        with mock.patch("harvest_search._no_redirect_opener.open", side_effect=err):
+            result = harvest_search._resolve_grounding_redirect(uri, 5)
         self.assertEqual(result, "https://real.example.com/article")
 
     def test_grounding_host_network_error_returns_none(self):
         uri = "https://vertexaisearch.cloud.google.com/grounding-api-redirect/1"
-        with mock.patch("harvest._no_redirect_opener.open",
+        with mock.patch("harvest_search._no_redirect_opener.open",
                          side_effect=harvest.urllib.error.URLError("connection refused")):
-            result = harvest._resolve_grounding_redirect(uri, 5)
+            result = harvest_search._resolve_grounding_redirect(uri, 5)
         self.assertIsNone(result)
 
     def test_malformed_uri_returns_none_without_raising(self):
         # uri is model-controlled grounding output; an unterminated IPv6
         # literal makes urlsplit raise ValueError -- must be swallowed and
         # dropped, never propagated to abort the whole backend.
-        with mock.patch("harvest._no_redirect_opener.open") as m:
-            result = harvest._resolve_grounding_redirect("http://[::1", 5)
+        with mock.patch("harvest_search._no_redirect_opener.open") as m:
+            result = harvest_search._resolve_grounding_redirect("http://[::1", 5)
         self.assertIsNone(result)
         m.assert_not_called()
 
@@ -903,8 +915,8 @@ class TestResolveGroundingRedirect(unittest.TestCase):
         # chunk (None) and close the response rather than leak it.
         uri = "https://vertexaisearch.cloud.google.com/grounding-api-redirect/1"
         fake_resp = mock.Mock()
-        with mock.patch("harvest._no_redirect_opener.open", return_value=fake_resp):
-            result = harvest._resolve_grounding_redirect(uri, 5)
+        with mock.patch("harvest_search._no_redirect_opener.open", return_value=fake_resp):
+            result = harvest_search._resolve_grounding_redirect(uri, 5)
         self.assertIsNone(result)
         fake_resp.close.assert_called_once()
 
@@ -921,7 +933,7 @@ class TestGeminiGroundingFallThrough(unittest.TestCase):
             ({"type": "gemini-grounding", "model": "g"}, harvest.RateLimiter(0)),
         ]
         real_results = [{"url": "https://real.example.com/article", "title": "t", "snippet": "s"}]
-        with mock.patch("harvest.call_search_backend", side_effect=[None, real_results]):
+        with mock.patch("harvest_search.call_search_backend", side_effect=[None, real_results]):
             result = harvest.do_search("q", "en", backends, journal, cfg)
         data = json.loads(result)
         self.assertEqual(data["results"][0]["url"], "https://real.example.com/article")
@@ -938,12 +950,12 @@ class TestGeminiGroundingFallThrough(unittest.TestCase):
 
 class TestGroundingPromptCompleteness(unittest.TestCase):
     def test_prompt_demands_complete_source_set(self):
-        prompt = harvest._GROUNDING_SEARCH_PROMPT
+        prompt = harvest_search._GROUNDING_SEARCH_PROMPT
         self.assertIn("COMPLETE set", prompt)
         self.assertIn("do not truncate", prompt)
 
     def test_prompt_has_no_hard_must_call_constraint(self):
-        self.assertNotIn("You MUST", harvest._GROUNDING_SEARCH_PROMPT)
+        self.assertNotIn("You MUST", harvest_search._GROUNDING_SEARCH_PROMPT)
 
 
 # ---------------------------------------------------------------------------
@@ -960,9 +972,9 @@ class TestGroundingThinkingBudget(unittest.TestCase):
             "https://vertexaisearch.cloud.google.com/grounding-api-redirect/1", "example.com")
         backend_cfg = {"model": "gemini-3.5-flash", **cfg_overrides}
         with mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"}), \
-             mock.patch("harvest._http_json_post", return_value=_grounding_response([chunk])) as post_mock, \
-             mock.patch("harvest._resolve_grounding_redirect", return_value="https://example.com/real"):
-            harvest._search_gemini_grounding(backend_cfg, "q", 5, cfg)
+             mock.patch("harvest_clients.base._http_json_post", return_value=_grounding_response([chunk])) as post_mock, \
+             mock.patch("harvest_search._resolve_grounding_redirect", return_value="https://example.com/real"):
+            harvest_search._search_gemini_grounding(backend_cfg, "q", 5, cfg)
         return post_mock.call_args.args[1]
 
     def test_thinking_budget_configured_adds_generation_config(self):
@@ -1018,9 +1030,9 @@ class TestGroundingRedirectResolutionParallel(unittest.TestCase):
             return result
 
         with mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"}), \
-             mock.patch("harvest._http_json_post", return_value=_grounding_response(chunks)), \
-             mock.patch("harvest._resolve_grounding_redirect", side_effect=fake_resolve_side_effect):
-            results, reason = harvest._search_gemini_grounding({"model": "g"}, "q", 5, cfg)
+             mock.patch("harvest_clients.base._http_json_post", return_value=_grounding_response(chunks)), \
+             mock.patch("harvest_search._resolve_grounding_redirect", side_effect=fake_resolve_side_effect):
+            results, reason = harvest_search._search_gemini_grounding({"model": "g"}, "q", 5, cfg)
 
         self.assertIsNone(reason)
         # chunk2 (exception) dropped, chunk4 (dedup of chunk1's real url)
@@ -1157,13 +1169,13 @@ class TestBackendDegradation(unittest.TestCase):
     def setUp(self):
         self.config = base_config()
         self._orig_getaddrinfo = socket.getaddrinfo
-        self._orig_real = harvest._real_getaddrinfo
-        harvest._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))]
+        self._orig_real = harvest_safety._real_getaddrinfo
+        harvest_safety._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))]
         harvest.install_ssrf_guard()
 
     def tearDown(self):
         socket.getaddrinfo = self._orig_getaddrinfo
-        harvest._real_getaddrinfo = self._orig_real
+        harvest_safety._real_getaddrinfo = self._orig_real
 
     def test_search_falls_through_to_second_backend(self):
         journal = []
@@ -1171,7 +1183,7 @@ class TestBackendDegradation(unittest.TestCase):
             ({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0)),
             ({"type": "duckduckgo"}, harvest.RateLimiter(0)),
         ]
-        with mock.patch("harvest.call_search_backend", side_effect=[None, [{"url": "https://a.com", "title": "t", "snippet": "s"}]]):
+        with mock.patch("harvest_search.call_search_backend", side_effect=[None, [{"url": "https://a.com", "title": "t", "snippet": "s"}]]):
             result = harvest.do_search("q", "en", backends, journal, self.config)
         data = json.loads(result)
         self.assertEqual(data["results"][0]["url"], "https://a.com")
@@ -1180,7 +1192,7 @@ class TestBackendDegradation(unittest.TestCase):
     def test_search_all_backends_fail(self):
         journal = []
         backends = [({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_search_backend", return_value=None):
+        with mock.patch("harvest_search.call_search_backend", return_value=None):
             result = harvest.do_search("q", "en", backends, journal, self.config)
         data = json.loads(result)
         self.assertEqual(data["results"], [])
@@ -1195,7 +1207,7 @@ class TestBackendDegradation(unittest.TestCase):
             ({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0)),
             ({"type": "duckduckgo"}, harvest.RateLimiter(0)),
         ]
-        with mock.patch("harvest.call_search_backend", side_effect=[
+        with mock.patch("harvest_search.call_search_backend", side_effect=[
             [{"url": "https://blog.csdn.net/x", "title": "t", "snippet": "s"}],
             [{"url": "https://good.com/y", "title": "t2", "snippet": "s2"}],
         ]):
@@ -1209,7 +1221,7 @@ class TestBackendDegradation(unittest.TestCase):
         backends = [({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0))]
         results = [{"url": "https://blog.csdn.net/x", "title": "t", "snippet": "s"},
                    {"url": "https://good.com/x", "title": "t", "snippet": "s"}]
-        with mock.patch("harvest.call_search_backend", return_value=results):
+        with mock.patch("harvest_search.call_search_backend", return_value=results):
             result = harvest.do_search("q", "en", backends, journal, self.config)
         data = json.loads(result)
         urls = [r["url"] for r in data["results"]]
@@ -1222,7 +1234,7 @@ class TestBackendDegradation(unittest.TestCase):
             ({"type": "tavily-extract", "api_key_env": "X"}, harvest.RateLimiter(0)),
             ({"type": "urllib-ua"}, harvest.RateLimiter(0)),
         ]
-        with mock.patch("harvest.call_fetch_backend", side_effect=[None, "full page text"]):
+        with mock.patch("harvest_fetch.call_fetch_backend", side_effect=[None, "full page text"]):
             result = harvest.do_fetch("https://good.com/x", backends, journal, self.config)
         self.assertEqual(result, "full page text")
         self.assertEqual(journal[0]["backend"], "urllib-ua")
@@ -1230,7 +1242,7 @@ class TestBackendDegradation(unittest.TestCase):
     def test_fetch_all_backends_fail(self):
         journal = []
         backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_fetch_backend", return_value=None):
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value=None):
             result = harvest.do_fetch("https://good.com/x", backends, journal, self.config)
         data = json.loads(result)
         self.assertIn("error", data)
@@ -1238,17 +1250,17 @@ class TestBackendDegradation(unittest.TestCase):
     def test_fetch_blacklisted_domain_rejected_before_backends(self):
         journal = []
         backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_fetch_backend") as m:
+        with mock.patch("harvest_fetch.call_fetch_backend") as m:
             result = harvest.do_fetch("https://blog.csdn.net/x", backends, journal, self.config)
         m.assert_not_called()
         self.assertEqual(journal[0]["blocked"], "blacklist")
 
     def test_fetch_ssrf_private_ip_rejected(self):
-        harvest._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("127.0.0.1", 0))]
+        harvest_safety._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("127.0.0.1", 0))]
         harvest.install_ssrf_guard()
         journal = []
         backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_fetch_backend") as m:
+        with mock.patch("harvest_fetch.call_fetch_backend") as m:
             result = harvest.do_fetch("http://internal.local/x", backends, journal, self.config)
         m.assert_not_called()
         self.assertEqual(journal[0]["blocked"], "ssrf")
@@ -1258,7 +1270,7 @@ class TestBackendDegradation(unittest.TestCase):
         cfg = base_config()
         cfg["limits"]["fetch_max_chars"] = 5
         backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_fetch_backend", return_value="0123456789"):
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value="0123456789"):
             result = harvest.do_fetch("https://good.com/x", backends, journal, cfg)
         self.assertEqual(result, "01234")
 
@@ -1271,7 +1283,12 @@ class TestBackendDegradation(unittest.TestCase):
             ({"type": "tavily", "api_key_env": "NONEXISTENT_TAVILY_KEY_VAR"}, harvest.RateLimiter(0)),
             ({"type": "duckduckgo"}, harvest.RateLimiter(0)),
         ]
-        with mock.patch("harvest.urllib.request.urlopen",
+        # _HAS_CURL_CFFI pinned False so the duckduckgo backend takes the
+        # mocked urllib path -- without this pin it hits curl_cffi_requests.get
+        # (real network) on any machine where curl_cffi is installed, making
+        # this test flaky. Mirrors the sibling test below.
+        with mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", False), \
+             mock.patch("harvest.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
             result = harvest.do_search("q", "en", backends, journal, self.config)
         data = json.loads(result)
@@ -1287,7 +1304,7 @@ class TestBackendDegradation(unittest.TestCase):
             ({"type": "tavily", "api_key_env": "NONEXISTENT_TAVILY_KEY_VAR"}, harvest.RateLimiter(0)),
             ({"type": "duckduckgo"}, harvest.RateLimiter(0)),
         ]
-        with mock.patch.object(harvest, "_HAS_CURL_CFFI", False), \
+        with mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", False), \
              mock.patch("harvest.urllib.request.urlopen", side_effect=OSError("network down")):
             harvest.do_search("q", "en", backends, journal, self.config)
         attempts = journal[0]["attempts"]
@@ -1314,7 +1331,7 @@ class TestUrllibUaHtmlStripping(unittest.TestCase):
     def _fetch(self, html_body, max_chars=20000):
         with mock.patch("harvest.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(html_body.encode("utf-8"))):
-            return harvest._fetch_urllib_ua({}, "https://a.com/x", 5, max_chars)
+            return harvest_fetch._fetch_urllib_ua({}, "https://a.com/x", 5, max_chars)
 
     def test_tags_stripped_from_output(self):
         content, reason = self._fetch("<html><body><p>Hello <b>world</b>.</p></body></html>")
@@ -1359,23 +1376,23 @@ class TestUrllibUaHtmlStripping(unittest.TestCase):
         cfg["limits"]["fetch_max_chars"] = 200
         backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
         orig_getaddrinfo = socket.getaddrinfo
-        orig_real_getaddrinfo = harvest._real_getaddrinfo
-        harvest._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))]
+        orig_real_getaddrinfo = harvest_safety._real_getaddrinfo
+        harvest_safety._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))]
         harvest.install_ssrf_guard()
         try:
             with mock.patch("harvest.urllib.request.urlopen",
                              return_value=FakeHTTPResponse(html_body.encode("utf-8"))):
                 result = harvest.do_fetch("https://a.com/x", backends, journal, cfg)
         finally:
-            harvest._real_getaddrinfo = orig_real_getaddrinfo
+            harvest_safety._real_getaddrinfo = orig_real_getaddrinfo
             socket.getaddrinfo = orig_getaddrinfo
         self.assertIn("keep this text", result)
 
 
 @unittest.skipUnless(
-    harvest._HAS_CURL_CFFI,
-    "curl_cffi not installed: harvest.curl_cffi_requests is None, so "
-    "mock.patch('harvest.curl_cffi_requests.get') cannot attach. These tests "
+    harvest_clients.base._HAS_CURL_CFFI,
+    "curl_cffi not installed: harvest_clients.base.curl_cffi_requests is None, so "
+    "mock.patch('harvest_clients.base.curl_cffi_requests.get') cannot attach. These tests "
     "exercise the curl-cffi fetch backend and require the optional dependency.",
 )
 class TestCurlCffiFetch(unittest.TestCase):
@@ -1385,36 +1402,36 @@ class TestCurlCffiFetch(unittest.TestCase):
 
     def setUp(self):
         self._orig_getaddrinfo = socket.getaddrinfo
-        self._orig_real = harvest._real_getaddrinfo
-        self._orig_has = harvest._HAS_CURL_CFFI
-        harvest._HAS_CURL_CFFI = True
-        harvest._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))]
+        self._orig_real = harvest_safety._real_getaddrinfo
+        self._orig_has = harvest_clients.base._HAS_CURL_CFFI
+        harvest_clients.base._HAS_CURL_CFFI = True
+        harvest_safety._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))]
         harvest.install_ssrf_guard()
 
     def tearDown(self):
         socket.getaddrinfo = self._orig_getaddrinfo
-        harvest._real_getaddrinfo = self._orig_real
-        harvest._HAS_CURL_CFFI = self._orig_has
+        harvest_safety._real_getaddrinfo = self._orig_real
+        harvest_clients.base._HAS_CURL_CFFI = self._orig_has
 
     def _fetch(self, url, timeout=5, max_chars=20000, config=None):
         with harvest.tool_request_guard():
-            return harvest._fetch_curl_cffi({}, url, timeout, max_chars, config or base_config())
+            return harvest_fetch._fetch_curl_cffi({}, url, timeout, max_chars, config or base_config())
 
     def test_normal_fetch_strips_html_and_pins_resolved_ip(self):
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, "<p>Hello <b>world</b>.</p>")) as m:
             result, reason = self._fetch("https://a.com/x")
         self.assertIsNone(reason)
         self.assertNotIn("<", result)
         self.assertIn("Hello world", result)
         kwargs = m.call_args.kwargs
-        pin_list = kwargs["curl_options"][harvest.CurlCffiOpt.RESOLVE]
+        pin_list = kwargs["curl_options"][harvest_clients.base.CurlCffiOpt.RESOLVE]
         self.assertEqual(pin_list, ["a.com:443:93.184.216.34"])
         self.assertFalse(kwargs["allow_redirects"])
 
     def test_private_host_blocked_before_any_curl_call(self):
-        harvest._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("127.0.0.1", 0))]
-        with mock.patch("harvest.curl_cffi_requests.get") as m:
+        harvest_safety._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("127.0.0.1", 0))]
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get") as m:
             with self.assertRaises(harvest.SSRFBlocked):
                 self._fetch("http://internal.local/x")
         m.assert_not_called()
@@ -1428,14 +1445,14 @@ class TestCurlCffiFetch(unittest.TestCase):
             if host == "internal.local":
                 return [(2, 1, 6, "", ("127.0.0.1", 0))]
             return [(2, 1, 6, "", ("93.184.216.34", 0))]
-        harvest._real_getaddrinfo = fake_resolve
-        with mock.patch("harvest.curl_cffi_requests.get",
+        harvest_safety._real_getaddrinfo = fake_resolve
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(302, location="http://internal.local/x")):
             with self.assertRaises(harvest.SSRFBlocked):
                 self._fetch("https://a.com/start")
 
     def test_redirect_hop_to_blacklisted_domain_rejected(self):
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(302, location="https://blog.csdn.net/x")):
             result, reason = self._fetch("https://a.com/start")
         self.assertIsNone(result)
@@ -1446,34 +1463,34 @@ class TestCurlCffiFetch(unittest.TestCase):
             FakeCurlResponse(301, location="/next"),
             FakeCurlResponse(200, "final content"),
         ]
-        with mock.patch("harvest.curl_cffi_requests.get", side_effect=responses):
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get", side_effect=responses):
             result, reason = self._fetch("https://a.com/start")
         self.assertIsNone(reason)
         self.assertIn("final content", result)
 
     def test_exceeds_max_redirect_hops_fails(self):
         responses = [FakeCurlResponse(302, location=f"/hop{i}") for i in range(10)]
-        with mock.patch("harvest.curl_cffi_requests.get", side_effect=responses):
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get", side_effect=responses):
             result, reason = self._fetch("https://a.com/start")
         self.assertIsNone(result)
         self.assertIn("max redirect hops", reason)
 
     def test_redirect_missing_location_header_fails(self):
-        with mock.patch("harvest.curl_cffi_requests.get", return_value=FakeCurlResponse(302)):
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get", return_value=FakeCurlResponse(302)):
             result, reason = self._fetch("https://a.com/start")
         self.assertIsNone(result)
         self.assertIn("Location", reason)
 
     def test_request_exception_degrades_with_reason(self):
-        with mock.patch("harvest.curl_cffi_requests.get", side_effect=RuntimeError("boom")):
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get", side_effect=RuntimeError("boom")):
             result, reason = self._fetch("https://a.com/x")
         self.assertIsNone(result)
         self.assertIn("request failed", reason)
 
     def test_call_fetch_backend_dispatches_to_curl_cffi(self):
         cfg = base_config()
-        with mock.patch("harvest._fetch_curl_cffi", return_value=("clean text", None)) as m:
-            content = harvest.call_fetch_backend({"type": "curl-cffi"}, harvest.RateLimiter(0), "https://a.com/x", cfg)
+        with mock.patch("harvest_fetch._fetch_curl_cffi", return_value=("clean text", None)) as m:
+            content = harvest_fetch.call_fetch_backend({"type": "curl-cffi"}, harvest.RateLimiter(0), "https://a.com/x", cfg)
         self.assertEqual(content, "clean text")
         m.assert_called_once()
 
@@ -1481,12 +1498,12 @@ class TestCurlCffiFetch(unittest.TestCase):
         cfg = base_config()
         cfg["limits"]["fetch_low_speed_bytes_s"] = 999
         cfg["limits"]["fetch_low_speed_window_s"] = 7
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, "<p>ok</p>")) as m:
             self._fetch("https://a.com/x", config=cfg)
         curl_options = m.call_args.kwargs["curl_options"]
-        self.assertEqual(curl_options[harvest.CurlCffiOpt.LOW_SPEED_LIMIT], 999)
-        self.assertEqual(curl_options[harvest.CurlCffiOpt.LOW_SPEED_TIME], 7)
+        self.assertEqual(curl_options[harvest_clients.base.CurlCffiOpt.LOW_SPEED_LIMIT], 999)
+        self.assertEqual(curl_options[harvest_clients.base.CurlCffiOpt.LOW_SPEED_TIME], 7)
 
     def test_timeout_tuple_connect_plus_read_equals_remaining_budget(self):
         # curl_cffi 0.15.0 sums (connect, read) into CURLOPT_TIMEOUT_MS for
@@ -1494,7 +1511,7 @@ class TestCurlCffiFetch(unittest.TestCase):
         # `remaining - connect`, not `remaining`, or the effective total
         # would be connect + remaining (over budget).
         with mock.patch("harvest.time.monotonic", side_effect=[0.0, 0.0]), \
-             mock.patch("harvest.curl_cffi_requests.get",
+             mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, "<p>ok</p>")) as m:
             self._fetch("https://a.com/x", timeout=20)
         conn, read = m.call_args.kwargs["timeout"]
@@ -1509,7 +1526,7 @@ class TestCurlCffiFetch(unittest.TestCase):
         # "simplified" to conn = remaining (which would zero out the read
         # component and reintroduce the libcurl 0ms-means-infinite hang).
         with mock.patch("harvest.time.monotonic", side_effect=[0.0, 0.0]), \
-             mock.patch("harvest.curl_cffi_requests.get",
+             mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, "<p>ok</p>")) as m:
             self._fetch("https://a.com/x", timeout=2)
         conn, read = m.call_args.kwargs["timeout"]
@@ -1522,7 +1539,7 @@ class TestCurlCffiFetch(unittest.TestCase):
         # second hop would fire, the shared deadline has less than 1s left
         # -- it must abort there instead of issuing another curl call.
         with mock.patch("harvest.time.monotonic", side_effect=[0.0, 0.0, 4.5]), \
-             mock.patch("harvest.curl_cffi_requests.get",
+             mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(302, location="/next")) as m:
             result, reason = self._fetch("https://a.com/start", timeout=5)
         self.assertIsNone(result)
@@ -1538,7 +1555,7 @@ class TestCurlCffiFetch(unittest.TestCase):
         cfg["limits"] = {k: v for k, v in cfg["limits"].items()
                           if k not in ("fetch_connect_timeout_s", "fetch_low_speed_bytes_s",
                                        "fetch_low_speed_window_s")}
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, "<p>legacy ok</p>")):
             result, reason = self._fetch("https://a.com/x", config=cfg)
         self.assertIsNone(reason)
@@ -1547,7 +1564,7 @@ class TestCurlCffiFetch(unittest.TestCase):
     def test_non_2xx_terminal_status_degrades_without_returning_body(self):
         # No challenge marker in the body -- this is gate 2 (plain HTTP
         # error), not gate 1. The body text must not leak into the reason.
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(403, "<html>Access Denied</html>")):
             result, reason = self._fetch("https://a.com/x")
         self.assertIsNone(result)
@@ -1556,7 +1573,7 @@ class TestCurlCffiFetch(unittest.TestCase):
 
     def test_cloudflare_challenge_200_degrades(self):
         body = "<html><body><script src='/cdn-cgi/challenge-platform/h/g'></script></body></html>"
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, body)):
             result, reason = self._fetch("https://a.com/x")
         self.assertIsNone(result)
@@ -1566,7 +1583,7 @@ class TestCurlCffiFetch(unittest.TestCase):
         # Locks down gate ordering: challenge detection (gate 1) must fire
         # before the generic HTTP-status gate (gate 2), even on a 403.
         body = "<html><body><script src='/cdn-cgi/challenge-platform/h/g'></script></body></html>"
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(403, body)):
             result, reason = self._fetch("https://a.com/x")
         self.assertIsNone(result)
@@ -1575,7 +1592,7 @@ class TestCurlCffiFetch(unittest.TestCase):
 
     def test_datadome_challenge_degrades(self):
         body = "<html><body><script src='https://ct.captcha-delivery.com/c.js'></script></body></html>"
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, body)):
             result, reason = self._fetch("https://a.com/x")
         self.assertIsNone(result)
@@ -1583,7 +1600,7 @@ class TestCurlCffiFetch(unittest.TestCase):
 
     def test_perimeterx_challenge_degrades(self):
         body = "<html><body><div id='px-captcha'></div></body></html>"
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, body)):
             result, reason = self._fetch("https://a.com/x")
         self.assertIsNone(result)
@@ -1593,7 +1610,7 @@ class TestCurlCffiFetch(unittest.TestCase):
         # Mixed case in the source, verifying marker matching is
         # case-insensitive.
         body = "<html><body><div id='_Incapsula_Resource'></div></body></html>"
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, body)):
             result, reason = self._fetch("https://a.com/x")
         self.assertIsNone(result)
@@ -1606,27 +1623,27 @@ class TestCurlCffiFetch(unittest.TestCase):
         # "cf-turnstile" -- the size gate lets anything >= 100KB through.
         body = "<p>" + "Cloudflare Turnstile 分析。" * 20000 + " cf-turnstile </p>"
         self.assertGreaterEqual(len(body), 100 * 1024)
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, body)):
             result, reason = self._fetch("https://a.com/x")
         self.assertIsNone(reason)
         self.assertIn("Cloudflare Turnstile", result)
 
     def test_empty_body_does_not_crash(self):
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, "")):
             result, reason = self._fetch("https://a.com/x")
         self.assertIsNone(reason)
         self.assertEqual(result, "")
-        self.assertFalse(harvest._looks_like_challenge_page(None))
-        self.assertFalse(harvest._looks_like_challenge_page(""))
+        self.assertFalse(harvest_fetch._looks_like_challenge_page(None))
+        self.assertFalse(harvest_fetch._looks_like_challenge_page(""))
 
     def test_small_page_quoting_challenge_prose_not_flagged(self):
         # Human-readable phrases like "just a moment" or vendor names like
         # "datadome" appearing in ordinary prose must not trigger a false
         # positive -- only the literal script/DOM/CDN artifacts do.
         body = "<p>Just a moment while we discuss the datadome product review.</p>"
-        with mock.patch("harvest.curl_cffi_requests.get",
+        with mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, body)):
             result, reason = self._fetch("https://a.com/x")
         self.assertIsNone(reason)
@@ -1640,29 +1657,29 @@ class TestCurlCffiStartupCheck(unittest.TestCase):
     call -- not silently degrade to the next fetch backend."""
 
     def setUp(self):
-        self._orig_has = harvest._HAS_CURL_CFFI
+        self._orig_has = harvest_clients.base._HAS_CURL_CFFI
 
     def tearDown(self):
-        harvest._HAS_CURL_CFFI = self._orig_has
+        harvest_clients.base._HAS_CURL_CFFI = self._orig_has
 
     def test_configured_but_missing_exits_4_with_install_instructions(self):
-        harvest._HAS_CURL_CFFI = False
+        harvest_clients.base._HAS_CURL_CFFI = False
         cfg = base_config(fetch_backends=[{"type": "curl-cffi"}, {"type": "urllib-ua"}])
         with self.assertRaises(SystemExit) as ctx:
             with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
-                harvest._check_curl_cffi_available(cfg)
+                harvest_clients.base._check_curl_cffi_available(cfg)
         self.assertEqual(ctx.exception.code, 4)
         self.assertIn("pip3 install --user curl_cffi", stderr.getvalue())
 
     def test_configured_and_installed_does_not_exit(self):
-        harvest._HAS_CURL_CFFI = True
+        harvest_clients.base._HAS_CURL_CFFI = True
         cfg = base_config(fetch_backends=[{"type": "curl-cffi"}])
-        harvest._check_curl_cffi_available(cfg)  # must not raise
+        harvest_clients.base._check_curl_cffi_available(cfg)  # must not raise
 
     def test_not_configured_never_exits_regardless_of_install_state(self):
-        harvest._HAS_CURL_CFFI = False
+        harvest_clients.base._HAS_CURL_CFFI = False
         cfg = base_config(fetch_backends=[{"type": "urllib-ua"}])
-        harvest._check_curl_cffi_available(cfg)  # must not raise
+        harvest_clients.base._check_curl_cffi_available(cfg)  # must not raise
 
 
 class TestCallFetchBackendPerBackendTimeout(unittest.TestCase):
@@ -1674,22 +1691,22 @@ class TestCallFetchBackendPerBackendTimeout(unittest.TestCase):
 
     def test_backend_with_timeout_s_uses_its_own_value(self):
         cfg = base_config()
-        with mock.patch("harvest._fetch_curl_cffi", return_value=("text", None)) as m:
-            harvest.call_fetch_backend({"type": "curl-cffi", "timeout_s": 25},
+        with mock.patch("harvest_fetch._fetch_curl_cffi", return_value=("text", None)) as m:
+            harvest_fetch.call_fetch_backend({"type": "curl-cffi", "timeout_s": 25},
                                         harvest.RateLimiter(0), "https://a.com/x", cfg)
         self.assertEqual(m.call_args.args[2], 25)
 
     def test_jina_backend_with_timeout_s_uses_its_own_value(self):
         cfg = base_config()
-        with mock.patch("harvest._fetch_jina_reader", return_value=("text", None)) as m:
-            harvest.call_fetch_backend({"type": "jina-reader", "timeout_s": 60},
+        with mock.patch("harvest_fetch._fetch_jina_reader", return_value=("text", None)) as m:
+            harvest_fetch.call_fetch_backend({"type": "jina-reader", "timeout_s": 60},
                                         harvest.RateLimiter(0), "https://a.com/x", cfg)
         self.assertEqual(m.call_args.args[2], 60)
 
     def test_backend_without_timeout_s_falls_back_to_call_timeout_s(self):
         cfg = base_config()  # call_timeout_s: 5, from base_config()
-        with mock.patch("harvest._fetch_urllib_ua", return_value=("text", None)) as m:
-            harvest.call_fetch_backend({"type": "urllib-ua"},
+        with mock.patch("harvest_fetch._fetch_urllib_ua", return_value=("text", None)) as m:
+            harvest_fetch.call_fetch_backend({"type": "urllib-ua"},
                                         harvest.RateLimiter(0), "https://a.com/x", cfg)
         self.assertEqual(m.call_args.args[2], cfg["limits"]["call_timeout_s"])
 
@@ -1735,7 +1752,7 @@ class TestJinaReaderAuthHeader(unittest.TestCase):
         with mock.patch.dict(os.environ, env, clear=False), \
              mock.patch("harvest.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(b"page text")) as m:
-            harvest._fetch_jina_reader({"api_key_env": "JINA_API_KEY"}, "https://a.com/x", 5, 20000)
+            harvest_fetch._fetch_jina_reader({"api_key_env": "JINA_API_KEY"}, "https://a.com/x", 5, 20000)
         return m.call_args.args[0]
 
     def test_authorization_header_present_when_key_set(self):
@@ -1778,11 +1795,11 @@ _ORIG_TOOL_REQUEST_GUARD = harvest.tool_request_guard
 class TestSSRFGuardScopeNarrowing(unittest.TestCase):
     def setUp(self):
         self._orig_getaddrinfo = socket.getaddrinfo
-        self._orig_real = harvest._real_getaddrinfo
+        self._orig_real = harvest_safety._real_getaddrinfo
 
     def tearDown(self):
         socket.getaddrinfo = self._orig_getaddrinfo
-        harvest._real_getaddrinfo = self._orig_real
+        harvest_safety._real_getaddrinfo = self._orig_real
 
     def _spy_guard(self, calls):
         class SpyGuard(_ORIG_TOOL_REQUEST_GUARD):
@@ -1794,33 +1811,33 @@ class TestSSRFGuardScopeNarrowing(unittest.TestCase):
     def test_search_backends_never_enter_guard(self):
         calls = []
         backends = [({"type": "gemini-grounding", "model": "g"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.tool_request_guard", self._spy_guard(calls)), \
-             mock.patch("harvest.call_search_backend", return_value=[{"url": "https://a.com", "title": "t", "snippet": "s"}]):
+        with mock.patch("harvest_safety.tool_request_guard", self._spy_guard(calls)), \
+             mock.patch("harvest_search.call_search_backend", return_value=[{"url": "https://a.com", "title": "t", "snippet": "s"}]):
             harvest.do_search("q", "en", backends, [], base_config())
         self.assertEqual(calls, [])
 
     def test_tavily_extract_backend_never_enters_guard(self):
         calls = []
         backends = [({"type": "tavily-extract", "api_key_env": "X"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.tool_request_guard", self._spy_guard(calls)), \
-             mock.patch("harvest.call_fetch_backend", return_value="content"):
+        with mock.patch("harvest_safety.tool_request_guard", self._spy_guard(calls)), \
+             mock.patch("harvest_fetch.call_fetch_backend", return_value="content"):
             harvest.do_fetch("https://a.com/x", backends, [], base_config())
         self.assertEqual(calls, [])
 
     def test_jina_reader_backend_never_enters_guard(self):
         calls = []
         backends = [({"type": "jina-reader", "api_key_env": "X"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.tool_request_guard", self._spy_guard(calls)), \
-             mock.patch("harvest.call_fetch_backend", return_value="content"):
+        with mock.patch("harvest_safety.tool_request_guard", self._spy_guard(calls)), \
+             mock.patch("harvest_fetch.call_fetch_backend", return_value="content"):
             harvest.do_fetch("https://a.com/x", backends, [], base_config())
         self.assertEqual(calls, [])
 
     def test_urllib_ua_backend_still_enters_guard(self):
         calls = []
         backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.tool_request_guard", self._spy_guard(calls)), \
-             mock.patch("harvest._ssrf_precheck"), \
-             mock.patch("harvest.call_fetch_backend", return_value="content"):
+        with mock.patch("harvest_safety.tool_request_guard", self._spy_guard(calls)), \
+             mock.patch("harvest_safety._ssrf_precheck"), \
+             mock.patch("harvest_fetch.call_fetch_backend", return_value="content"):
             harvest.do_fetch("https://a.com/x", backends, [], base_config())
         self.assertGreaterEqual(len(calls), 1)
 
@@ -1830,9 +1847,9 @@ class TestSSRFGuardScopeNarrowing(unittest.TestCase):
         # take `url` as a request parameter to a fixed API host).
         calls = []
         backends = [({"type": "curl-cffi"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.tool_request_guard", self._spy_guard(calls)), \
-             mock.patch("harvest._ssrf_precheck"), \
-             mock.patch("harvest.call_fetch_backend", return_value="content"):
+        with mock.patch("harvest_safety.tool_request_guard", self._spy_guard(calls)), \
+             mock.patch("harvest_safety._ssrf_precheck"), \
+             mock.patch("harvest_fetch.call_fetch_backend", return_value="content"):
             harvest.do_fetch("https://a.com/x", backends, [], base_config())
         self.assertGreaterEqual(len(calls), 1)
 
@@ -1840,28 +1857,28 @@ class TestSSRFGuardScopeNarrowing(unittest.TestCase):
         # Fake DNS resolves the search backend's target to a private IP --
         # since search is unguarded, this must NOT raise SSRFBlocked (an
         # internally-hosted gateway/API must keep working).
-        harvest._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("10.0.0.5", 0))]
+        harvest_safety._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("10.0.0.5", 0))]
         harvest.install_ssrf_guard()
         backends = [({"type": "gemini-grounding", "model": "g"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_search_backend", return_value=[{"url": "https://a.com", "title": "t", "snippet": "s"}]):
+        with mock.patch("harvest_search.call_search_backend", return_value=[{"url": "https://a.com", "title": "t", "snippet": "s"}]):
             result = harvest.do_search("q", "en", backends, [], base_config())
         data = json.loads(result)
         self.assertEqual(data["results"][0]["url"], "https://a.com")
 
     def test_tavily_extract_reaching_private_host_not_blocked(self):
-        harvest._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("10.0.0.5", 0))]
+        harvest_safety._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("10.0.0.5", 0))]
         harvest.install_ssrf_guard()
         backends = [({"type": "tavily-extract", "api_key_env": "X"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_fetch_backend", return_value="internal gateway content"):
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value="internal gateway content"):
             result = harvest.do_fetch("https://internal-gateway.local/x", backends, [], base_config())
         self.assertEqual(result, "internal gateway content")
 
     def test_urllib_ua_private_host_still_rejected(self):
-        harvest._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("127.0.0.1", 0))]
+        harvest_safety._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("127.0.0.1", 0))]
         harvest.install_ssrf_guard()
         journal = []
         backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_fetch_backend") as m:
+        with mock.patch("harvest_fetch.call_fetch_backend") as m:
             result = harvest.do_fetch("http://internal.local/x", backends, journal, base_config())
         m.assert_not_called()
         self.assertEqual(journal[0]["blocked"], "ssrf")
@@ -1869,11 +1886,11 @@ class TestSSRFGuardScopeNarrowing(unittest.TestCase):
         self.assertIn("error", data)
 
     def test_curl_cffi_private_host_still_rejected(self):
-        harvest._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("127.0.0.1", 0))]
+        harvest_safety._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("127.0.0.1", 0))]
         harvest.install_ssrf_guard()
         journal = []
         backends = [({"type": "curl-cffi"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_fetch_backend") as m:
+        with mock.patch("harvest_fetch.call_fetch_backend") as m:
             result = harvest.do_fetch("http://internal.local/x", backends, journal, base_config())
         m.assert_not_called()
         self.assertEqual(journal[0]["blocked"], "ssrf")
@@ -1930,7 +1947,7 @@ class TestSubprocessSafety(unittest.TestCase):
         self.assertNotIn("shell=True", source)
 
     def test_gemini_cli_uses_list_args_and_devnull_stdin(self):
-        source = Path(harvest.__file__).read_text(encoding="utf-8")
+        source = Path(harvest_search.__file__).read_text(encoding="utf-8")
         self.assertIn("stdin=subprocess.DEVNULL", source)
         self.assertIn('["gemini", "-m"', source)
 
@@ -1950,12 +1967,12 @@ class TestWorkerDriver(unittest.TestCase):
         self.config = base_config()
         self.search_backends = []
         self.fetch_backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
-        patcher = mock.patch("harvest._ssrf_precheck")  # SSRF DNS resolution not under test here
+        patcher = mock.patch("harvest_safety._ssrf_precheck")  # SSRF DNS resolution not under test here
         patcher.start()
         self.addCleanup(patcher.stop)
 
     def _run(self, client):
-        with mock.patch("harvest.call_fetch_backend", return_value="Rayleigh scattering explains the blue sky."):
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value="Rayleigh scattering explains the blue sky."):
             return harvest.run_worker("m1", "model-a", client, self.config, self.search_backends,
                                        self.fetch_backends, "why is the sky blue?", [], None)
 
@@ -2035,7 +2052,7 @@ class TestWorkerDriver(unittest.TestCase):
             assistant_final(findings_block([
                 {"claim": "c", "excerpt": fact, "url": "https://a.com/2", "credibility": 4, "language": "en"}])),
         ])
-        with mock.patch("harvest.call_fetch_backend", return_value=fact):
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value=fact):
             result = harvest.run_worker("m1", "model-a", client, cfg, [], self.fetch_backends, "goal", [], None)
         self.assertEqual(client.calls, 3)
         self.assertEqual(result.status, "OK")
@@ -2057,7 +2074,7 @@ class TestWorkerDriver(unittest.TestCase):
             assistant_final("not valid json"),
             assistant_final("still not valid json"),
         ])
-        with mock.patch("harvest.call_fetch_backend", return_value="text"):
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value="text"):
             result = harvest.run_worker("m1", "model-a", client, cfg, [], self.fetch_backends, "goal", [], None)
         self.assertEqual(client.calls, 4)
         self.assertEqual(result.status, "FAILED")
@@ -2600,9 +2617,9 @@ class TestCmdRunEndToEnd(unittest.TestCase):
         self.goal_file = self.project_dir / harvest.GOAL_FILE_NAME
         self.goal_file.write_text("why is the sky blue?", encoding="utf-8")
 
-        self._orig_real = harvest._real_getaddrinfo
+        self._orig_real = harvest_safety._real_getaddrinfo
         self._orig_getaddrinfo = socket.getaddrinfo
-        harvest._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))]
+        harvest_safety._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))]
 
         # cmd_run's new gateway-key gate (--no-api local mode) fires before
         # any of the normal-mode logic these tests exercise -- fake key
@@ -2614,7 +2631,7 @@ class TestCmdRunEndToEnd(unittest.TestCase):
 
     def tearDown(self):
         self._env_patch.stop()
-        harvest._real_getaddrinfo = self._orig_real
+        harvest_safety._real_getaddrinfo = self._orig_real
         socket.getaddrinfo = self._orig_getaddrinfo
         self.tmpdir.cleanup()
 
@@ -2645,7 +2662,7 @@ class TestCmdRunEndToEnd(unittest.TestCase):
 
         with mock.patch("harvest.load_config", return_value=config), \
              mock.patch("harvest.make_client_factory", return_value=factory), \
-             mock.patch("harvest.call_fetch_backend", return_value=fact):
+             mock.patch("harvest_fetch.call_fetch_backend", return_value=fact):
             harvest.cmd_run(args)
 
         verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
@@ -2701,7 +2718,7 @@ class TestCmdRunEndToEnd(unittest.TestCase):
 
         with mock.patch("harvest.load_config", return_value=config), \
              mock.patch("harvest.make_client_factory", return_value=factory), \
-             mock.patch("harvest.call_fetch_backend", return_value="irrelevant fetched text"):
+             mock.patch("harvest_fetch.call_fetch_backend", return_value="irrelevant fetched text"):
             with self.assertRaises(SystemExit) as ctx:
                 harvest.cmd_run(args)
         self.assertEqual(ctx.exception.code, 3)
@@ -2747,7 +2764,7 @@ class TestCmdRunEndToEnd(unittest.TestCase):
 
         with mock.patch("harvest.load_config", return_value=config), \
              mock.patch("harvest.make_client_factory", return_value=factory), \
-             mock.patch("harvest.call_fetch_backend", return_value=fact):
+             mock.patch("harvest_fetch.call_fetch_backend", return_value=fact):
             harvest.cmd_run(args)
 
         verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
@@ -2794,7 +2811,7 @@ class TestCmdRunEndToEnd(unittest.TestCase):
 
         with mock.patch("harvest.load_config", return_value=config), \
              mock.patch("harvest.make_client_factory", return_value=factory), \
-             mock.patch("harvest.call_fetch_backend", return_value=fact):
+             mock.patch("harvest_fetch.call_fetch_backend", return_value=fact):
             harvest.cmd_run(args)
 
         report = (self.raw_dir / "fetch-report.md").read_text(encoding="utf-8")
@@ -2839,7 +2856,7 @@ class TestCmdRunEndToEnd(unittest.TestCase):
 
         with mock.patch("harvest.load_config", return_value=config), \
              mock.patch("harvest.make_client_factory", return_value=factory), \
-             mock.patch("harvest.call_fetch_backend", return_value=fact):
+             mock.patch("harvest_fetch.call_fetch_backend", return_value=fact):
             harvest.cmd_run(args)
 
         report = (self.raw_dir / "fetch-report.md").read_text(encoding="utf-8")
@@ -4366,7 +4383,7 @@ class TestCompletionRetryAndForcedSynthesisRecovery(unittest.TestCase):
     def setUp(self):
         self.config = base_config()
         self.fetch_backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
-        patcher = mock.patch("harvest._ssrf_precheck")
+        patcher = mock.patch("harvest_safety._ssrf_precheck")
         patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -4399,7 +4416,7 @@ class TestCompletionRetryAndForcedSynthesisRecovery(unittest.TestCase):
                 {"claim": "c", "excerpt": fact, "url": "https://a.com/x",
                  "credibility": 4, "language": "en"}])),
         ])
-        with mock.patch("harvest.call_fetch_backend", return_value=fact):
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value=fact):
             result = harvest.run_worker("m1", "model-a", client, self.config, [],
                                          self.fetch_backends, "goal", [], None)
         self.assertEqual(result.status, "OK")
@@ -4439,7 +4456,7 @@ class TestGeminiGroundingJournalInjection(unittest.TestCase):
         journal = []
         cfg = base_config()
         backends = [({"type": "gemini-grounding", "model": "g"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_search_backend", return_value=self._grounding_results()):
+        with mock.patch("harvest_search.call_search_backend", return_value=self._grounding_results()):
             harvest.do_search("q", "en", backends, journal, cfg)
 
         # No "fetch"-typed entries at all from grounding -- they must be
@@ -4462,7 +4479,7 @@ class TestGeminiGroundingJournalInjection(unittest.TestCase):
         journal = []
         cfg = base_config()
         backends = [({"type": "gemini-grounding", "model": "g"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_search_backend", return_value=self._grounding_results()):
+        with mock.patch("harvest_search.call_search_backend", return_value=self._grounding_results()):
             harvest.do_search("q", "en", backends, journal, cfg)
 
         claims = harvest.assign_claim_ids("m1", [
@@ -4483,7 +4500,7 @@ class TestGeminiGroundingJournalInjection(unittest.TestCase):
         journal = []
         cfg = base_config()
         backends = [({"type": "gemini-grounding", "model": "g"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_search_backend", return_value=self._grounding_results()):
+        with mock.patch("harvest_search.call_search_backend", return_value=self._grounding_results()):
             harvest.do_search("q", "en", backends, journal, cfg)
         journal.append({"tool": "fetch", "url": "https://example.com/page1",
                          "backend": "urllib-ua", "content": "Full real page text."})
@@ -4511,7 +4528,7 @@ class TestBudgetNudgeAndForcedSynthesisConvergence(unittest.TestCase):
         self.config = base_config()
         self.config["limits"]["max_steps_per_model"] = 6
         self.fetch_backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
-        patcher = mock.patch("harvest._ssrf_precheck")
+        patcher = mock.patch("harvest_safety._ssrf_precheck")
         patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -4532,7 +4549,7 @@ class TestBudgetNudgeAndForcedSynthesisConvergence(unittest.TestCase):
             assistant_final(findings_block([
                 {"claim": "c", "excerpt": fact, "url": "https://a.com/6", "credibility": 4, "language": "en"}])),
         ])
-        with mock.patch("harvest.call_fetch_backend", return_value=fact):
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value=fact):
             harvest.run_worker("m1", "model-a", client, self.config, [],
                                 self.fetch_backends, "goal", [], None)
 
@@ -4571,7 +4588,7 @@ class TestBudgetNudgeAndForcedSynthesisConvergence(unittest.TestCase):
             assistant_tool_call("c2", "fetch", {"url": "https://a.com/2"}),
             synthesis_with_stray_tool_call,
         ])
-        with mock.patch("harvest.call_fetch_backend", return_value=fact):
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value=fact):
             result = harvest.run_worker("m1", "model-a", client, cfg, [], self.fetch_backends, "goal", [], None)
         self.assertEqual(client.calls, 3)
         self.assertEqual(result.status, "OK")
@@ -4591,7 +4608,7 @@ class TestBudgetNudgeAndForcedSynthesisConvergence(unittest.TestCase):
             assistant_final(findings_block([
                 {"claim": "c", "excerpt": fact, "url": "https://a.com/2", "credibility": 4, "language": "en"}])),
         ])
-        with mock.patch("harvest.call_fetch_backend", return_value=fact):
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value=fact):
             result = harvest.run_worker("m1", "model-a", client, cfg, [], self.fetch_backends, "goal", [], None)
         self.assertEqual(client.calls, cfg["limits"]["max_steps_per_model"] + 2)
         self.assertEqual(result.status, "OK")
@@ -4614,7 +4631,7 @@ class TestBudgetNudgeAndForcedSynthesisConvergence(unittest.TestCase):
             assistant_final("this is not json at all"),
             assistant_final("still not json"),
         ])
-        with mock.patch("harvest.call_fetch_backend", return_value="text"):
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value="text"):
             result = harvest.run_worker("m1", "model-a", client, cfg, [], self.fetch_backends, "goal", [], None)
         self.assertEqual(client.calls, 4)
         self.assertEqual(result.status, "FAILED")
@@ -4681,8 +4698,8 @@ class TestCmdRunLocalModeDispatch(unittest.TestCase):
         with mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"}), \
              mock.patch("harvest.load_config", return_value=config), \
              mock.patch("harvest.make_client_factory", side_effect=AssertionError("must not call normal-mode factory")), \
-             mock.patch("harvest.do_search", return_value=json.dumps({"results": [{"url": "https://a.com/1", "title": "t"}]})), \
-             mock.patch("harvest.do_fetch") as mock_do_fetch:
+             mock.patch("harvest_search.do_search", return_value=json.dumps({"results": [{"url": "https://a.com/1", "title": "t"}]})), \
+             mock.patch("harvest_fetch.do_fetch") as mock_do_fetch:
             def fake_fetch(url, fetch_backends, journal, config):
                 journal.append({"tool": "fetch", "url": url, "backend": "urllib-ua", "content": "fetched body"})
                 return "fetched body"
@@ -4731,8 +4748,8 @@ class TestCmdRunLocalEndToEnd(unittest.TestCase):
             journal.append({"tool": "fetch", "url": url, "backend": "urllib-ua", "content": content})
             return content
 
-        with mock.patch("harvest.do_search", return_value=search_results), \
-             mock.patch("harvest.do_fetch", side_effect=fake_fetch):
+        with mock.patch("harvest_search.do_search", return_value=search_results), \
+             mock.patch("harvest_fetch.do_fetch", side_effect=fake_fetch):
             harvest.cmd_run_local(self._args(queries_file), self.config)
 
         verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
@@ -4765,7 +4782,7 @@ class TestCmdRunLocalEndToEnd(unittest.TestCase):
         queries_file = self.project_dir / "queries.json"
         queries_file.write_text(json.dumps({"queries": ["q1"]}), encoding="utf-8")
         empty_results = json.dumps({"results": []})
-        with mock.patch("harvest.do_search", return_value=empty_results):
+        with mock.patch("harvest_search.do_search", return_value=empty_results):
             with self.assertRaises(SystemExit) as ctx:
                 harvest.cmd_run_local(self._args(queries_file), self.config)
         self.assertEqual(ctx.exception.code, 3)
@@ -4782,8 +4799,8 @@ class TestCmdRunLocalEndToEnd(unittest.TestCase):
             journal.append({"tool": "fetch", "url": url, "backend": None, "content": None})
             return json.dumps({"error": "all fetch backends failed"})
 
-        with mock.patch("harvest.do_search", return_value=search_results), \
-             mock.patch("harvest.do_fetch", side_effect=fake_fetch_fail):
+        with mock.patch("harvest_search.do_search", return_value=search_results), \
+             mock.patch("harvest_fetch.do_fetch", side_effect=fake_fetch_fail):
             with self.assertRaises(SystemExit) as ctx:
                 harvest.cmd_run_local(self._args(queries_file), self.config)
         self.assertEqual(ctx.exception.code, 3)
@@ -4810,8 +4827,8 @@ class TestCmdRunLocalEndToEnd(unittest.TestCase):
             journal.append({"tool": "fetch", "url": url, "backend": "urllib-ua", "content": "c"})
             return "c"
 
-        with mock.patch("harvest.do_search", side_effect=fake_search), \
-             mock.patch("harvest.do_fetch", side_effect=fake_fetch):
+        with mock.patch("harvest_search.do_search", side_effect=fake_search), \
+             mock.patch("harvest_fetch.do_fetch", side_effect=fake_fetch):
             harvest.cmd_run_local(self._args(queries_file), self.config)
 
         self.assertEqual(fetch_order[0], "https://x.com/b")
@@ -4832,8 +4849,8 @@ class TestCmdRunLocalEndToEnd(unittest.TestCase):
             journal.append({"tool": "fetch", "url": url, "backend": "urllib-ua", "content": "c"})
             return "c"
 
-        with mock.patch("harvest.do_search", return_value=many_results), \
-             mock.patch("harvest.do_fetch", side_effect=fake_fetch):
+        with mock.patch("harvest_search.do_search", return_value=many_results), \
+             mock.patch("harvest_fetch.do_fetch", side_effect=fake_fetch):
             harvest.cmd_run_local(self._args(queries_file), cfg)
 
         self.assertEqual(len(fetched), 2)
@@ -5083,9 +5100,9 @@ class TestProgressEmit(unittest.TestCase):
                  "url": "https://a.com/x", "credibility": 4, "language": "en"}])),
         ])
         search_backends = [({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0))]
-        with mock.patch("harvest.call_search_backend",
+        with mock.patch("harvest_search.call_search_backend",
                          return_value=[{"url": "https://a.com/x", "title": "t", "snippet": "s"}]), \
-             mock.patch("harvest.call_fetch_backend",
+             mock.patch("harvest_fetch.call_fetch_backend",
                          return_value="Rayleigh scattering explains the blue sky."), \
              mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
             harvest.run_worker("m1", "model-a", client, base_config(), search_backends, [],

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -596,7 +596,7 @@ class TestDuckDuckGoSearch(unittest.TestCase):
         self._patch.stop()
 
     def test_parses_result_links_and_unwraps_uddg_redirect(self):
-        with mock.patch("harvest.urllib.request.urlopen",
+        with mock.patch("harvest_search.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
             results, reason = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertIsNone(reason)
@@ -605,34 +605,34 @@ class TestDuckDuckGoSearch(unittest.TestCase):
         self.assertIn("https://blog.csdn.net/x", urls)  # blacklist filtering happens in do_search, not here
 
     def test_title_html_entities_and_tags_stripped(self):
-        with mock.patch("harvest.urllib.request.urlopen",
+        with mock.patch("harvest_search.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
             results, _ = harvest_search._search_duckduckgo({}, "query", 5)
         titles = [r["title"] for r in results]
         self.assertTrue(any("Example & Title highlighted" == t for t in titles))
 
     def test_non_result_anchor_ignored(self):
-        with mock.patch("harvest.urllib.request.urlopen",
+        with mock.patch("harvest_search.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
             results, _ = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertEqual(len(results), 2)  # the result__snippet anchor is not counted
 
     def test_empty_page_returns_none_with_no_result_links_reason(self):
-        with mock.patch("harvest.urllib.request.urlopen",
+        with mock.patch("harvest_search.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(b"<html><body>no results</body></html>")):
             result, reason = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertIsNone(result)
         self.assertIn("no result links found", reason)
 
     def test_network_failure_returns_none_with_reason(self):
-        with mock.patch("harvest.urllib.request.urlopen", side_effect=OSError("network down")):
+        with mock.patch("harvest_search.urllib.request.urlopen", side_effect=OSError("network down")):
             result, reason = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertIsNone(result)
         self.assertIn("request failed", reason)
 
     def test_requires_no_api_key(self):
         # cfg has no api_key_env at all -- must not raise or require one.
-        with mock.patch("harvest.urllib.request.urlopen",
+        with mock.patch("harvest_search.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
             results, _ = harvest_search._search_duckduckgo({}, "query", 5)
         self.assertIsNotNone(results)
@@ -645,7 +645,7 @@ class TestDuckDuckGoSearch(unittest.TestCase):
         # path instead of curl_cffi_requests.get (real network) -- otherwise
         # flaky on any machine with curl_cffi installed.
         with mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", False), \
-             mock.patch("harvest.urllib.request.urlopen",
+             mock.patch("harvest_search.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
             result = harvest.do_search("query", "en", backends, journal, cfg)
         data = json.loads(result)
@@ -693,7 +693,7 @@ class TestDuckDuckGoSearch(unittest.TestCase):
         # "no results" -- it's an IP-reputation block, not a parser bug.
         fixture = _FIXTURES_DIR / "ddg_anomaly_real.html"
         raw = fixture.read_bytes()
-        with mock.patch("harvest.urllib.request.urlopen", return_value=FakeHTTPResponse(raw)):
+        with mock.patch("harvest_search.urllib.request.urlopen", return_value=FakeHTTPResponse(raw)):
             result, reason = harvest_search._search_duckduckgo({}, "sqlite wal", 5)
         self.assertIsNone(result)
         self.assertIn("bot-check challenge page", reason)
@@ -770,7 +770,7 @@ class TestSearchBackendMissingKeySkips(unittest.TestCase):
         # path instead of curl_cffi_requests.get (real network) -- otherwise
         # flaky on any machine with curl_cffi installed.
         with mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", False), \
-             mock.patch("harvest.urllib.request.urlopen",
+             mock.patch("harvest_search.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
             result = harvest.do_search("query", "en", backends, journal, cfg)
         data = json.loads(result)
@@ -1288,7 +1288,7 @@ class TestBackendDegradation(unittest.TestCase):
         # (real network) on any machine where curl_cffi is installed, making
         # this test flaky. Mirrors the sibling test below.
         with mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", False), \
-             mock.patch("harvest.urllib.request.urlopen",
+             mock.patch("harvest_search.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(_DDG_SAMPLE_HTML.encode("utf-8"))):
             result = harvest.do_search("q", "en", backends, journal, self.config)
         data = json.loads(result)
@@ -1305,7 +1305,7 @@ class TestBackendDegradation(unittest.TestCase):
             ({"type": "duckduckgo"}, harvest.RateLimiter(0)),
         ]
         with mock.patch.object(harvest_clients.base, "_HAS_CURL_CFFI", False), \
-             mock.patch("harvest.urllib.request.urlopen", side_effect=OSError("network down")):
+             mock.patch("harvest_search.urllib.request.urlopen", side_effect=OSError("network down")):
             harvest.do_search("q", "en", backends, journal, self.config)
         attempts = journal[0]["attempts"]
         self.assertEqual(len(attempts), 2)
@@ -1317,7 +1317,7 @@ class TestBackendDegradation(unittest.TestCase):
             ({"type": "tavily-extract", "api_key_env": "NONEXISTENT_TAVILY_KEY_VAR"}, harvest.RateLimiter(0)),
             ({"type": "urllib-ua"}, harvest.RateLimiter(0)),
         ]
-        with mock.patch("harvest.urllib.request.urlopen",
+        with mock.patch("harvest_fetch.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(b"full page text")):
             result = harvest.do_fetch("https://good.com/x", backends, journal, self.config)
         self.assertEqual(result, "full page text")
@@ -1329,7 +1329,7 @@ class TestBackendDegradation(unittest.TestCase):
 
 class TestUrllibUaHtmlStripping(unittest.TestCase):
     def _fetch(self, html_body, max_chars=20000):
-        with mock.patch("harvest.urllib.request.urlopen",
+        with mock.patch("harvest_fetch.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(html_body.encode("utf-8"))):
             return harvest_fetch._fetch_urllib_ua({}, "https://a.com/x", 5, max_chars)
 
@@ -1380,7 +1380,7 @@ class TestUrllibUaHtmlStripping(unittest.TestCase):
         harvest_safety._real_getaddrinfo = lambda host, *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))]
         harvest.install_ssrf_guard()
         try:
-            with mock.patch("harvest.urllib.request.urlopen",
+            with mock.patch("harvest_fetch.urllib.request.urlopen",
                              return_value=FakeHTTPResponse(html_body.encode("utf-8"))):
                 result = harvest.do_fetch("https://a.com/x", backends, journal, cfg)
         finally:
@@ -1510,7 +1510,7 @@ class TestCurlCffiFetch(unittest.TestCase):
         # non-stream calls -- so the read component must be
         # `remaining - connect`, not `remaining`, or the effective total
         # would be connect + remaining (over budget).
-        with mock.patch("harvest.time.monotonic", side_effect=[0.0, 0.0]), \
+        with mock.patch("harvest_fetch.time.monotonic", side_effect=[0.0, 0.0]), \
              mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, "<p>ok</p>")) as m:
             self._fetch("https://a.com/x", timeout=20)
@@ -1525,7 +1525,7 @@ class TestCurlCffiFetch(unittest.TestCase):
         # 0.1. This locks down the epsilon fallback so it can't be
         # "simplified" to conn = remaining (which would zero out the read
         # component and reintroduce the libcurl 0ms-means-infinite hang).
-        with mock.patch("harvest.time.monotonic", side_effect=[0.0, 0.0]), \
+        with mock.patch("harvest_fetch.time.monotonic", side_effect=[0.0, 0.0]), \
              mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(200, "<p>ok</p>")) as m:
             self._fetch("https://a.com/x", timeout=2)
@@ -1538,7 +1538,7 @@ class TestCurlCffiFetch(unittest.TestCase):
         # First hop resolves within budget and redirects; by the time the
         # second hop would fire, the shared deadline has less than 1s left
         # -- it must abort there instead of issuing another curl call.
-        with mock.patch("harvest.time.monotonic", side_effect=[0.0, 0.0, 4.5]), \
+        with mock.patch("harvest_fetch.time.monotonic", side_effect=[0.0, 0.0, 4.5]), \
              mock.patch("harvest_clients.base.curl_cffi_requests.get",
                          return_value=FakeCurlResponse(302, location="/next")) as m:
             result, reason = self._fetch("https://a.com/start", timeout=5)
@@ -1750,7 +1750,7 @@ class TestJinaReaderAuthHeader(unittest.TestCase):
 
     def _fetch(self, env):
         with mock.patch.dict(os.environ, env, clear=False), \
-             mock.patch("harvest.urllib.request.urlopen",
+             mock.patch("harvest_fetch.urllib.request.urlopen",
                          return_value=FakeHTTPResponse(b"page text")) as m:
             harvest_fetch._fetch_jina_reader({"api_key_env": "JINA_API_KEY"}, "https://a.com/x", 5, 20000)
         return m.call_args.args[0]


### PR DESCRIPTION
## 摘要

将巨型 `harvest.py`（2451 行）按单向无环依赖 DAG 拆为主编排层 + 三个子模块，**纯代码搬迁，无外部行为变更**。closes #101

## 模块结构

| 模块 | 职责 |
|------|------|
| `harvest.py`（1632 行） | 主编排：pipeline / worker / judge / merge / verify / CLI |
| `harvest_safety.py`（新增 147 行） | SSRF 守卫 / 域黑名单 / 路径沙箱 / 限流 / URL 规范化（零依赖叶子） |
| `harvest_search/`（新增 390 行） | 4 个 web search backend + `do_search` 编排 |
| `harvest_fetch/`（新增 336 行） | 4 个 URL fetch backend + `do_fetch` 编排 |
| `harvest_clients/base.py`（+33 行） | curl_cffi 传输能力 + fail-fast 检查随 `_fetch_curl_cffi` 上移 |

**依赖铁律**：search 与 fetch 严格平级互不 import；safety 与 clients.base 是叶子，不 import 主模块。

## 测试

- `test_harvest.py` 438 用例全绿（内部符号引用改走子模块 facade，用例数不变）
- 唯一 error 是 `test_verify_report_html` 缺 pytest —— pre-existing 环境问题，与本改动无关

## 版本

双写 1.10.4 → **1.11.0**（plugin.json + marketplace.json 已一致）