### PR TITLE
feat(harvest): journal 事件级时间戳 (v1.12.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -1218,7 +1218,8 @@ def cmd_run_local(args, config):
     top_urls = ranked[:max_fetch]
     if not top_urls:
         print("error: all searches returned no usable URLs", file=sys.stderr)
-        abort_unavailable(verify_dir, goal_hash, "no usable URLs from search")
+        abort_unavailable(verify_dir, goal_hash, "no usable URLs from search",
+                          {"harvest_wall_s": round(time.monotonic() - _local_t0, 2)})
 
     fetched_pages = []
     harvest_dir = raw_dir / HARVEST_SUBDIR / "local"
@@ -1246,7 +1247,8 @@ def cmd_run_local(args, config):
 
     if not fetched_pages:
         print("error: all fetches failed", file=sys.stderr)
-        abort_unavailable(verify_dir, goal_hash, "all fetches failed")
+        abort_unavailable(verify_dir, goal_hash, "all fetches failed",
+                          {"harvest_wall_s": round(time.monotonic() - _local_t0, 2)})
 
     harvest_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1440,6 +1442,8 @@ def cmd_run(args):
         cleanup_stale_state(pipeline_dir, verify_dir, raw_dir)
     write_tombstone(verify_dir, goal_hash, verify_filename=verify_filename)
 
+    _harvest_t0 = None
+    harvest_wall_s = None
     try:
         install_ssrf_guard()
 
@@ -1515,7 +1519,12 @@ def cmd_run(args):
     except SystemExit:
         raise
     except Exception as e:
-        abort_unavailable(verify_dir, goal_hash, f"unexpected error: {e}", verify_filename=verify_filename)
+        extra = {}
+        if harvest_wall_s is not None:
+            extra["harvest_wall_s"] = harvest_wall_s
+        elif _harvest_t0 is not None:
+            extra["harvest_wall_s"] = round(time.monotonic() - _harvest_t0, 2)
+        abort_unavailable(verify_dir, goal_hash, f"unexpected error: {e}", extra, verify_filename=verify_filename)
 
 
 _VERDICT_EXIT_CODES = {"PASS": 0, "FAIL": 1, "N_A": 2}

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -339,6 +339,7 @@ from harvest_fetch import (
     call_fetch_backend, do_fetch,
 )
 import harvest_fetch  # for qualified do_fetch() calls in body (facade-penetration guard)
+import harvest_journal
 
 
 # ---------------------------------------------------------------------------
@@ -348,24 +349,24 @@ import harvest_fetch  # for qualified do_fetch() calls in body (facade-penetrati
 def do_read_local(path, offset, journal, config, local_dir):
     local_cfg = config.get("local_sources", {})
     if not local_cfg.get("enabled"):
-        journal.append({"tool": "read_local", "url": f"local://{path}", "blocked": "disabled", "content": None})
+        harvest_journal.jappend(journal, {"tool": "read_local", "url": f"local://{path}", "blocked": "disabled", "content": None})
         return json.dumps({"error": "local_sources disabled"})
     if not local_dir:
-        journal.append({"tool": "read_local", "url": f"local://{path}", "blocked": "no_dir", "content": None})
+        harvest_journal.jappend(journal, {"tool": "read_local", "url": f"local://{path}", "blocked": "no_dir", "content": None})
         return json.dumps({"error": "no local_dir configured"})
     resolved = resolve_local_path(local_dir, path)
     if resolved is None or not resolved.is_file():
-        journal.append({"tool": "read_local", "url": f"local://{path}", "blocked": "sandbox", "content": None})
+        harvest_journal.jappend(journal, {"tool": "read_local", "url": f"local://{path}", "blocked": "sandbox", "content": None})
         return json.dumps({"error": "path rejected by sandbox"})
     try:
         text = resolved.read_text(encoding="utf-8", errors="replace")
     except OSError:
-        journal.append({"tool": "read_local", "url": f"local://{path}", "blocked": "read_error", "content": None})
+        harvest_journal.jappend(journal, {"tool": "read_local", "url": f"local://{path}", "blocked": "read_error", "content": None})
         return json.dumps({"error": "read error"})
     offset = offset or 0
     max_chars = config["limits"]["fetch_max_chars"]
     chunk = text[offset:offset + max_chars]
-    journal.append({"tool": "read_local", "url": f"local://{path}", "content": chunk})
+    harvest_journal.jappend(journal, {"tool": "read_local", "url": f"local://{path}", "content": chunk})
     return chunk
 
 
@@ -489,7 +490,8 @@ def _extract_message(resp):
 
 
 class WorkerResult:
-    def __init__(self, alias, model_id, status, findings, journal, reason=None, rejected_claims=None):
+    def __init__(self, alias, model_id, status, findings, journal, reason=None, rejected_claims=None,
+                 wall_clock_s=None, completion_wall_s=0.0):
         self.alias = alias
         self.model_id = model_id
         self.status = status
@@ -497,6 +499,8 @@ class WorkerResult:
         self.journal = journal
         self.reason = reason
         self.rejected_claims = rejected_claims or []
+        self.wall_clock_s = wall_clock_s
+        self.completion_wall_s = completion_wall_s
 
 
 def append_or_merge_user(messages, text):
@@ -547,6 +551,17 @@ _FORCED_SYNTHESIS_PROMPT = (
 
 def run_worker(alias, model_id, client, config, search_backends, fetch_backends,
                 goal_text, local_manifest, local_dir):
+    t0 = time.monotonic()
+    completion_wall = [0.0]  # mutable box so inner can accumulate
+    r = _run_worker_inner(alias, model_id, client, config, search_backends, fetch_backends,
+                           goal_text, local_manifest, local_dir, completion_wall)
+    r.wall_clock_s = round(time.monotonic() - t0, 2)
+    r.completion_wall_s = round(completion_wall[0], 2)
+    return r
+
+
+def _run_worker_inner(alias, model_id, client, config, search_backends, fetch_backends,
+                       goal_text, local_manifest, local_dir, completion_wall):
     journal = []
     try:
         limits = config["limits"]
@@ -562,10 +577,13 @@ def run_worker(alias, model_id, client, config, search_backends, fetch_backends,
         for step in range(max_steps):
             if time.monotonic() > deadline:
                 return WorkerResult(alias, model_id, "FAILED", None, journal, "wall_clock_exceeded")
+            _cs = time.monotonic()
             try:
                 resp = client.complete(messages=messages, tools=TOOL_SCHEMAS)
             except Exception:
                 break
+            finally:
+                completion_wall[0] += time.monotonic() - _cs
             message = _extract_message(resp)
             if message is None:
                 return WorkerResult(alias, model_id, "FAILED", None, journal, "bad_response")
@@ -662,11 +680,14 @@ def run_worker(alias, model_id, client, config, search_backends, fetch_backends,
         # calling a tool, not the schema's absence -- so a model that ignores
         # the prompt and returns tool_calls anyway is handled below by
         # looking only at text content, never by re-dispatching those calls.
+        _cs = time.monotonic()
         try:
             resp = client.complete(messages=messages, tools=TOOL_SCHEMAS)
         except Exception as e:
             return WorkerResult(alias, model_id, "FAILED", None, journal,
                                 f"synthesis_failed ({type(e).__name__}): {e}")
+        finally:
+            completion_wall[0] += time.monotonic() - _cs
         message = _extract_message(resp)
         if message is None:
             return WorkerResult(alias, model_id, "FAILED", None, journal, "synthesis_no_response")
@@ -687,11 +708,14 @@ def run_worker(alias, model_id, client, config, search_backends, fetch_backends,
                 # actually said) and feed back the concrete parse error.
                 messages.append(message)
                 messages.append({"role": "user", "content": f"JSON parse error: {err}. Re-output valid findings JSON."})
+            _cs = time.monotonic()
             try:
                 resp = client.complete(messages=messages, tools=TOOL_SCHEMAS)
             except Exception as e:
                 return WorkerResult(alias, model_id, "FAILED", None, journal,
                                     f"synthesis_retry_failed ({type(e).__name__}): {e}")
+            finally:
+                completion_wall[0] += time.monotonic() - _cs
             message = _extract_message(resp)
             content = (message.get("content") or "") if message else ""
             data, err = parse_findings_json(content)
@@ -729,7 +753,8 @@ def run_panel(config, goal_text, local_manifest, local_dir, client_factory):
                 claims_count = len(claims) if isinstance(claims, list) else 0
             except Exception:
                 pass
-            _emit("worker_done", alias=r.alias, model_id=r.model_id, status=r.status, claims=claims_count)
+            _emit("worker_done", alias=r.alias, model_id=r.model_id, status=r.status, claims=claims_count,
+                  wall_clock_s=r.wall_clock_s, completion_wall_s=r.completion_wall_s)
     alive = [r for r in results if r.status == "OK"]
     _emit("panel_done", alive=[r.alias for r in alive], quorum_met=len(alive) >= quorum)
     return results, alive, len(alive) >= quorum
@@ -1170,6 +1195,7 @@ def cmd_run_local(args, config):
 
     queries = _read_queries_json(args.queries_json)
     search_backends, fetch_backends = build_backends(config)
+    _local_t0 = time.monotonic()
 
     journal = []
     all_urls = []
@@ -1258,6 +1284,7 @@ def cmd_run_local(args, config):
         "mode": "local",
         "pages_fetched": len(fetched_pages),
         "queries_executed": len(queries),
+        "harvest_wall_s": round(time.monotonic() - _local_t0, 2),
     })
 
     print(f"harvest local mode complete: {len(fetched_pages)} pages fetched")
@@ -1434,13 +1461,16 @@ def cmd_run(args):
         _emit("run_start", models=config["panel_models"],
               max_steps=config["limits"]["max_steps_per_model"],
               wall_clock_s=config["limits"]["wall_clock_s"])
+        _harvest_t0 = time.monotonic()
         results, alive, quorum_met = run_panel(config, goal_text, local_manifest, local_dir, client_factory)
+        harvest_wall_s = round(time.monotonic() - _harvest_t0, 2)
 
         _persist_worker_outputs(raw_dir, results)
 
         if not quorum_met:
             abort_unavailable(verify_dir, goal_hash, "quorum not met",
-                               {"quorum_met": False, "models_alive": [r.alias for r in alive]},
+                               {"quorum_met": False, "models_alive": [r.alias for r in alive],
+                                "harvest_wall_s": harvest_wall_s},
                                verify_filename=verify_filename)
 
         worker_findings_by_alias = {r.alias: r.findings for r in alive}
@@ -1450,7 +1480,8 @@ def cmd_run(args):
               err=judge_err)
         if judge_data is None:
             abort_unavailable(verify_dir, goal_hash, f"judge failed: {judge_err}",
-                               {"quorum_met": True, "models_alive": [r.alias for r in alive]},
+                               {"quorum_met": True, "models_alive": [r.alias for r in alive],
+                                "harvest_wall_s": harvest_wall_s},
                                verify_filename=verify_filename)
 
         merged = merge_findings(worker_findings_by_alias, judge_data)
@@ -1462,6 +1493,7 @@ def cmd_run(args):
 
         if total_claims == 0:
             abort_unavailable(verify_dir, goal_hash, "quorum met but zero valid claims",
+                               {"harvest_wall_s": harvest_wall_s},
                                verify_filename=verify_filename)
 
         raw_dir.mkdir(parents=True, exist_ok=True)
@@ -1476,6 +1508,7 @@ def cmd_run(args):
             "invalid_citation_rate": invalid_rate,
             "invalid_claim_count": invalid_total,
             "total_claims": total_claims,
+            "harvest_wall_s": harvest_wall_s,
         }, verify_filename=verify_filename)
         _emit("run_done", verdict=verdict, total_claims=total_claims, invalid_rate=round(invalid_rate, 4))
         print(f"harvest run complete: verdict={verdict}")

--- a/plugins/deep-research/scripts/harvest_fetch/__init__.py
+++ b/plugins/deep-research/scripts/harvest_fetch/__init__.py
@@ -14,6 +14,7 @@ import urllib.request
 
 import harvest_safety
 import harvest_clients.base
+import harvest_journal
 
 __all__ = [
     "_fetch_tavily_extract", "_fetch_jina_reader", "_strip_html_to_text",
@@ -305,9 +306,11 @@ def do_fetch(url, fetch_backends, journal, config):
     # serving it. (curl-cffi additionally re-validates + re-pins every
     # redirect hop internally, since libcurl's own DNS resolution bypasses
     # this guard entirely -- see _fetch_curl_cffi().)
+    _t0 = time.monotonic()
     blacklist = config.get("blacklist_domains", [])
     if harvest_safety.is_blacklisted(url, blacklist):
-        journal.append({"tool": "fetch", "url": url, "blocked": "blacklist", "content": None})
+        harvest_journal.jappend(journal, {"tool": "fetch", "url": url, "blocked": "blacklist", "content": None,
+                         "duration_s": round(time.monotonic() - _t0, 3)})
         return json.dumps({"error": "domain blacklisted"})
 
     max_chars = config["limits"]["fetch_max_chars"]
@@ -322,15 +325,17 @@ def do_fetch(url, fetch_backends, journal, config):
             else:
                 content = call_fetch_backend(backend_cfg, limiter, url, config, attempts)
         except harvest_safety.SSRFBlocked as e:
-            journal.append({"tool": "fetch", "url": url, "blocked": "ssrf", "content": None, "attempts": attempts})
+            harvest_journal.jappend(journal, {"tool": "fetch", "url": url, "blocked": "ssrf", "content": None,
+                             "attempts": attempts, "duration_s": round(time.monotonic() - _t0, 3)})
             return json.dumps({"error": f"blocked by SSRF guard: {e}"})
         except Exception as e:
             content = None
             attempts.append({"backend": backend_cfg["type"], "error": f"unexpected error: {e}"})
         if content:
             truncated = content[:max_chars]
-            journal.append({"tool": "fetch", "url": url, "backend": backend_cfg["type"], "content": truncated,
-                             "attempts": attempts})
+            harvest_journal.jappend(journal, {"tool": "fetch", "url": url, "backend": backend_cfg["type"], "content": truncated,
+                             "attempts": attempts, "duration_s": round(time.monotonic() - _t0, 3)})
             return truncated
-    journal.append({"tool": "fetch", "url": url, "backend": None, "content": None, "attempts": attempts})
+    harvest_journal.jappend(journal, {"tool": "fetch", "url": url, "backend": None, "content": None,
+                     "attempts": attempts, "duration_s": round(time.monotonic() - _t0, 3)})
     return json.dumps({"error": "all fetch backends failed"})

--- a/plugins/deep-research/scripts/harvest_journal.py
+++ b/plugins/deep-research/scripts/harvest_journal.py
@@ -10,7 +10,11 @@ def jappend(journal, entry):
     """Append `entry` to `journal` after stamping it with `t` (epoch seconds,
     0.1s precision -- same source/precision as run.log's _emit t field). The
     single place a journal event gets its timestamp, so no append site can
-    forget it."""
+    forget it.
+
+    Mutates `entry` in place (sets its `t` field) -- callers must pass a
+    fresh dict, not a reused/shared template, or previously appended
+    entries will have their `t` silently overwritten too."""
     entry["t"] = round(time.time(), 1)
     journal.append(entry)
     return entry

--- a/plugins/deep-research/scripts/harvest_journal.py
+++ b/plugins/deep-research/scripts/harvest_journal.py
@@ -1,0 +1,16 @@
+"""Journal-append helper: single choke point that stamps every journal
+event with a wall-clock timestamp. Zero-dependency bottom module -- imported
+by harvest.py + harvest_search + harvest_fetch, imports nothing of theirs, so
+the dependency graph stays acyclic (harvest.py already imports the two
+sub-packages; a reverse import would be a circular-import ImportError)."""
+import time
+
+
+def jappend(journal, entry):
+    """Append `entry` to `journal` after stamping it with `t` (epoch seconds,
+    0.1s precision -- same source/precision as run.log's _emit t field). The
+    single place a journal event gets its timestamp, so no append site can
+    forget it."""
+    entry["t"] = round(time.time(), 1)
+    journal.append(entry)
+    return entry

--- a/plugins/deep-research/scripts/harvest_search/__init__.py
+++ b/plugins/deep-research/scripts/harvest_search/__init__.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import subprocess
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -14,6 +15,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import harvest_safety
 import harvest_clients.base
+import harvest_journal
 
 __all__ = [
     "_search_gemini_cli", "_ddg_extract_target_url", "_search_duckduckgo",
@@ -354,6 +356,7 @@ def do_search(query, lang, search_backends, journal, config):
     # host (api.tavily.com / html.duckduckgo.com / our own gateway) -- the model's
     # query text does not steer the connection destination, so this is not
     # an SSRF surface and is not wrapped in tool_request_guard().
+    _t0 = time.monotonic()
     blacklist = config.get("blacklist_domains", [])
     attempts = []
     for backend_cfg, limiter in search_backends:
@@ -379,12 +382,13 @@ def do_search(query, lang, search_backends, journal, config):
                     # fails as url_not_fetched (real citation retry required)
                     # rather than url_not_in_journal (worse: implies the model
                     # never even saw the URL) or silently passing.
-                    journal.append({"tool": "search_grounding", "url": r["url"],
+                    harvest_journal.jappend(journal, {"tool": "search_grounding", "url": r["url"],
                                     "backend": "grounding", "content": None,
                                     "title": r.get("title") or r["url"]})
-            journal.append({"tool": "search", "query": query, "lang": lang,
+            harvest_journal.jappend(journal, {"tool": "search", "query": query, "lang": lang,
                              "backend": backend_cfg["type"], "urls": [r["url"] for r in filtered],
-                             "attempts": attempts})
+                             "attempts": attempts, "duration_s": round(time.monotonic() - _t0, 3)})
             return json.dumps({"results": filtered}, ensure_ascii=False)
-    journal.append({"tool": "search", "query": query, "lang": lang, "backend": None, "urls": [], "attempts": attempts})
+    harvest_journal.jappend(journal, {"tool": "search", "query": query, "lang": lang, "backend": None, "urls": [],
+                     "attempts": attempts, "duration_s": round(time.monotonic() - _t0, 3)})
     return json.dumps({"results": [], "error": "all search backends failed"})

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -15,6 +15,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 import harvest  # noqa: E402
 import harvest_fetch  # noqa: E402
+import harvest_journal  # noqa: E402
 import harvest_safety  # noqa: E402
 import harvest_search  # noqa: E402
 import harvest_clients.base  # noqa: E402
@@ -1325,6 +1326,153 @@ class TestBackendDegradation(unittest.TestCase):
         self.assertEqual(len(attempts), 1)
         self.assertEqual(attempts[0]["backend"], "tavily-extract")
         self.assertIn("not set", attempts[0]["error"])
+
+
+class TestJournalTimestamps(unittest.TestCase):
+    """harvest_journal.jappend is the single choke point every journal.append
+    call site was converted to -- these lock down the `t` (wall-clock) and
+    `duration_s` (monotonic-diff) fields it and its callers stamp on, plus
+    the wall_clock_s/completion_wall_s fields run_worker's wrapper computes
+    around _run_worker_inner. See #44."""
+
+    def setUp(self):
+        self.config = base_config()
+
+    def test_jappend_independently_importable_and_stamps_float_t(self):
+        # harvest_journal is a zero-dependency bottom module: importable and
+        # usable on its own, with no harvest/harvest_fetch/harvest_search
+        # import required first.
+        journal = []
+        entry = {"tool": "probe"}
+        with mock.patch("harvest_journal.time.time", return_value=123.456):
+            returned = harvest_journal.jappend(journal, entry)
+        self.assertIs(returned, entry)  # returns the same entry it mutated
+        self.assertIs(journal[0], entry)
+        self.assertEqual(journal[0]["t"], 123.5)  # round(x, 1)
+        self.assertIsInstance(journal[0]["t"], float)
+
+    def test_do_fetch_success_entry_carries_t_and_exact_duration_s(self):
+        journal = []
+        backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
+        # do_fetch calls time.monotonic() exactly twice on this path (_t0 at
+        # entry, then once more when building the success journal entry) --
+        # call_fetch_backend is mocked wholesale so RateLimiter.acquire()'s
+        # own internal monotonic() call never fires.
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value="hello world"), \
+             mock.patch("harvest_fetch.time.monotonic", side_effect=[10.0, 12.5]), \
+             mock.patch("harvest_fetch.time.time", return_value=999.0):
+            result = harvest.do_fetch("https://good.com/x", backends, journal, self.config)
+        self.assertEqual(result, "hello world")
+        self.assertEqual(journal[0]["duration_s"], 2.5)
+        self.assertEqual(journal[0]["t"], 999.0)
+
+    def test_do_fetch_all_backends_failed_entry_carries_duration_s(self):
+        journal = []
+        backends = [({"type": "urllib-ua"}, harvest.RateLimiter(0))]
+        with mock.patch("harvest_fetch.call_fetch_backend", return_value=None), \
+             mock.patch("harvest_fetch.time.monotonic", side_effect=[10.0, 11.0]):
+            harvest.do_fetch("https://good.com/x", backends, journal, self.config)
+        self.assertEqual(journal[0]["backend"], None)
+        self.assertEqual(journal[0]["duration_s"], 1.0)
+
+    def test_do_search_success_entry_carries_t_and_exact_duration_s(self):
+        journal = []
+        backends = [({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0))]
+        # Same shape as do_fetch: call_search_backend mocked wholesale means
+        # only do_search's own two time.monotonic() calls (_t0, then the
+        # success entry) fire -- limiter.acquire() lives inside the mocked
+        # function and never runs.
+        with mock.patch("harvest_search.call_search_backend",
+                         return_value=[{"url": "https://a.com", "title": "t", "snippet": "s"}]), \
+             mock.patch("harvest_search.time.monotonic", side_effect=[10.0, 13.25]), \
+             mock.patch("harvest_search.time.time", return_value=888.0):
+            harvest.do_search("q", "en", backends, journal, self.config)
+        self.assertEqual(journal[0]["duration_s"], 3.25)
+        self.assertEqual(journal[0]["t"], 888.0)
+
+    def test_do_search_all_backends_failed_entry_carries_duration_s(self):
+        journal = []
+        backends = [({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0))]
+        with mock.patch("harvest_search.call_search_backend", return_value=None), \
+             mock.patch("harvest_search.time.monotonic", side_effect=[10.0, 10.75]):
+            harvest.do_search("q", "en", backends, journal, self.config)
+        self.assertEqual(journal[0]["backend"], None)
+        self.assertEqual(journal[0]["duration_s"], 0.75)
+
+    def test_run_worker_computes_wall_clock_s_and_completion_wall_s(self):
+        # Deterministic single-threaded direct run_worker call (not
+        # run_panel, so a shared side_effect iterator is safe): one
+        # zero-tool-call OK turn walks through 6 time.monotonic() call
+        # sites -- wrapper t0, inner's deadline anchor, the per-step
+        # deadline check, _cs before client.complete(), the finally's
+        # accumulation read, and the wrapper's final wall_clock_s read.
+        client = ScriptedClient([assistant_final(findings_block([]))])
+        side_effect = [100.0, 100.0, 100.0, 100.0, 105.0, 110.0]
+        with mock.patch("harvest.time.monotonic", side_effect=side_effect):
+            result = harvest.run_worker("m1", "model-a", client, self.config, [], [],
+                                        "goal", [], None)
+        self.assertEqual(result.status, "OK")
+        self.assertEqual(result.wall_clock_s, 10.0)
+        self.assertEqual(result.completion_wall_s, 5.0)
+
+    def test_run_worker_completion_wall_s_nonnegative_on_exception_path(self):
+        # try/finally around client.complete() must still accumulate
+        # completion_wall even when the call raises -- exercised here via
+        # ExplodingClient (main-loop except -> break -> forced synthesis ->
+        # also raises -> FAILED), no time mocking so this is a real-clock
+        # sanity check rather than an exact-diff assertion.
+        class ExplodingClient:
+            def complete(self, messages, tools):
+                raise RuntimeError("network exploded")
+        result = harvest.run_worker("m1", "model-a", ExplodingClient(), self.config, [], [],
+                                    "goal", [], None)
+        self.assertEqual(result.status, "FAILED")
+        self.assertGreaterEqual(result.completion_wall_s, 0)
+        self.assertGreaterEqual(result.wall_clock_s, 0)
+
+    def test_worker_done_emit_carries_wall_clock_and_completion_wall(self):
+        # run_panel is multi-threaded (ThreadPoolExecutor) -- a shared
+        # side_effect list on time.monotonic would race across worker
+        # threads, so this only asserts the fields are present and
+        # non-negative (ANY-equivalent tolerance), not exact values.
+        config = base_config()
+
+        def factory(model_id):
+            return ScriptedClient([assistant_final(findings_block([]))])
+
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            harvest.run_panel(config, "goal", [], None, factory)
+        events = [json.loads(line) for line in stderr.getvalue().splitlines()]
+        worker_done_events = [e for e in events if e["event"] == "worker_done"]
+        self.assertTrue(worker_done_events)
+        for e in worker_done_events:
+            self.assertIn("wall_clock_s", e)
+            self.assertIn("completion_wall_s", e)
+            self.assertGreaterEqual(e["wall_clock_s"], 0)
+            self.assertGreaterEqual(e["completion_wall_s"], 0)
+
+    def test_new_journal_fields_do_not_break_citation_validation(self):
+        # Regression guard: build_fetch_index/build_journal_url_set/
+        # validate_claims only ever read tool/url/content/urls -- the
+        # additive t/duration_s fields on journal entries must not confuse
+        # them.
+        journal = [
+            {"tool": "fetch", "url": "https://a.com/x", "content": "The quick brown fox.",
+             "t": 100.0, "duration_s": 0.5, "attempts": []},
+            {"tool": "search", "query": "q", "lang": "en", "backend": "gemini-cli",
+             "urls": ["https://a.com/only-searched"], "t": 100.1, "duration_s": 0.2, "attempts": []},
+        ]
+        claims = harvest.assign_claim_ids("m1", [
+            {"claim": "c1", "excerpt": "quick brown fox", "url": "https://a.com/x"},
+            {"claim": "c2", "excerpt": "anything", "url": "https://a.com/only-searched"},
+        ])
+        idx = harvest.build_fetch_index(journal)
+        urls = harvest.build_journal_url_set(journal)
+        valid, invalid = harvest.validate_claims(claims, idx, urls)
+        self.assertEqual(len(valid), 1)
+        self.assertEqual(valid[0]["url"], "https://a.com/x")
+        self.assertEqual(len(invalid), 1)
+        self.assertEqual(invalid[0][1], "url_not_fetched")
 
 
 class TestUrllibUaHtmlStripping(unittest.TestCase):
@@ -2672,6 +2820,8 @@ class TestCmdRunEndToEnd(unittest.TestCase):
         self.assertTrue(data["quorum_met"])
         self.assertEqual(data["total_claims"], 3)
         self.assertEqual(data["invalid_citation_rate"], 0.0)
+        self.assertIn("harvest_wall_s", data)
+        self.assertGreaterEqual(data["harvest_wall_s"], 0)
 
         merged_file = self.raw_dir / harvest.MERGED_FINDINGS_FILE
         self.assertTrue(merged_file.exists())
@@ -4758,6 +4908,8 @@ class TestCmdRunLocalEndToEnd(unittest.TestCase):
         self.assertEqual(data["verdict"], "LOCAL")
         self.assertEqual(data["pages_fetched"], 2)
         self.assertEqual(data["queries_executed"], 2)
+        self.assertIn("harvest_wall_s", data)
+        self.assertGreaterEqual(data["harvest_wall_s"], 0)
 
         manifest_file = self.raw_dir / "harvest-local.json"
         self.assertTrue(manifest_file.exists())

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -4941,6 +4941,10 @@ class TestCmdRunLocalEndToEnd(unittest.TestCase):
         verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
         data = json.loads(verify_file.read_text(encoding="utf-8"))
         self.assertEqual(data["verdict"], "UNAVAILABLE")
+        # Regression: this abort path used to skip harvest_wall_s entirely,
+        # leaving no way to tell how long the local run ran before bailing.
+        self.assertIn("harvest_wall_s", data)
+        self.assertGreaterEqual(data["harvest_wall_s"], 0)
 
     def test_all_fetches_fail_aborts_unavailable(self):
         queries_file = self.project_dir / "queries.json"
@@ -4959,6 +4963,10 @@ class TestCmdRunLocalEndToEnd(unittest.TestCase):
         verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
         data = json.loads(verify_file.read_text(encoding="utf-8"))
         self.assertEqual(data["verdict"], "UNAVAILABLE")
+        # Regression: this abort path used to skip harvest_wall_s entirely,
+        # leaving no way to tell how long the local run ran before bailing.
+        self.assertIn("harvest_wall_s", data)
+        self.assertGreaterEqual(data["harvest_wall_s"], 0)
 
     def test_ranks_urls_by_search_result_frequency(self):
         # url "b" appears in both query results, "a" only once -- ranked
@@ -5006,6 +5014,67 @@ class TestCmdRunLocalEndToEnd(unittest.TestCase):
             harvest.cmd_run_local(self._args(queries_file), cfg)
 
         self.assertEqual(len(fetched), 2)
+
+
+# ---------------------------------------------------------------------------
+# cmd_run: top-level except must still carry harvest_wall_s once the
+# try-block has reached run_panel, even when run_panel itself blows up.
+# ---------------------------------------------------------------------------
+
+class TestCmdRunUnexpectedErrorCarriesWallClock(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.project_dir = Path(self.tmpdir.name)
+        self.pipeline_dir = self.project_dir / "pipeline"
+        self.raw_dir = self.pipeline_dir / "1_raw"
+        self.raw_dir.mkdir(parents=True)
+        self.goal_file = self.project_dir / harvest.GOAL_FILE_NAME
+        self.goal_file.write_text("why is the sky blue?", encoding="utf-8")
+        self._env_patch = mock.patch.dict(os.environ, {"TEST_GATEWAY_KEY": "fake-key"})
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+        self.tmpdir.cleanup()
+
+    def test_run_panel_exception_still_records_harvest_wall_s(self):
+        config = base_config()
+        args = argparse_ns(goal_file=str(self.goal_file), out=str(self.raw_dir), config="unused", local_dir=None)
+
+        with mock.patch("harvest.load_config", return_value=config), \
+             mock.patch("harvest.run_panel", side_effect=RuntimeError("boom")):
+            with self.assertRaises(SystemExit) as ctx:
+                harvest.cmd_run(args)
+        self.assertEqual(ctx.exception.code, 3)
+
+        verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
+        data = json.loads(verify_file.read_text(encoding="utf-8"))
+        self.assertEqual(data["verdict"], "UNAVAILABLE")
+        self.assertIn("unexpected error: boom", data["reason"])
+        # Regression: the top-level except used to write no harvest_wall_s
+        # at all, even though _harvest_t0 was already ticking by the time
+        # run_panel raised.
+        self.assertIn("harvest_wall_s", data)
+        self.assertGreaterEqual(data["harvest_wall_s"], 0)
+
+    def test_failure_before_run_panel_omits_harvest_wall_s(self):
+        # install_ssrf_guard() runs before _harvest_t0 is ever set -- if
+        # something blows up that early, there is no wall-clock reading to
+        # report, and abort_unavailable must not choke on an empty extra.
+        config = base_config()
+        args = argparse_ns(goal_file=str(self.goal_file), out=str(self.raw_dir), config="unused", local_dir=None)
+
+        with mock.patch("harvest.load_config", return_value=config), \
+             mock.patch("harvest.install_ssrf_guard", side_effect=RuntimeError("early boom")):
+            with self.assertRaises(SystemExit) as ctx:
+                harvest.cmd_run(args)
+        self.assertEqual(ctx.exception.code, 3)
+
+        verify_file = self.pipeline_dir / "verification" / harvest.VERIFY_FILE
+        data = json.loads(verify_file.read_text(encoding="utf-8"))
+        self.assertEqual(data["verdict"], "UNAVAILABLE")
+        self.assertIn("unexpected error: early boom", data["reason"])
+        self.assertNotIn("harvest_wall_s", data)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概述

给 harvest 管线补**事件级时间可观测性**，消除性能归因硬缺口——此前 journal 每行无时间戳、verification 无采集耗时，只能靠文件 mtime 粗估阶段墙钟，无法拆分单模型 completion/fetch/search 各自耗时。

## 变更

- **新建 `harvest_journal.py`**（零依赖底层模块）：`jappend()` 单点为每条 journal event 盖 `t` 字段（epoch 秒，与 run.log `_emit` 同源同精度）。11 处分散的 `journal.append` 全部收敛到此，消除"每个落点都要记得加 t"的边界情况。底层模块单向被 harvest.py / harvest_search / harvest_fetch import，依赖图无环。
- **fetch/search 事件补 `duration_s`**：单次操作墙钟（含失败后端重试），支持"哪类操作最慢"直接归因。
- **worker_done 补 `wall_clock_s` + `completion_wall_s`**：`run_worker` → `_run_worker_inner` + 薄 wrapper 单点计时，覆盖全部 8+ 返回分支；completion 累计用 `try/finally` 保证异常路径也累加，初始化 `0.0` 防 `None += x` 崩溃。
- **verification json 补 `harvest_wall_s`**：采集阶段总墙钟，OK / 全部 abort 分支 / local 模式均覆盖。

## 测试

- 新增 `TestJournalTimestamps`：单线程隔离测试精确断言时间差值（mock `time.monotonic` side_effect），多线程路径（`run_panel`/`cmd_run`）用 `mock.ANY` + `>0` 断言避免 ThreadPoolExecutor 竞态 flaky。
- `python3 -m pytest plugins/deep-research/tests/` → **447 passed**。
- 真实 gateway e2e run：verdict=OK，三个 panel 模型全 OK，journal `t` / `duration_s`、verify `harvest_wall_s`、worker_done `wall_clock_s`/`completion_wall_s` 全部按预期落盘（Python 断言全绿）。

## 版本

deep-research 1.11.0 → 1.12.0（plugin.json + marketplace.json 双写）。