### PR TITLE
chore(harvest): 移除死后端 gemini-cli (v1.13.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/CLAUDE.md
+++ b/plugins/deep-research/CLAUDE.md
@@ -10,7 +10,7 @@
 |------|------|
 | `scripts/harvest.py` | 主编排：pipeline / worker / judge / merge / verify / CLI |
 | `scripts/harvest_safety.py` | SSRF 守卫 / 域黑名单 / 路径沙箱 / 限流 / URL 规范化（零外部依赖叶子） |
-| `scripts/harvest_search/` | 4 个 web search backend + do_search 编排 |
+| `scripts/harvest_search/` | 3 个 web search backend + do_search 编排 |
 | `scripts/harvest_fetch/` | 4 个 URL fetch backend + do_fetch 编排 |
 | `scripts/harvest_clients/base.py` | HTTP/SSE 原语 + curl_cffi 传输能力 |
 

--- a/plugins/deep-research/README.md
+++ b/plugins/deep-research/README.md
@@ -16,8 +16,7 @@ The methodology (skill + subagents) works out of the box. The **multi-model harv
 
 | Dependency | Needed for | How |
 |------------|-----------|-----|
-| `GATEWAY_API_KEY` (env) | harvest.py panel models (gemini/gpt/claude via your OpenAI-compatible gateway) | Set gateway `base_url` + key in `scripts/harvest.config.json` / env |
-| `agy` CLI | primary search backend | Install per your `agy` setup |
+| `GATEWAY_API_KEY` (env) | harvest.py panel models (gemini/gpt/claude via your OpenAI-compatible gateway) **and the primary `gemini-grounding` search backend** | Set gateway `base_url` + key in `scripts/harvest.config.json` / env |
 | `curl_cffi` (Python, optional) | `curl-cffi` fetch backend (direct free fetch) | `pip3 install --user curl_cffi` — else harvest.py exits 4 with install hint |
 | `TAVILY_API_KEY` / `JINA_API_KEY` (env, optional) | tavily/jina search & fetch fallbacks | Set as env vars if used |
 | Python 3 | harvest.py + gate_check.py (stdlib only) | System Python 3 |

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -326,7 +326,7 @@ from harvest_clients.gemini import (
 
 
 from harvest_search import (
-    _search_gemini_cli, _ddg_extract_target_url, _search_duckduckgo,
+    _ddg_extract_target_url, _search_duckduckgo,
     _search_tavily, _resolve_grounding_redirect, _search_gemini_grounding,
     _no_redirect_opener, call_search_backend, do_search,
 )

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -29,7 +29,6 @@ import re
 import shutil
 import socket
 import ssl
-import subprocess
 import sys
 import threading
 import time

--- a/plugins/deep-research/scripts/harvest_search/__init__.py
+++ b/plugins/deep-research/scripts/harvest_search/__init__.py
@@ -1,4 +1,4 @@
-"""harvest_search - web search backends (gemini-cli, duckduckgo, tavily,
+"""harvest_search - web search backends (duckduckgo, tavily,
 gemini-grounding) + orchestration (call_search_backend/do_search). Depends on
 harvest_safety (blacklist) and harvest_clients.base (HTTP primitives +
 curl_cffi capability); never imports harvest_fetch (strict siblings)."""
@@ -6,7 +6,6 @@ import html
 import json
 import os
 import re
-import subprocess
 import time
 import urllib.error
 import urllib.parse
@@ -18,7 +17,7 @@ import harvest_clients.base
 import harvest_journal
 
 __all__ = [
-    "_search_gemini_cli", "_ddg_extract_target_url", "_search_duckduckgo",
+    "_ddg_extract_target_url", "_search_duckduckgo",
     "_search_tavily", "_resolve_grounding_redirect", "_search_gemini_grounding",
     "_no_redirect_opener", "call_search_backend", "do_search",
 ]
@@ -36,28 +35,6 @@ _PARALLEL_FETCH_MAX_WORKERS = 3
 # ---------------------------------------------------------------------------
 # Search backends (degrade in config order)
 # ---------------------------------------------------------------------------
-
-def _search_gemini_cli(cfg, query, timeout):
-    try:
-        proc = subprocess.run(
-            ["gemini", "-m", cfg.get("model", "gemini-3.5-flash"), "-p", query],
-            capture_output=True, timeout=timeout, stdin=subprocess.DEVNULL, text=True,
-        )
-    except subprocess.TimeoutExpired:
-        return None, "gemini-cli: timed out"
-    except OSError as e:
-        return None, f"gemini-cli: failed to launch subprocess: {e}"
-    if proc.returncode != 0:
-        detail = (proc.stderr or "").strip()[:200]
-        return None, f"gemini-cli: exited with code {proc.returncode}" + (f": {detail}" if detail else "")
-    text = proc.stdout or ""
-    if not text.strip():
-        return None, "gemini-cli: empty output"
-    urls = list(dict.fromkeys(re.findall(r'https?://[^\s\)\]\'"<>]+', text)))
-    if not urls:
-        return None, "gemini-cli: no URLs found in output"
-    return [{"url": u, "title": "", "snippet": text[:500]} for u in urls], None
-
 
 _DDG_ANCHOR_RE = re.compile(r'<a\b([^>]*)>(.*?)</a>', re.IGNORECASE | re.DOTALL)
 _DDG_HREF_RE = re.compile(r'href="([^"]*)"')
@@ -334,9 +311,7 @@ def call_search_backend(backend_cfg, limiter, query, lang, config, attempts=None
     timeout = config["limits"]["call_timeout_s"]
     btype = backend_cfg["type"]
     try:
-        if btype == "gemini-cli":
-            result, reason = _search_gemini_cli(backend_cfg, query, timeout)
-        elif btype == "tavily":
+        if btype == "tavily":
             result, reason = _search_tavily(backend_cfg, query, timeout)
         elif btype == "duckduckgo":
             result, reason = _search_duckduckgo(backend_cfg, query, timeout)

--- a/plugins/deep-research/skills/deep-research/references/context-economics.md
+++ b/plugins/deep-research/skills/deep-research/references/context-economics.md
@@ -76,12 +76,9 @@
 
 内部 search 后端链按优先级降级（配置于 `harvest.config.json`，与 `harvest.py` 同目录）：
 
-1. agy-cli（主力，本机 `agy` CLI，经实测可联网搜索，零网关成本）
-2. 网关 gemini（经聚合网关调用，agy-cli 失败时兜底）
-3. 付费搜索 API（tavily 适配器，key 就绪时启用）
-4. DuckDuckGo HTML（零 key 尽力型兜底，可能被反爬拦截）
-
-> gemini-cli 适配器代码保留但已移出默认链（本机 CLI 凭据长期失效，每次搜索空耗一次 subprocess 失败）。CLI 恢复登录后可在 config 中重新加回链，或继续用 agy-cli 作为其替代。
+1. gemini-grounding（主力，经聚合网关 API 调用 Gemini grounding 搜索）
+2. 付费搜索 API（tavily 适配器，key 就绪时启用）
+3. DuckDuckGo HTML（零 key 尽力型兜底，可能被反爬拦截）
 
 fetch 后端链同理降级：curl-cffi（本地免费直连，软依赖）→ tavily-extract → jina-reader → urllib+UA 兜底。**harvest.py 采集失败（exit 3 / `UNAVAILABLE`）不自动降级到 legacy 链**——失败即阻塞上报用户裁决，降级权在用户（见 [quality-gates.md](./quality-gates.md) 引用校验机械门）。
 

--- a/plugins/deep-research/skills/deep-research/references/web-research.md
+++ b/plugins/deep-research/skills/deep-research/references/web-research.md
@@ -63,7 +63,7 @@ harvester（Task subagent）执行采集。**禁止**在主上下文直接搜索
 python3 <harvest.py 路径> run --goal-file intake/requirements/research-goal.md --out pipeline/1_raw/ [--config <harvest.config.json 路径>] [--local-dir intake/local_sources]
 ```
 
-三个异构面板模型（由 `harvest.config.json` 的 `panel_models` 配置，当前为 gemini/gpt/claude 三家族）并行各跑独立 agentic loop 自主检索，内部 search 后端链按优先级降级（agy-cli → 网关 gemini → tavily → DuckDuckGo 兜底，见 [context-economics.md](./context-economics.md)）；merge 阶段裁判模型产出共识标签与 Fusion 五元组分析，落盘 `merged-findings.json` + 带机械门数据的 `fetch-report.md`。exit 3（`UNAVAILABLE`）时 harvester 停止并上报 Lead，**不自行转 fallback**（见 deep-research 插件的 research-harvester subagent 工具链）。
+三个异构面板模型（由 `harvest.config.json` 的 `panel_models` 配置，当前为 gemini/gpt/claude 三家族）并行各跑独立 agentic loop 自主检索，内部 search 后端链按优先级降级（gemini-grounding → tavily → DuckDuckGo 兜底，见 [context-economics.md](./context-economics.md)）；merge 阶段裁判模型产出共识标签与 Fusion 五元组分析，落盘 `merged-findings.json` + 带机械门数据的 `fetch-report.md`。exit 3（`UNAVAILABLE`）时 harvester 停止并上报 Lead，**不自行转 fallback**（见 deep-research 插件的 research-harvester subagent 工具链）。
 
 **agentic loop 收敛语义（强制收尾兜底）**：每个 panel worker 的 loop 有 `max_steps_per_model` 轮工具预算（LLM 回合数，非工具调用数），system prompt 会告知该预算并引导「先双语搜索摸清源 → fetch 最相关几篇 → 主动停下吐 findings JSON」。**预算耗尽不再直接丢弃已采证据**：loop 结束后强制发一次收尾 synthesis 调用，让 worker 把已 fetch 的证据收敛成 findings，再走同一套引用机械门校验（追不到已 fetch 内容的 claim 照剔）。收尾仍无合法产出才判 `step_limit_no_synthesis` 失败。此设计避免「worker 采足证据却因未主动收尾被整个作废、进而拖垮 quorum」。`wall_clock_s` 超时是另一条独立硬停路径（濒临墙钟死线不再追加调用），不走强制收尾。
 

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -32,7 +32,7 @@ def base_config(**overrides):
         "gateway": {"base_url": "https://gw.example.com/v1", "api_key_env": "TEST_GATEWAY_KEY"},
         "panel_models": ["model-a", "model-b", "model-c"],
         "judge_model": "model-judge",
-        "search_backends": [{"type": "gemini-cli", "model": "gemini-3.5-flash"}],
+        "search_backends": [{"type": "gemini-grounding", "model": "gemini-3.5-flash"}],
         "fetch_backends": [{"type": "urllib-ua"}],
         "local_sources": {"enabled": False, "dir": "intake/local_sources"},
         "limits": {"max_steps_per_model": 6, "call_timeout_s": 5, "wall_clock_s": 60,
@@ -494,7 +494,7 @@ class TestCitationValidation(unittest.TestCase):
         self.assertEqual(invalid, [])
 
     def test_url_seen_in_search_but_never_fetched_rejected_as_not_fetched(self):
-        journal = [{"tool": "search", "query": "q", "lang": "en", "backend": "gemini-cli",
+        journal = [{"tool": "search", "query": "q", "lang": "en", "backend": "gemini-grounding",
                     "urls": ["https://a.com/only-searched"]}]
         claims = harvest.assign_claim_ids("m1", [
             {"claim": "c", "excerpt": "anything", "url": "https://a.com/only-searched"}])
@@ -1181,7 +1181,7 @@ class TestBackendDegradation(unittest.TestCase):
     def test_search_falls_through_to_second_backend(self):
         journal = []
         backends = [
-            ({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0)),
+            ({"type": "gemini-grounding", "model": "x"}, harvest.RateLimiter(0)),
             ({"type": "duckduckgo"}, harvest.RateLimiter(0)),
         ]
         with mock.patch("harvest_search.call_search_backend", side_effect=[None, [{"url": "https://a.com", "title": "t", "snippet": "s"}]]):
@@ -1192,7 +1192,7 @@ class TestBackendDegradation(unittest.TestCase):
 
     def test_search_all_backends_fail(self):
         journal = []
-        backends = [({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0))]
+        backends = [({"type": "gemini-grounding", "model": "x"}, harvest.RateLimiter(0))]
         with mock.patch("harvest_search.call_search_backend", return_value=None):
             result = harvest.do_search("q", "en", backends, journal, self.config)
         data = json.loads(result)
@@ -1205,7 +1205,7 @@ class TestBackendDegradation(unittest.TestCase):
         # genuine empty answer -- the chain must still try the next backend.
         journal = []
         backends = [
-            ({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0)),
+            ({"type": "gemini-grounding", "model": "x"}, harvest.RateLimiter(0)),
             ({"type": "duckduckgo"}, harvest.RateLimiter(0)),
         ]
         with mock.patch("harvest_search.call_search_backend", side_effect=[
@@ -1219,7 +1219,7 @@ class TestBackendDegradation(unittest.TestCase):
 
     def test_search_results_filtered_by_blacklist(self):
         journal = []
-        backends = [({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0))]
+        backends = [({"type": "gemini-grounding", "model": "x"}, harvest.RateLimiter(0))]
         results = [{"url": "https://blog.csdn.net/x", "title": "t", "snippet": "s"},
                    {"url": "https://good.com/x", "title": "t", "snippet": "s"}]
         with mock.patch("harvest_search.call_search_backend", return_value=results):
@@ -1377,7 +1377,10 @@ class TestJournalTimestamps(unittest.TestCase):
 
     def test_do_search_success_entry_carries_t_and_exact_duration_s(self):
         journal = []
-        backends = [({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0))]
+        # duckduckgo (not gemini-grounding): grounding backends prepend a
+        # per-URL search_grounding entry, which would make journal[0] the
+        # grounding row (no duration_s) instead of the search row under test.
+        backends = [({"type": "duckduckgo"}, harvest.RateLimiter(0))]
         # Same shape as do_fetch: call_search_backend mocked wholesale means
         # only do_search's own two time.monotonic() calls (_t0, then the
         # success entry) fire -- limiter.acquire() lives inside the mocked
@@ -1392,7 +1395,7 @@ class TestJournalTimestamps(unittest.TestCase):
 
     def test_do_search_all_backends_failed_entry_carries_duration_s(self):
         journal = []
-        backends = [({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0))]
+        backends = [({"type": "gemini-grounding", "model": "x"}, harvest.RateLimiter(0))]
         with mock.patch("harvest_search.call_search_backend", return_value=None), \
              mock.patch("harvest_search.time.monotonic", side_effect=[10.0, 10.75]):
             harvest.do_search("q", "en", backends, journal, self.config)
@@ -1459,7 +1462,7 @@ class TestJournalTimestamps(unittest.TestCase):
         journal = [
             {"tool": "fetch", "url": "https://a.com/x", "content": "The quick brown fox.",
              "t": 100.0, "duration_s": 0.5, "attempts": []},
-            {"tool": "search", "query": "q", "lang": "en", "backend": "gemini-cli",
+            {"tool": "search", "query": "q", "lang": "en", "backend": "gemini-grounding",
              "urls": ["https://a.com/only-searched"], "t": 100.1, "duration_s": 0.2, "attempts": []},
         ]
         claims = harvest.assign_claim_ids("m1", [
@@ -2093,11 +2096,6 @@ class TestSubprocessSafety(unittest.TestCase):
     def test_no_shell_true_in_source(self):
         source = Path(harvest.__file__).read_text(encoding="utf-8")
         self.assertNotIn("shell=True", source)
-
-    def test_gemini_cli_uses_list_args_and_devnull_stdin(self):
-        source = Path(harvest_search.__file__).read_text(encoding="utf-8")
-        self.assertIn("stdin=subprocess.DEVNULL", source)
-        self.assertIn('["gemini", "-m"', source)
 
     def test_all_urlopen_calls_have_explicit_timeout(self):
         source = Path(harvest.__file__).read_text(encoding="utf-8")
@@ -5320,7 +5318,7 @@ class TestProgressEmit(unittest.TestCase):
                 {"claim": "c", "excerpt": "Rayleigh scattering explains the blue sky.",
                  "url": "https://a.com/x", "credibility": 4, "language": "en"}])),
         ])
-        search_backends = [({"type": "gemini-cli", "model": "x"}, harvest.RateLimiter(0))]
+        search_backends = [({"type": "gemini-grounding", "model": "x"}, harvest.RateLimiter(0))]
         with mock.patch("harvest_search.call_search_backend",
                          return_value=[{"url": "https://a.com/x", "title": "t", "snippet": "s"}]), \
              mock.patch("harvest_fetch.call_fetch_backend",

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -1178,6 +1178,21 @@ class TestBackendDegradation(unittest.TestCase):
         socket.getaddrinfo = self._orig_getaddrinfo
         harvest_safety._real_getaddrinfo = self._orig_real
 
+    def test_unknown_search_backend_type_records_attempt_and_returns_none(self):
+        # Regression lock for the gemini-cli removal: a config still naming a
+        # dropped/unknown backend type (e.g. a stale project-local config that
+        # kept "gemini-cli" or "agy-cli") must degrade cleanly -- call_search_backend
+        # returns None and records an "unknown search backend type" attempt, so
+        # do_search just falls through to the next backend rather than crashing.
+        # call_search_backend returns the bare result (None on failure); the
+        # failure reason is side-channelled onto the caller-supplied attempts
+        # list, not returned.
+        attempts = []
+        result = harvest_search.call_search_backend(
+            {"type": "gemini-cli"}, harvest.RateLimiter(0), "q", "en", self.config, attempts)
+        self.assertIsNone(result)
+        self.assertIn("unknown search backend type", attempts[0]["error"])
+
     def test_search_falls_through_to_second_backend(self):
         journal = []
         backends = [


### PR DESCRIPTION
## 背景

`gemini-cli` search 后端本机 CLI 凭据长期失效、早已移出默认链（shipped config `harvest.config.json` 只用 `gemini-grounding`/`tavily`/`duckduckgo`）。适配器代码此前有意保留，现确认不再需要，彻底清除——避免残留 config 项（如某研究项目的 local config 曾配 `agy-cli`/`gemini-cli`）触发 `unknown search backend type` 空耗。

## 变更

- **harvest_search/__init__.py**：删 `_search_gemini_cli` 实现 + `call_search_backend` 的 gemini-cli dispatch 分支 + `__all__` 导出 + docstring 提及；仅该函数使用的 `import subprocess` 一并删（grep 确认无他用）。
- **harvest.py**：从 `from harvest_search import (...)` 列表删死 re-export `_search_gemini_cli`（collection 时会 ImportError）。
- **测试**：`base_config` 默认后端与 7 处降级占位 backend 统一改 `gemini-grounding`（均被 mock，type 仅作标签）；删 `test_gemini_cli_uses_list_args_and_devnull_stdin` 专项；`duration_s` 精确断言测试改用 `duckduckgo`（`gemini-grounding` 有 `search_grounding` 副作用会占据 `journal[0]`）。
- **skill references**（context-economics / web-research）：search 后端链描述同步为 `gemini-grounding → tavily → duckduckgo`，与 shipped config 一致。

## 测试

`pytest plugins/deep-research/tests/` → **505 passed**（含 issue #44 的时间戳测试全绿）。

## 版本

deep-research 1.12.0 → 1.13.0（plugin.json + marketplace.json 双写）。

## 附带

移除范围外发现 `harvest.py:32` 有个从 v3 抽离时就存在的未使用 `import subprocess`（0 次调用）——按范围围栏未在本 PR 处理，仅记录。