### PR TITLE
feat(plan-review): 抑制时间维度幻觉致过时知识 false correction (v1.1.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "plan-review",
       "description": "Adversarial plan review via cross-model consultation (agy/Claude)",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/plan-review/.claude-plugin/plugin.json
+++ b/plugins/plan-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-review",
   "description": "Adversarial plan review via cross-model consultation (agy/Claude)",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "woodragon"
   }

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -516,6 +516,15 @@ calls, or parameter names that do not exist in YOUR environment — this is norm
 and correct. DO NOT judge whether tool names or agent type identifiers match your
 own system. Focus exclusively on logic, architecture, and engineering quality.
 
+Your training knowledge has a cutoff; the plan may reference things newer than it.
+Treat version identifiers in the plan — model names (e.g. `sonnet-5`, `opus-4.8`),
+library/dependency versions, API signatures — as GROUND TRUTH, not as claims to
+verify against your memory. Whether such an identifier "exists" or "is correct" is
+NOT common knowledge you may assert unprompted: it requires evidence from the plan
+or project context. Absent that evidence, you have no grounds to flag it — do not
+raise it. If you genuinely suspect a concrete, evidence-backed problem, emit it as
+`[UNVERIFIED]` (never Critical), never as a confident correction.
+
 Keep your response under 3000 characters.
 
 ## Review Criteria

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -603,8 +603,8 @@ False positives burn scarce negotiation rounds. Gate EVERY finding:
    suspected Critical → keep as `[UNVERIFIED]`, downgrade to Major (→ CONCERNS, not REJECT).
 2. **False-positive registry** — Never raise: naming/style preferences, justified design
    choices (attack the justification instead), tool/agent-type/parameter names, or version
-   identifiers newer than your knowledge cutoff — model names, library/dependency versions,
-   API signatures (Scope Boundary).
+   identifiers whose existence or correctness you cannot verify from the plan or project
+   context — model names, library/dependency versions, API signatures (Scope Boundary).
 3. **Severity calibration** — Style is never Major/Critical. Critical requires a concrete,
    named blocker (specific vuln, data-loss path, wrong-result logic).
 4. **Verdict↔severity** — Confirm verdict matches highest surviving finding:

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -602,7 +602,9 @@ False positives burn scarce negotiation rounds. Gate EVERY finding:
 1. **Confidence** — Low confidence + Minor/Major → DROP silently. Low confidence +
    suspected Critical → keep as `[UNVERIFIED]`, downgrade to Major (→ CONCERNS, not REJECT).
 2. **False-positive registry** — Never raise: naming/style preferences, justified design
-   choices (attack the justification instead), tool/agent-type/parameter names (Scope Boundary).
+   choices (attack the justification instead), tool/agent-type/parameter names, or version
+   identifiers newer than your knowledge cutoff — model names, library/dependency versions,
+   API signatures (Scope Boundary).
 3. **Severity calibration** — Style is never Major/Critical. Critical requires a concrete,
    named blocker (specific vuln, data-loss path, wrong-result logic).
 4. **Verdict↔severity** — Confirm verdict matches highest surviving finding:

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -2380,6 +2380,11 @@ Use Task( for analysis.
   grep -q "3000 characters" "${HOOK_SCRIPT:?Missing hook script}"
 }
 
+@test "system-instructions: Scope Boundary has training-cutoff / version-identifier ground-truth directive" {
+  grep -q "GROUND TRUTH" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "verify against your memory" "${HOOK_SCRIPT:?Missing hook script}"
+}
+
 # ---------------------------------------------------------------------------
 # Finding Quality Gate (issue #30) — prompt-layer denoising directives.
 # These are static prompt-content assertions: the gate operates inside the

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -2383,6 +2383,9 @@ Use Task( for analysis.
 @test "system-instructions: Scope Boundary has training-cutoff / version-identifier ground-truth directive" {
   grep -q "GROUND TRUTH" "${HOOK_SCRIPT:?Missing hook script}"
   grep -q "verify against your memory" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "training knowledge has a cutoff" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "NOT common knowledge" "${HOOK_SCRIPT:?Missing hook script}"
+  grep -q "never Critical" "${HOOK_SCRIPT:?Missing hook script}"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概述

抑制 plan-review 审阅引擎的**时间维度幻觉**：引擎拿训练截止点后的旧知识当权威，反过来"纠正"实际更新的 plan（如坚持把 `sonnet-5` 改回 `claude-3-5`、把家族名 `sonnet` 改成过时日期版 ID）。

## 根因

现有 `## Scope Boundary` 只覆盖**空间维度**（"你的系统 vs 别的 AI 系统"横向错位），漏了**时间维度**（"训练截止点 vs 现在"纵向错位）。同一病根，边界只画一半。且 evidence 规则有"常识豁免"漏洞——引擎把"我知道 sonnet-5 不存在"当免引用常识，绕过门控。

## 方案

纯 prompt 加固，零维护。Scope Boundary 段尾追加时效性子段，复用社区实测有效的三机制：

- `GROUND TRUTH` 声明 = external knowledge restriction（Anthropic 官方）
- 堵"常识豁免"漏洞，接已有 evidence 规则
- 存疑走已有 `[UNVERIFIED]` 降级通道，不占磋商轮次

砍掉被证无效的 date injection（隐含场景成功率仅 ~19%）与版本白名单（过时即负维护）。

## 变更

- `plan-review.sh`：Scope Boundary 段尾插入时效性子段
- 版本双写 1.1.0 → 1.1.1（plugin.json + marketplace.json）
- 新增 bats test 135（GROUND TRUTH 锚点断言）

## 测试

- 全套 bats（plan-review.bats + dispatch-check.bats）**166 项全绿**
- 新增 test 135 通过
- 本增强在自身 plan-review 对抗性磋商中，成功驳回引擎要求写死过时日期版 model ID 的 false correction——活样本印证问题真实

Closes #107
