### PR TITLE
feat(plan-review): APPROVE ack-deny 显式声明"通过≠可开工" (v1.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "plan-review",
       "description": "Adversarial plan review via cross-model consultation (agy/Claude)",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/plan-review/.claude-plugin/plugin.json
+++ b/plugins/plan-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-review",
   "description": "Adversarial plan review via cross-model consultation (agy/Claude)",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "woodragon"
   }

--- a/plugins/plan-review/README.md
+++ b/plugins/plan-review/README.md
@@ -49,10 +49,15 @@ Legacy variables (`GEMINI_REVIEW_OFF`, `GEMINI_DRY_RUN`, `GEMINI_MAX_REVIEWS`) a
 
 ```
 ExitPlanMode → hook intercepts → engine reviews
-  ├─ APPROVE → allow through
+  ├─ APPROVE → ack-deny: present review + re-call ExitPlanMode → allow (user's native go/no-go)
   ├─ CONCERNS/REJECT → deny + feedback → Claude revises → re-submit
   └─ max rounds reached → allow through (user decides)
 ```
+
+An engine APPROVE is **not** authorization to start work — it only clears the plan
+for the user's native ExitPlanMode decision. The ack-deny message instructs Claude to
+present the review and re-call ExitPlanMode (unchanged); only the user's native approval
+on that second call permits execution.
 
 ## Review Criteria
 

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -1214,7 +1214,12 @@ ${REVIEW}
 
 ---
 
-> 请向用户简要展示上述审阅结果，然后直接再次调用 ExitPlanMode（不要修改 plan）。
+**审阅通过 ≠ 可以开工。** 审阅引擎只是对等 peer，它的 APPROVE 仅表示"技术上无异议"，**不代表**用户已授权执行。此刻**禁止**开始任何落地动作（编辑文件、执行命令）。
+
+下一步（必须严格照做）：
+1. 向用户简要展示上述审阅结果；
+2. **不修改 plan**，直接再次调用 ExitPlanMode——这一步才会把 plan 交给用户做原生的 go/no-go 决策；
+3. 只有在用户通过 ExitPlanMode 原生批准后，才可以开工。
 APPROVE_EOF
   )
   FEEDBACK_JSON=$(printf '%s' "$FEEDBACK" | jq -Rs .)

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -1206,7 +1206,7 @@ if [ "$VERDICT" = "APPROVE" ]; then
   FEEDBACK=$(cat << APPROVE_EOF
 ## ${APPROVE_HEADER}
 
-审阅引擎已**通过**本次 plan。以下是审阅摘要：
+审阅引擎对本次 plan **技术上无异议**（verdict=APPROVE）。以下是审阅摘要：
 
 ---
 

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -490,6 +490,25 @@ Plan looks solid."
   [ -f "${REVIEW_COUNTER_DIR}/.review-approved-test-session" ]
 }
 
+# 24a-2. Ack-deny message must state APPROVE != authorization to start work,
+# and must direct Claude to re-call ExitPlanMode for the user's native go/no-go.
+@test "branch: APPROVE ack-deny message forbids starting work before user arbitration" {
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+Plan looks solid."
+  INPUT=$(build_input)
+  run_hook
+
+  local reason
+  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+
+  # Must explicitly decouple approval from authorization to start work
+  [[ "$reason" == *"审阅通过 ≠ 可以开工"* ]]
+  # Must direct Claude to re-call ExitPlanMode for the user's native decision
+  [[ "$reason" == *"ExitPlanMode"* ]]
+  # Must instruct not to modify the plan before re-submitting
+  [[ "$reason" == *"不修改 plan"* ]]
+}
+
 # 24b. Ack-deny with round info (multi-round APPROVE)
 @test "branch: APPROVE ack-deny after prior rounds includes round info" {
   set_counter_value 2 test-session 4

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -507,6 +507,9 @@ Plan looks solid."
   [[ "$reason" == *"ExitPlanMode"* ]]
   # Must instruct not to modify the plan before re-submitting
   [[ "$reason" == *"不修改 plan"* ]]
+  # Must forbid starting any implementation action at this point
+  [[ "$reason" == *"禁止"* ]]
+  [[ "$reason" == *"落地"* ]]
 }
 
 # 24b. Ack-deny with round info (multi-round APPROVE)


### PR DESCRIPTION
## 背景

plan-review 是纯 hook 插件(无 skills)。审阅引擎 APPROVE 时走 **ack-deny**:hook 返回 deny + 反馈,Claude 展示审阅结果后**再次**调 ExitPlanMode,第二次才被 allow,交由用户做原生 go/no-go 决策。

原 ack-deny 反馈仅软引导「展示后再次调用 ExitPlanMode」,措辞上「审阅引擎已**通过**」易被 LLM 误读为「批准了,可以开工」,从而跳过第二次 ExitPlanMode 直接落地(编辑文件/执行命令)。

## 改动

- **`scripts/plan-review.sh`**:APPROVE 分支 ack-deny 消息硬性声明三条约束——审阅通过 ≠ 可开工;此刻禁止任何落地动作;必须不改 plan 直接再次调 ExitPlanMode 交用户裁决;仅用户原生批准后可开工。机制未变,只是把「为什么必须走第二步」讲透。
- **`tests/plan-review.bats`**:新增用例锁定新语义(禁开工措辞 / ExitPlanMode 指引 / 不改 plan)。
- **`README.md`**:Consultation Flow 图纠正 `APPROVE → allow through` 为真实 ack-deny 两步流程。
- **版本号**:plugin.json + marketplace.json 双写 1.2.0 → 1.3.0。

## 测试

`bats tests/plan-review.bats` → **171/171 通过**(含新增 1 例)。