### PR TITLE
fix(plan-review): agy 反转义器补 <>/& 转义，修复 verdict 恒被误判为 CONCERNS (v1.3.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "plan-review",
       "description": "Adversarial plan review via cross-model consultation (agy/Claude)",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/plan-review/.claude-plugin/plugin.json
+++ b/plugins/plan-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-review",
   "description": "Adversarial plan review via cross-model consultation (agy/Claude)",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "woodragon"
   }

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -901,6 +901,21 @@ ${PLAN}"
                 else if (nc == "\"") out = out "\""
                 else if (nc == "\\") out = out "\\"
                 else if (nc == "r") out = out "\r"
+                else if (nc == "u") {
+                  # \uXXXX: Go encoding/json HTML-safe mode escapes <, >, & and
+                  # U+2028/U+2029 this way by default (XSS defense) — that set
+                  # is what agy actually emits, verified by reproduction. Any
+                  # other \uXXXX is passed through literally (backslash intact)
+                  # rather than silently dropped, so an unanticipated escape is
+                  # visibly wrong instead of corrupting the tag structure.
+                  hex = tolower(substr(s, i + 1, 4))
+                  if (hex == "003c") out = out "<"
+                  else if (hex == "003e") out = out ">"
+                  else if (hex == "0026") out = out "&"
+                  else if (hex == "2028" || hex == "2029") out = out "\n"
+                  else out = out "\\u" substr(s, i + 1, 4)
+                  i += 4
+                }
                 else out = out nc
                 i++
               } else if (c == "\"") {

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -2770,6 +2770,37 @@ MOCK_INNER
   [[ "$reason" != *"REJECT"* ]]
 }
 
+# json: agy's real backend HTML-safe-escapes < > & inside the "response" string
+# value as < > & (Go encoding/json default, verified against
+# production output). Regression for a bug where these were NOT among the awk
+# unescaper's handled cases, silently corrupting the first-line verdict tag
+# into literal "u003cverdictu003e..." text and forcing every agy call to fall
+# back to CONCERNS regardless of the engine's real verdict.
+#
+# The JSON body is built into a shell VAR and emitted via `printf '%s' "$VAR"`
+# — NOT inlined into printf's format string — because bash's printf builtin
+# itself decodes \uHHHH escapes found in the FORMAT string (verified: it
+# would silently turn < back into a literal "<" before agy's mock even
+# runs), which would make the mock stop reproducing the real bug.
+@test "json: \\u003c/\\u003e/\\u0026-escaped verdict tag (agy's real HTML-safe JSON) → APPROVE, not corrupted-to-CONCERNS" {
+  cat > "${MOCK_BIN}/agy" <<'MOCK_INNER'
+#!/bin/bash
+printf '%s\n' "$*" > "$(dirname "$0")/../.agy-args-agy"
+BODY='{"conversation_id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"SUCCESS","response":"\u003cverdict\u003eAPPROVE\u003c/verdict\u003e\nA \u0026 B look fine.","usage":{"input_tokens":1,"total_tokens":2}}'
+printf '%s\n' "$BODY"
+MOCK_INNER
+  chmod +x "${MOCK_BIN}/agy"
+  INPUT=$(build_input)
+  run_hook
+  assert_ack_approve_json
+  local reason
+  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+  # The unescaped review body must reach the user cleanly — no leftover
+  # "u003c"-style mangling, and the escaped "&" must decode too.
+  [[ "$reason" == *"A & B look fine."* ]]
+  [[ "$reason" != *"u003c"* ]]
+}
+
 # ttl: new default 600 — degraded file aged 700s (> 600) → expired, agy called
 @test "ttl: default 600 — 700s-old degrade file treated as expired (agy invoked)" {
   create_degraded_file 700   # older than new 600 default

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -2770,34 +2770,49 @@ MOCK_INNER
   [[ "$reason" != *"REJECT"* ]]
 }
 
-# json: agy's real backend HTML-safe-escapes < > & inside the "response" string
-# value as < > & (Go encoding/json default, verified against
+# json: agy's real backend HTML-safe-escapes the "response" string value's
+# angle brackets and ampersand (Go encoding/json default, verified against
 # production output). Regression for a bug where these were NOT among the awk
 # unescaper's handled cases, silently corrupting the first-line verdict tag
-# into literal "u003cverdictu003e..." text and forcing every agy call to fall
-# back to CONCERNS regardless of the engine's real verdict.
-#
-# The JSON body is built into a shell VAR and emitted via `printf '%s' "$VAR"`
-# — NOT inlined into printf's format string — because bash's printf builtin
-# itself decodes \uHHHH escapes found in the FORMAT string (verified: it
-# would silently turn < back into a literal "<" before agy's mock even
-# runs), which would make the mock stop reproducing the real bug.
-@test "json: \\u003c/\\u003e/\\u0026-escaped verdict tag (agy's real HTML-safe JSON) → APPROVE, not corrupted-to-CONCERNS" {
-  cat > "${MOCK_BIN}/agy" <<'MOCK_INNER'
-#!/bin/bash
-printf '%s\n' "$*" > "$(dirname "$0")/../.agy-args-agy"
-BODY='{"conversation_id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"SUCCESS","response":"\u003cverdict\u003eAPPROVE\u003c/verdict\u003e\nA \u0026 B look fine.","usage":{"input_tokens":1,"total_tokens":2}}'
-printf '%s\n' "$BODY"
-MOCK_INNER
-  chmod +x "${MOCK_BIN}/agy"
+# into mangled literal text and forcing every agy call to fall back to
+# CONCERNS regardless of the engine's real verdict. create_mock_engine itself
+# now performs this same HTML-safe escaping (test_helper/common-setup.bash),
+# so a plain fixture string round-trips through the real production shape
+# automatically -- no bespoke mock needed here.
+@test "json: HTML-safe-escaped verdict tag (agy's real JSON shape) -> APPROVE, not corrupted-to-CONCERNS" {
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+A & B look fine."
   INPUT=$(build_input)
   run_hook
   assert_ack_approve_json
   local reason
   reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
-  # The unescaped review body must reach the user cleanly — no leftover
+  # The unescaped review body must reach the user cleanly -- no leftover
   # "u003c"-style mangling, and the escaped "&" must decode too.
   [[ "$reason" == *"A & B look fine."* ]]
+  [[ "$reason" != *"u003c"* ]]
+}
+
+# json: same HTML-safe-escaped shape, but a REJECT verdict -- the
+# higher-stakes half of this bug. Before the fix, ANY verdict (not just
+# APPROVE) silently fell back to CONCERNS on agy, since the first-line tag
+# structure itself was corrupted regardless of which keyword it wrapped. A
+# confirmed-Critical REJECT getting silently downgraded to CONCERNS is worse
+# than a missed APPROVE: REJECT resets the negotiation-round counter and
+# forces Critical framing in front of the user; CONCERNS just burns a round
+# and can eventually auto-allow via the non-critical safety valve -- letting
+# a plan with a real Critical defect slip through.
+@test "json: HTML-safe-escaped verdict tag (agy's real JSON shape) -> REJECT, not silently downgraded to CONCERNS" {
+  create_mock_engine "agy" "<verdict>REJECT</verdict>
+[Critical] Data loss path & no rollback."
+  INPUT=$(build_input)
+  run_hook
+  assert_deny_json
+  local reason
+  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+  [[ "$reason" == *"REJECT"* ]]
+  [[ "$reason" != *"CONCERNS"* ]]
+  [[ "$reason" == *"Data loss path & no rollback."* ]]
   [[ "$reason" != *"u003c"* ]]
 }
 

--- a/plugins/plan-review/tests/test_helper/common-setup.bash
+++ b/plugins/plan-review/tests/test_helper/common-setup.bash
@@ -101,7 +101,12 @@ ENGINE_OUTPUT
 )
   # Escape backslash + double-quote for the JSON string; keep raw newlines
   # (agy's real JSON has unescaped newlines in "response" — that's the point).
-  _esc=\$(printf '%s' "\$_out" | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
+  # Also HTML-safe-escape < > & into < > & — agy's real
+  # backend (Go encoding/json default) always does this, so a fixture
+  # containing a literal "<verdict>" tag must round-trip through the same
+  # \u-escaped shape production traffic actually has, or this mock silently
+  # stops exercising the awk unescaper's \u handling.
+  _esc=\$(printf '%s' "\$_out" | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g; s/</\\\\u003c/g; s/>/\\\\u003e/g; s/\&/\\\\u0026/g')
   printf '{"conversation_id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"SUCCESS","response":"%s","usage":{"input_tokens":100,"total_tokens":200}}\n' "\$_esc"
 else
   cat << 'ENGINE_OUTPUT'
@@ -159,7 +164,7 @@ ENGINE_OUTPUT
 )
 case "\$*" in
   *"--output-format json"*)
-    _esc=\$(printf '%s' "\$_out" | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
+    _esc=\$(printf '%s' "\$_out" | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g; s/</\\\\u003c/g; s/>/\\\\u003e/g; s/\&/\\\\u0026/g')
     printf '{"conversation_id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"SUCCESS","response":"%s","usage":{"input_tokens":100,"total_tokens":200}}\n' "\$_esc" ;;
   *) printf '%s\n' "\$_out" ;;
 esac
@@ -203,7 +208,7 @@ ENGINE_OUTPUT
 )
 case "\$*" in
   *"--output-format json"*)
-    _esc=\$(printf '%s' "\$_out" | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
+    _esc=\$(printf '%s' "\$_out" | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g; s/</\\\\u003c/g; s/>/\\\\u003e/g; s/\&/\\\\u0026/g')
     printf '{"conversation_id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"SUCCESS","response":"%s","usage":{"input_tokens":100,"total_tokens":200}}\n' "\$_esc" ;;
   *) printf '%s\n' "\$_out" ;;
 esac


### PR DESCRIPTION
## Summary

- agy 后端（Go `encoding/json` HTML-safe 默认转义）把 `response` 字段里的 `<` `>` `&` 编码成 `<` `>` `&`，但 `plan-review.sh` 自造的 awk 反转义器只认 `\n \t \" \\ \r` 五种转义，遇到 `\u` 转义会把反斜杠吞掉、留下裸的 `u003c` 字面文本，导致 `<verdict>...</verdict>` 首行 tag 结构被破坏，下游正则永远匹配不到，静默兜底成 `CONCERNS`——不管引擎真实判断是什么。
- 用生产日志实测坐实：该 log 中全部 26 次 `agy-success` 无一例外落到 `verdict=CONCERNS`；REST 兜底路径走 `jq fromjson` 能正确解转义，`APPROVE`/`REJECT` 都能正常提取，问题只出在 agy 这条手撸解析路径上。
- 修复：awk 循环里补上对 `<` `>` `&`（Go html-safe 转义全集）及 ` `/` ` 的显式解码，未知 `\uXXXX` 保留字面反斜杠而非静默吞掉，避免以后出现同类隐性破坏。

## Test plan

- [x] 新增 bats 用例复现该场景（`json: </>/&-escaped verdict tag ...`）
- [x] `git stash` 验证：套用旧代码该用例必现失败（输出与用户原始复现内容一字不差），打补丁后转绿
- [x] 全量 `plugins/plan-review/tests/plan-review.bats` 172/172 通过，无回归
- [x] 版本号同步 bump：`plugin.json` + `marketplace.json` 1.3.0 → 1.3.1