### PR TITLE
feat(guardrails): 新增 guardrails plugin — code-size + git-push gate 整合

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,6 +59,17 @@
       "source": "./plugins/deep-research",
       "category": "research",
       "homepage": "https://github.com/WooDragon/cc-plugins"
+    },
+    {
+      "name": "guardrails",
+      "description": "Guardrail hooks — code size gate (informational) + git push protection (blocks direct push to main/master)",
+      "version": "1.0.0",
+      "author": {
+        "name": "WooDragon"
+      },
+      "source": "./plugins/guardrails",
+      "category": "development",
+      "homepage": "https://github.com/WooDragon/cc-plugins"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "guardrails",
-      "description": "Guardrail hooks — code size gate (informational) + git push protection (blocks direct push to main/master)",
+      "description": "Guardrail hooks — code size gate (informational) + git push guard (guards against accidental direct push to main/master)",
       "version": "1.0.0",
       "author": {
         "name": "WooDragon"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ WooDragon 的 Claude Code 插件 + 技能包 marketplace。
 | Plugin | doc-gate（1 skill + 3 hooks + 2 tools） | 文档编辑门禁 + 词法召回 |
 | Plugin | code-search（1 skill） | 代码搜索与符号导航方法论（纯 skill，零 hook） |
 | Plugin | deep-research（1 skill + 4 agents + 1 hook） | 7-Stage 深度研究管线 + 多模型采集引擎 + 引用验证门禁 |
+| Plugin | guardrails（2 hooks） | 代码规模提示（信息性）+ git push 防手滑（拦截误推 main/master，非防绕过安全边界） |
 
 ## 版本变更铁律
 

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guardrails",
-  "description": "Guardrail hooks — code size gate (informational) + git push protection (blocks direct push to main/master)",
+  "description": "Guardrail hooks — code size gate (informational) + git push guard (guards against accidental direct push to main/master)",
   "version": "1.0.0",
   "author": { "name": "WooDragon" }
 }

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "guardrails",
+  "description": "Guardrail hooks — code size gate (informational) + git push protection (blocks direct push to main/master)",
+  "version": "1.0.0",
+  "author": { "name": "WooDragon" }
+}

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -1,0 +1,58 @@
+# guardrails
+
+Two independent, fail-open guardrail hooks for Claude Code: an informational **code size gate** and a hard **git push protection** gate. Pure-hook plugin — no skills.
+
+## Installation
+
+```bash
+# From marketplace
+claude plugin add guardrails@WooDragon-cc-plugins
+```
+
+## Hooks
+
+### code-size.sh — `PostToolUse: Edit|Write` (10s timeout)
+
+After an Edit/Write lands on a whitelisted source file (`.py .ts .tsx .js .jsx .sh .go .rs .c .cpp .h .java .rb`), checks:
+
+- **Dual line-count threshold** — soft (default 500) / hard (default 2000) total lines.
+- **Single-function length** (ast-grep, degradable) — default 150 lines, supported for `.py/.go/.rs/.ts/.tsx/.js/.jsx`.
+
+Emits `additionalContext` only when the tier for a given file **increases** relative to a per-session watermark (never re-alerts at steady state; re-arms if the file shrinks back down and later regrows). Purely informational — never blocks, `_main` runs under a top-level `2>/dev/null || true` soft catch-all so any anomaly degrades to silent no-op.
+
+Environment variables:
+
+| Var | Default | Purpose |
+|---|---|---|
+| `CODE_SIZE_GATE_DISABLED` | `0` | kill switch (`1` disables) |
+| `CODE_SIZE_SOFT_LINES` | `500` | soft line-count threshold |
+| `CODE_SIZE_HARD_LINES` | `2000` | hard line-count threshold |
+| `CODE_SIZE_MAX_FN_LINES` | `150` | single-function length threshold |
+| `CODE_SIZE_GATE_DIR` | `/tmp/claude-reviews` | watermark marker directory |
+| `CODE_SIZE_GATE_STALE_MIN` | `120` | marker staleness (minutes) before cleanup |
+
+### git-push-guard.sh — `PreToolUse: Bash` (5s timeout)
+
+Blocks `git push` (and compound commands containing one, split on `&&`, `||`, `;`, newline) that target `main` or `master` — exact branch name, refspec (`:main`, `:refs/heads/main`), or `--all`/`--mirror`. On a hit: `exit 2` + explanatory `stderr`, hard-blocking the tool call. All other cases (parse ambiguity, missing fields, non-matching branch) fail open with `exit 0`.
+
+**Known limitation (v1.0.0): protected branch names are hard-coded to `main`/`master`.** Repositories using `trunk`, `develop`, or other default-branch conventions are **not currently protected** by this hook — pushes to those branches pass through untouched. Generalizing this to a configurable branch list (`PROTECTED_BRANCHES` env var) is a planned follow-up, not yet implemented.
+
+Bypass: `export ALLOW_PUSH_MAIN=1` (temporary, intended for genuine emergencies — not a standing override).
+
+## Shared library
+
+`scripts/_gate_common.sh` holds only three side-effect-free helpers shared by both scripts (jq presence probe, JSON field extraction, bypass-flag check). It intentionally does **not** unify top-level fallback behavior: `code-size.sh` is fully fail-open (`_main 2>/dev/null || true`), while `git-push-guard.sh` fail-opens on parse ambiguity but hard-blocks (`exit 2`) on a confirmed match — the two scripts' failure philosophies are opposite and must not be merged.
+
+## Testing
+
+```bash
+cd plugins/guardrails
+bats tests/code-size.bats tests/git-push-guard.bats            # default bash
+BATS_RUN_BASH=/bin/bash bats tests/code-size.bats tests/git-push-guard.bats  # bash 3.2 (macOS system bash)
+```
+
+Run against both bash 5.x (Homebrew) and bash 3.2 (macOS system `/bin/bash`) — the scripts avoid bash-4+-only syntax, but this is a known macOS pitfall worth re-checking on any future change.
+
+## TODO (future version)
+
+- Generalize `git-push-guard.sh`'s hard-coded `main`/`master` to a `PROTECTED_BRANCHES` environment variable, so repos with `trunk`/`develop`-style default branches are covered.

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -1,6 +1,6 @@
 # guardrails
 
-Two independent, fail-open guardrail hooks for Claude Code: an informational **code size gate** and a hard **git push protection** gate. Pure-hook plugin — no skills.
+Two independent, fail-open guardrail hooks for Claude Code: an informational **code size gate** and a **git push guard** that catches accidental direct pushes to `main`/`master`. Pure-hook plugin — no skills.
 
 ## Installation
 
@@ -33,11 +33,22 @@ Environment variables:
 
 ### git-push-guard.sh — `PreToolUse: Bash` (5s timeout)
 
-Blocks `git push` (and compound commands containing one, split on `&&`, `||`, `;`, newline) that target `main` or `master` — exact branch name, refspec (`:main`, `:refs/heads/main`), or `--all`/`--mirror`. On a hit: `exit 2` + explanatory `stderr`, hard-blocking the tool call. All other cases (parse ambiguity, missing fields, non-matching branch) fail open with `exit 0`.
+Guards against `git push` (and compound commands containing one, split on `&&`, `||`, `;`, newline) that target `main` or `master` — exact branch name (bare, `+`-prefixed force shorthand, or full `refs/heads/` path), refspec (`:main`, `:refs/heads/main`), or `--all`/`--mirror`. On a hit: `exit 2` + explanatory `stderr`, blocking that tool call. All other cases (parse ambiguity, missing fields, non-matching branch) fail open with `exit 0`.
 
-**Known limitation (v1.0.0): protected branch names are hard-coded to `main`/`master`.** Repositories using `trunk`, `develop`, or other default-branch conventions are **not currently protected** by this hook — pushes to those branches pass through untouched. Generalizing this to a configurable branch list (`PROTECTED_BRANCHES` env var) is a planned follow-up, not yet implemented.
+This is a **slip-catcher, not a security boundary** — it is pattern-matching over the literal command text, not a real shell parser, so it stops the common accidental-push shapes without attempting to be adversarially unevadable. See "Known limitations" below for what it does not cover.
 
 Bypass: `export ALLOW_PUSH_MAIN=1` (temporary, intended for genuine emergencies — not a standing override).
+
+**Known limitations (guards against slips, not against deliberate evasion).** These are known, accepted gaps — not yet implemented — tracked in [#118](https://github.com/WooDragon/cc-plugins/issues/118):
+
+- **Hard-coded protected branches.** Only `main`/`master` are recognized. Repos using `trunk`, `develop`, or other default-branch conventions are **not protected** — pushes to those branches pass through untouched. Planned fix: a configurable `PROTECTED_BRANCHES` env var.
+- **Alternate git invocations bypass detection entirely**, since the hook only pattern-matches the literal command string:
+  - Full binary path — `/usr/bin/git push origin main`
+  - `sudo -E git push origin main` (only bare `sudo git` is recognized)
+  - `env git push origin main`
+  - `GIT_DIR=... git push origin main` (env-var prefix before `git`)
+  - Nested shells — `bash -c 'git push origin main'`
+- **False positive**: a remote literally named `main` (e.g. `git push main HEAD:feature`) is not distinguished from the `main` *branch* and may be flagged even though no protected branch is being pushed to.
 
 ## Shared library
 
@@ -55,4 +66,4 @@ Run against both bash 5.x (Homebrew) and bash 3.2 (macOS system `/bin/bash`) —
 
 ## TODO (future version)
 
-- Generalize `git-push-guard.sh`'s hard-coded `main`/`master` to a `PROTECTED_BRANCHES` environment variable, so repos with `trunk`/`develop`-style default branches are covered.
+See "Known limitations" above and [#118](https://github.com/WooDragon/cc-plugins/issues/118) for the tracked follow-up work (evasion-vector hardening, `PROTECTED_BRANCHES` generalization).

--- a/plugins/guardrails/hooks/hooks.json
+++ b/plugins/guardrails/hooks/hooks.json
@@ -1,0 +1,29 @@
+{
+  "description": "Guardrails: code-size informational gate (PostToolUse) + git-push protection (PreToolUse)",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/code-size.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/git-push-guard.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/guardrails/hooks/hooks.json
+++ b/plugins/guardrails/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Guardrails: code-size informational gate (PostToolUse) + git-push protection (PreToolUse)",
+  "description": "Guardrails: code-size informational gate (PostToolUse) + git-push guard against accidental push to main/master (PreToolUse)",
   "hooks": {
     "PostToolUse": [
       {

--- a/plugins/guardrails/scripts/_gate_common.sh
+++ b/plugins/guardrails/scripts/_gate_common.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# guardrails 包内共享库 — code-size.sh / git-push-guard.sh 共享的无副作用纯函数。
+#
+# 只抽两个 hook 之间真正重复的输入解析/防御样板（jq 探测、字段提取、bypass
+# 开关判定）。绝不抽顶层兜底：code-size 用 `_main 2>/dev/null || true` 软兜底
+# 全吞，git-push 用逐步 `exit 0` + 命中 `exit 2` 硬阻断，两者 fail-open 哲学
+# 相反，合并顶层兜底会破坏 git-push 的阻断语义。
+
+# _gate_require_jq — 探测 jq 是否可用。只返回状态码，调用方自行决定
+# return 还是 exit（不代为退出）。
+_gate_require_jq() {
+  command -v jq >/dev/null 2>&1
+}
+
+# _gate_field <json> <jq-expr> — 提取字段，失败（含 JSON 解析失败）时状态码非零。
+# 位置参数用双引号，避免把 jq 表达式字面量化。
+_gate_field() {
+  jq -r "$2" <<< "$1" 2>/dev/null
+}
+
+# _gate_bypass_on <VAR_NAME> — 间接展开检查同名环境变量是否等于 "1"。
+# $1 是变量名字符串，${!1} 取其值；未设置时按 "0" 处理。
+_gate_bypass_on() {
+  [ "${!1:-0}" = "1" ]
+}

--- a/plugins/guardrails/scripts/code-size.sh
+++ b/plugins/guardrails/scripts/code-size.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# PostToolUse:Edit/Write hook — Code size gate (informational, non-blocking).
+#
+# After Edit/Write on a source file, checks total line count (dual threshold)
+# and single-function length (ast-grep, degradable) against watermarked state.
+# Only alerts when the current tier is HIGHER than last time for this file in
+# this session — never re-alerts at a steady state, but re-arms if the file
+# shrinks back down (tier drops) and later grows again. Fail-open on ALL
+# anomalies: missing tools, parse errors, unwritable dirs all degrade to
+# silent no-op, never to a hard failure.
+#
+# Environment variables:
+#   CODE_SIZE_GATE_DISABLED=1     — kill switch
+#   CODE_SIZE_SOFT_LINES          — soft line-count threshold (default: 500)
+#   CODE_SIZE_HARD_LINES          — hard line-count threshold (default: 2000)
+#   CODE_SIZE_MAX_FN_LINES        — single-function length threshold (default: 150)
+#   CODE_SIZE_GATE_DIR            — marker directory (default: /tmp/claude-reviews)
+#   CODE_SIZE_GATE_STALE_MIN      — marker stale threshold minutes (default: 120)
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_gate_common.sh"
+
+# Tier → number, for watermark comparison. NONE is shared (0) across both
+# dimensions; SOFT/HARD (file-size dimension) and HIGH (function-length
+# dimension) never get compared against each other, so reusing "1" for both
+# SOFT and HIGH is safe.
+_tier_num() {
+  case "$1" in
+    HARD) printf '2' ;;
+    SOFT) printf '1' ;;
+    HIGH) printf '1' ;;
+    *) printf '0' ;;
+  esac
+}
+
+_main() {
+  INPUT=$(cat)
+
+  # Kill switch (frontmost)
+  _gate_bypass_on CODE_SIZE_GATE_DISABLED && return
+
+  # Preconditions
+  _gate_require_jq || return
+
+  # Input extract
+  TOOL_NAME=$(_gate_field "$INPUT" '.tool_name // ""') || return
+  SESSION_ID=$(_gate_field "$INPUT" '.session_id // ""') || return
+  [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ] || return
+  [ -n "$SESSION_ID" ] || return
+
+  # file_path is the field Edit/Write carry — the only tools this hook matches
+  # (hooks.json matcher is "Edit|Write"). NOTE: a real NotebookEdit call is
+  # already rejected by the tool_name gate above, so notebook_path here is NOT
+  # a NotebookEdit code path — it is only a cheap fallback for the odd case of
+  # an Edit/Write payload carrying notebook_path instead of file_path. Never
+  # target_file (that is a Cursor field, not Claude Code).
+  FILE_PATH=$(_gate_field "$INPUT" '.tool_input.file_path // .tool_input.notebook_path // ""') || return
+  [ -n "$FILE_PATH" ] || return
+
+  CWD=$(_gate_field "$INPUT" '.cwd // ""') || return
+
+  # Resolve to absolute path (relative → via payload cwd)
+  if [ -n "$CWD" ] && [ "${FILE_PATH:0:1}" != "/" ]; then
+    ABS_PATH="${CWD%/}/${FILE_PATH}"
+  else
+    ABS_PATH="$FILE_PATH"
+  fi
+
+  # PostToolUse fires after the write lands — file must exist on disk.
+  [ -f "$ABS_PATH" ] || return
+
+  BASENAME="${ABS_PATH##*/}"
+
+  # Source-suffix whitelist — everything else is silently out of scope.
+  case "$BASENAME" in
+    *.py|*.ts|*.tsx|*.js|*.jsx|*.sh|*.go|*.rs|*.c|*.cpp|*.h|*.java|*.rb) ;;
+    *) return ;;
+  esac
+
+  # ---- Main criterion: dual-threshold line count (wc -l never fails) ----
+  SOFT="${CODE_SIZE_SOFT_LINES:-500}"
+  HARD="${CODE_SIZE_HARD_LINES:-2000}"
+
+  LINES=$(wc -l < "$ABS_PATH" 2>/dev/null) || LINES=0
+  LINES=$(printf '%d' "$LINES" 2>/dev/null) || LINES=0
+
+  if [ "$LINES" -gt "$HARD" ]; then
+    FILE_TIER="HARD"
+  elif [ "$LINES" -gt "$SOFT" ]; then
+    FILE_TIER="SOFT"
+  else
+    FILE_TIER="NONE"
+  fi
+
+  # ---- Structural signal: single-function length (ast-grep, degradable) ----
+  # kind map: extension → "language|rule". Split on first "|" below.
+  # Deliberately no big registry — six languages, inline case is enough.
+  MAXFN="${CODE_SIZE_MAX_FN_LINES:-150}"
+  FN_TIER="NONE"
+  MAX_FN_LEN=0
+  MAX_FN_START=0
+
+  AST_SPEC=""
+  case "$BASENAME" in
+    *.py) AST_SPEC='python|{kind: function_definition}' ;;
+    *.go) AST_SPEC='go|{kind: function_declaration}' ;;
+    *.rs) AST_SPEC='rust|{kind: function_item}' ;;
+    *.tsx) AST_SPEC='tsx|{any: [{kind: function_declaration}, {kind: arrow_function}, {kind: method_definition}]}' ;;
+    *.ts) AST_SPEC='typescript|{any: [{kind: function_declaration}, {kind: arrow_function}, {kind: method_definition}]}' ;;
+    *.js|*.jsx) AST_SPEC='javascript|{any: [{kind: function_declaration}, {kind: arrow_function}, {kind: method_definition}]}' ;;
+    # .sh/.c/.cpp/.h/.java/.rb intentionally left out of the kind map — no
+    # single-function structural signal for them yet; line-count tier still
+    # applies via the dual-threshold check above. Graceful skip, not an error.
+  esac
+
+  if [ -n "$AST_SPEC" ] && command -v ast-grep >/dev/null 2>&1; then
+    AST_LANG="${AST_SPEC%%|*}"
+    AST_RULE="${AST_SPEC#*|}"
+    AST_JSON=$(ast-grep scan --json --inline-rules "{id: fn-len, language: ${AST_LANG}, rule: ${AST_RULE}}" "$ABS_PATH" 2>/dev/null) || AST_JSON=""
+    if [ -n "$AST_JSON" ]; then
+      FN_COMBINED=$(printf '%s' "$AST_JSON" | jq -r '
+        [.[] | {len: (.range.end.line - .range.start.line + 1), start: (.range.start.line + 1)}]
+        | (sort_by(.len) | last) // {len:0, start:0}
+        | "\(.len) \(.start)"
+      ' 2>/dev/null) || FN_COMBINED=""
+      if [ -n "$FN_COMBINED" ]; then
+        read -r MAX_FN_LEN MAX_FN_START <<< "$FN_COMBINED"
+      fi
+    fi
+  fi
+
+  # Double-safety: clamp to clean non-negative integers no matter what leaked
+  # through (empty read, non-numeric jq artifact, etc). Fail-open, not fail-loud.
+  case "${MAX_FN_LEN:-}" in '' | *[!0-9]*) MAX_FN_LEN=0 ;; esac
+  case "${MAX_FN_START:-}" in '' | *[!0-9]*) MAX_FN_START=0 ;; esac
+
+  if [ "$MAX_FN_LEN" -gt "$MAXFN" ]; then
+    FN_TIER="HIGH"
+  fi
+
+  # ---- Watermark state machine (anti-spam) ----
+  GATE_DIR="${CODE_SIZE_GATE_DIR:-/tmp/claude-reviews}"
+  STALE_MIN="${CODE_SIZE_GATE_STALE_MIN:-120}"
+
+  # /tmp is volatile (cleared on reboot) — create unconditionally before any
+  # write or find, or a cold-start missing dir silently defeats the whole
+  # watermark and every run re-alerts.
+  mkdir -p "$GATE_DIR" 2>/dev/null || true
+
+  SAFE_SESSION_ID="${SESSION_ID//\//_}"
+  # Hash the absolute PATH only, never file content — content changes on
+  # every edit by definition, which would make the marker useless as a
+  # watermark. Pure hash (awk field 1), not raw shasum output (which trails
+  # a "  -" that would corrupt the marker filename).
+  PATH_HASH=$(printf '%s' "$ABS_PATH" | shasum -a 256 2>/dev/null | awk '{print $1}') || PATH_HASH=""
+  [ -n "$PATH_HASH" ] || return
+
+  # .code-size- prefix keeps this namespace distinct from doc-gate's
+  # .skill-gate-*/.recall-gate-* markers sharing the same directory.
+  MARKER="$GATE_DIR/.code-size-${SAFE_SESSION_ID}_${PATH_HASH}"
+
+  # Stale cleanup — scoped strictly to our own prefix so doc-gate markers
+  # are never touched by this hook.
+  find "$GATE_DIR" -maxdepth 1 -name '.code-size-*' -mmin +"$STALE_MIN" -delete 2>/dev/null || true
+
+  PREV_FILE_TIER="NONE"
+  PREV_FN_TIER="NONE"
+  if [ -f "$MARKER" ]; then
+    V=$(grep '^FILE_TIER=' "$MARKER" 2>/dev/null | cut -d= -f2) && [ -n "$V" ] && PREV_FILE_TIER="$V"
+    V=$(grep '^FN_TIER=' "$MARKER" 2>/dev/null | cut -d= -f2) && [ -n "$V" ] && PREV_FN_TIER="$V"
+  fi
+
+  ALERT_FILE=0
+  if [ "$(_tier_num "$FILE_TIER")" -gt "$(_tier_num "$PREV_FILE_TIER")" ]; then
+    ALERT_FILE=1
+  fi
+  ALERT_FN=0
+  if [ "$(_tier_num "$FN_TIER")" -gt "$(_tier_num "$PREV_FN_TIER")" ]; then
+    ALERT_FN=1
+  fi
+
+  # Marker MUST be rewritten unconditionally, every run, including a
+  # downgrade to NONE — never gated behind the alert decision, and never an
+  # early-return before this point once we've committed to a real file.
+  # Otherwise a file that shrinks from HARD back to NONE never re-arms: the
+  # stale HARD watermark stays forever and the file could regrow all the way
+  # past HARD again without ever alerting.
+  GATE_DIR_WRITABLE=0
+  [ -w "$GATE_DIR" ] && GATE_DIR_WRITABLE=1
+  if [ "$GATE_DIR_WRITABLE" = "1" ]; then
+    {
+      printf 'FILE_TIER=%s\n' "$FILE_TIER"
+      printf 'FN_TIER=%s\n' "$FN_TIER"
+    } > "$MARKER" 2>/dev/null || true
+  fi
+
+  # Nothing crossed a new watermark → stay silent (marker already updated above).
+  if [ "$ALERT_FILE" != "1" ] && [ "$ALERT_FN" != "1" ]; then
+    return
+  fi
+
+  # ---- Compose alert (additionalContext, not decision:block — the write
+  # already landed, PostToolUse cannot undo it) ----
+  MSG="代码规模提示："
+
+  if [ "$ALERT_FILE" = "1" ]; then
+    if [ "$FILE_TIER" = "HARD" ]; then
+      MSG="${MSG}当前文件 ${LINES} 行，超过强提醒阈值 ${HARD}（Claude Code Read 工具在 2000 行截断，超过后读取会降级为 PARTIAL view）。"
+    else
+      MSG="${MSG}当前文件 ${LINES} 行，超过提醒阈值 ${SOFT}。"
+    fi
+  fi
+
+  if [ "$ALERT_FN" = "1" ]; then
+    MSG="${MSG}文件含一个 ${MAX_FN_LEN} 行的超长函数（起于第 ${MAX_FN_START} 行）。"
+  fi
+
+  MSG="${MSG}建议考虑按职责拆分。"
+
+  MSG_JSON=$(printf '%s' "$MSG" | jq -Rs .) || return
+  printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":%s}}' "$MSG_JSON"
+}
+
+_main 2>/dev/null || true

--- a/plugins/guardrails/scripts/git-push-guard.sh
+++ b/plugins/guardrails/scripts/git-push-guard.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# PreToolUse hook (Bash): block git push to main/master branches.
+# PreToolUse hook (Bash): guards against accidental direct push to
+# main/master branches (a slip-catcher, not a hard security boundary —
+# see README "Known limitations" for evasion vectors this does not cover).
 #
 # Fail-open: parse errors, missing fields, or ambiguous commands pass through.
 # Temporary bypass: export ALLOW_PUSH_MAIN=1
@@ -22,7 +24,7 @@ COMMAND=$(_gate_field "$INPUT" '.tool_input.command // empty') || exit 0
 [ -z "$COMMAND" ] && exit 0
 [[ "$COMMAND" != *"push"* ]] && exit 0
 
-# Split compound command into sub-statements on &&, ||, ;, |, newline
+# Split compound command into sub-statements on &&, ||, ;, newline
 # then check each for git push to main/master
 check_push_target() {
   local stmt="$1"
@@ -32,26 +34,39 @@ check_push_target() {
 
   # Must contain "git" in command position followed (eventually) by "push"
   # Allow global options between git and push: git -C path push, git -c k=v push
-  if ! grep -Eq '(^|sudo\s+)git(\s+(-[a-zA-Z][^ ]*|[^ -][^ ]*))*\s+push' <<< "$stmt"; then
+  #
+  # NOTE: [[:space:]] (not \s) throughout this function — \s is a GNU
+  # grep/sed extension. macOS ships BSD grep/sed as /usr/bin/{grep,sed},
+  # which do NOT support \s: it silently fails to match as a metachar,
+  # degrading the sed extraction below to a no-op (push_args ends up as
+  # the whole original statement instead of just the push arguments).
+  if ! grep -Eq '(^|sudo[[:space:]]+)git([[:space:]]+(-[a-zA-Z][^ ]*|[^ -][^ ]*))*[[:space:]]+push' <<< "$stmt"; then
     return 1
   fi
 
   # Extract everything after "push" (the push arguments)
   local push_args
-  push_args=$(sed -E 's/^.*git(\s+(-[a-zA-Z][^ ]*|[^ -][^ ]*))*\s+push//' <<< "$stmt")
+  push_args=$(sed -E 's/^.*git([[:space:]]+(-[a-zA-Z][^ ]*|[^ -][^ ]*))*[[:space:]]+push//' <<< "$stmt")
+
+  # Strip quote characters so quoted branch names (e.g. "main", 'main')
+  # line up with the same bare word-boundary checks below.
+  push_args=$(printf '%s' "$push_args" | tr -d "\"'")
 
   # --all / --mirror → blocks all branches including main
-  if grep -Eq '(^|\s)--(all|mirror)(\s|$)' <<< "$push_args"; then
+  if grep -Eq '(^|[[:space:]])--(all|mirror)([[:space:]]|$)' <<< "$push_args"; then
     return 0
   fi
 
-  # Check for main/master as exact branch name or in refspec
-  # Word-boundary: preceded by space/start, followed by space/end/colon
+  # Check for main/master as exact branch name (optionally prefixed with
+  # the force-push shorthand "+" and/or the full "refs/heads/" ref path)
+  # or as a colon-refspec destination.
+  # Word-boundary: preceded by space/start(/plus), followed by space/end
+  # Bare/prefixed: main, +main, refs/heads/main, +refs/heads/main
   # Refspec: :main, :refs/heads/main, :master, :refs/heads/master
-  if grep -Eq '(^|\s)(main|master)(\s|$)' <<< "$push_args"; then
+  if grep -Eq '(^|[[:space:]])\+?(refs/heads/)?(main|master)([[:space:]]|$)' <<< "$push_args"; then
     return 0
   fi
-  if grep -Eq ':(refs/heads/)?(main|master)(\s|$)' <<< "$push_args"; then
+  if grep -Eq ':(refs/heads/)?(main|master)([[:space:]]|$)' <<< "$push_args"; then
     return 0
   fi
 

--- a/plugins/guardrails/scripts/git-push-guard.sh
+++ b/plugins/guardrails/scripts/git-push-guard.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Bash): block git push to main/master branches.
+#
+# Fail-open: parse errors, missing fields, or ambiguous commands pass through.
+# Temporary bypass: export ALLOW_PUSH_MAIN=1
+
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_gate_common.sh"
+
+INPUT=$(cat)
+[ -z "$INPUT" ] && exit 0
+
+# Fast path: no git mention at all
+[[ "$INPUT" != *"git"* ]] && exit 0
+[[ "$INPUT" != *"push"* ]] && exit 0
+
+# Bypass switch
+_gate_bypass_on ALLOW_PUSH_MAIN && exit 0
+
+COMMAND=$(_gate_field "$INPUT" '.tool_input.command // empty') || exit 0
+[ -z "$COMMAND" ] && exit 0
+[[ "$COMMAND" != *"push"* ]] && exit 0
+
+# Split compound command into sub-statements on &&, ||, ;, |, newline
+# then check each for git push to main/master
+check_push_target() {
+  local stmt="$1"
+
+  # Strip leading whitespace
+  stmt="${stmt#"${stmt%%[![:space:]]*}"}"
+
+  # Must contain "git" in command position followed (eventually) by "push"
+  # Allow global options between git and push: git -C path push, git -c k=v push
+  if ! grep -Eq '(^|sudo\s+)git(\s+(-[a-zA-Z][^ ]*|[^ -][^ ]*))*\s+push' <<< "$stmt"; then
+    return 1
+  fi
+
+  # Extract everything after "push" (the push arguments)
+  local push_args
+  push_args=$(sed -E 's/^.*git(\s+(-[a-zA-Z][^ ]*|[^ -][^ ]*))*\s+push//' <<< "$stmt")
+
+  # --all / --mirror → blocks all branches including main
+  if grep -Eq '(^|\s)--(all|mirror)(\s|$)' <<< "$push_args"; then
+    return 0
+  fi
+
+  # Check for main/master as exact branch name or in refspec
+  # Word-boundary: preceded by space/start, followed by space/end/colon
+  # Refspec: :main, :refs/heads/main, :master, :refs/heads/master
+  if grep -Eq '(^|\s)(main|master)(\s|$)' <<< "$push_args"; then
+    return 0
+  fi
+  if grep -Eq ':(refs/heads/)?(main|master)(\s|$)' <<< "$push_args"; then
+    return 0
+  fi
+
+  return 1
+}
+
+# Split on ;, &&, ||, newline — process each sub-statement
+while IFS= read -r stmt; do
+  if [ -n "$stmt" ] && check_push_target "$stmt"; then
+    printf '[git-push-guard] 禁止直接 push 到 main/master。请推送到功能分支并提 PR。\n' >&2
+    printf '[git-push-guard] 无特殊情况不得绕过此检查。紧急放行: export ALLOW_PUSH_MAIN=1\n' >&2
+    exit 2
+  fi
+done < <(printf '%s\n' "$COMMAND" | sed -E 's/(\&\&|\|\||;)/\n/g')
+
+exit 0

--- a/plugins/guardrails/tests/code-size.bats
+++ b/plugins/guardrails/tests/code-size.bats
@@ -1,0 +1,530 @@
+#!/usr/bin/env bats
+# BDD tests for post-code-size.sh (PostToolUse:Edit/Write hook)
+#
+# Covers: stdin parsing, suffix whitelist, dual line-count thresholds,
+# ast-grep structural signal (real, unmocked), graceful degradation,
+# fail-open paths, kill switch, and the watermark anti-spam/re-arm state
+# machine.
+
+setup() {
+  load 'test_helper/common-setup'
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+# ============================================================
+# stdin parsing
+# ============================================================
+
+@test "parse: file_path extracted from tool_input.file_path" {
+  make_lines_file "$SRC_DIR/a.py" 10
+  INPUT=$(build_edit_input file_path="$SRC_DIR/a.py")
+  run_gate
+  assert_silent
+}
+
+@test "parse: notebook_path used as fallback for NotebookEdit-shaped payload" {
+  # tool_name gate only allows Edit/Write, so a NotebookEdit-shaped payload
+  # (tool_name=NotebookEdit) is rejected before the notebook_path fallback is
+  # ever reached — see "dead code" note in final report.
+  make_lines_file "$SRC_DIR/nb_src.py" 10
+  INPUT=$(build_input tool_name=NotebookEdit notebook_path="$SRC_DIR/nb_src.py" session_id=s1)
+  run_gate
+  assert_silent
+}
+
+@test "parse: notebook_path fallback IS reachable when tool_name is Edit" {
+  # Same fallback expression, exercised through the one path that can reach
+  # it: an Edit call whose tool_input has notebook_path but no file_path
+  # (jq's // treats missing file_path as null, falls through).
+  make_lines_file "$SRC_DIR/b.py" 501
+  INPUT=$(jq -n --arg np "$SRC_DIR/b.py" '{tool_name:"Edit", session_id:"s1", cwd:"", tool_input:{notebook_path:$np}}')
+  run_gate
+  assert_alert_contains "超过提醒阈值 500"
+}
+
+@test "parse: empty file_path → silent (jq // does not fall through on empty string)" {
+  INPUT=$(build_edit_input file_path=)
+  run_gate
+  assert_silent
+}
+
+@test "parse: relative file_path resolved via payload cwd" {
+  make_lines_file "$SRC_DIR/rel.py" 501
+  INPUT=$(build_edit_input file_path=rel.py cwd="$SRC_DIR")
+  run_gate
+  assert_alert_contains "超过提醒阈值 500"
+}
+
+@test "parse: nonexistent file on disk → silent (PostToolUse requires file to exist)" {
+  INPUT=$(build_edit_input file_path="$SRC_DIR/does-not-exist.py")
+  run_gate
+  assert_silent
+}
+
+# ============================================================
+# Suffix whitelist
+# ============================================================
+
+@test "whitelist: .py file → in scope" {
+  make_lines_file "$SRC_DIR/f.py" 501
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_alert_contains "超过提醒阈值 500"
+}
+
+@test "whitelist: .json file → out of scope, silent" {
+  make_lines_file "$SRC_DIR/f.json" 501
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.json")
+  run_gate
+  assert_silent
+}
+
+@test "whitelist: .md file → out of scope, silent" {
+  make_lines_file "$SRC_DIR/f.md" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.md")
+  run_gate
+  assert_silent
+}
+
+@test "whitelist: file without extension → out of scope, silent" {
+  make_lines_file "$SRC_DIR/Makefile" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/Makefile")
+  run_gate
+  assert_silent
+}
+
+# ============================================================
+# Dual-threshold line count
+# ============================================================
+
+@test "lines: 499 lines (< 500 soft) → silent" {
+  make_lines_file "$SRC_DIR/f.py" 499
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_silent
+}
+
+@test "lines: exactly 500 lines (boundary, not > 500) → silent" {
+  make_lines_file "$SRC_DIR/f.py" 500
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_silent
+}
+
+@test "lines: 501 lines (SOFT tier) → alert with soft wording" {
+  make_lines_file "$SRC_DIR/f.py" 501
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_alert_contains "超过提醒阈值 500"
+}
+
+@test "lines: 1999 lines (still SOFT, below hard) → alert with soft wording, not hard" {
+  make_lines_file "$SRC_DIR/f.py" 1999
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_alert_contains "超过提醒阈值 500"
+  [[ "$HOOK_STDOUT" != *"PARTIAL view"* ]]
+}
+
+@test "lines: exactly 2000 lines (boundary, not > 2000) → SOFT, not HARD" {
+  make_lines_file "$SRC_DIR/f.py" 2000
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_alert_contains "超过提醒阈值 500"
+  [[ "$HOOK_STDOUT" != *"PARTIAL view"* ]]
+}
+
+@test "lines: 2001 lines (HARD tier) → alert with hard wording + PARTIAL view mention" {
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_alert_contains "超过强提醒阈值 2000"
+  assert_alert_contains "PARTIAL view"
+}
+
+@test "lines: custom thresholds via env vars respected" {
+  export CODE_SIZE_SOFT_LINES=10
+  export CODE_SIZE_HARD_LINES=20
+  make_lines_file "$SRC_DIR/f.py" 15
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_alert_contains "超过提醒阈值 10"
+}
+
+# ============================================================
+# Structural signal — real ast-grep, unmocked (most important: proves the
+# ast-grep invocation syntax is actually correct, not silently fail-open dead)
+# ============================================================
+
+@test "structural: 201-line function in a 201-line file (under soft line threshold) → HIGH fn alert fires" {
+  make_py_with_long_function "$SRC_DIR/longfn.py" 201 200
+  INPUT=$(build_edit_input file_path="$SRC_DIR/longfn.py")
+  run_gate
+  assert_alert_contains "超长函数"
+  assert_alert_contains "201 行"
+  # Must NOT contain the file-size wording — this run is fn-only.
+  [[ "$HOOK_STDOUT" != *"超过提醒阈值"* ]]
+}
+
+@test "structural: 150-line function (boundary, not > 150) → no fn alert" {
+  # make_py_with_long_function's function span is fn_body_lines + 1 (the
+  # `def` line plus the body) — fn_body=149 yields exactly a 150-line
+  # function, the boundary case.
+  make_py_with_long_function "$SRC_DIR/f.py" 150 149
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_silent
+}
+
+@test "structural: 151-line function (just over default 150 threshold) → fn alert fires" {
+  make_py_with_long_function "$SRC_DIR/f.py" 152 151
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_alert_contains "超长函数"
+}
+
+@test "structural: custom CODE_SIZE_MAX_FN_LINES respected" {
+  export CODE_SIZE_MAX_FN_LINES=20
+  make_py_with_long_function "$SRC_DIR/f.py" 30 25
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_alert_contains "超长函数"
+}
+
+@test "structural: short functions only → no fn alert even if file is long" {
+  # 501 lines of short (1-line-body) functions — line tier should fire,
+  # fn tier should not.
+  {
+    i=1
+    while [ "$i" -le 250 ]; do
+      printf 'def f_%d():\n    return %d\n\n' "$i" "$i"
+      i=$((i + 1))
+    done
+  } > "$SRC_DIR/manyshort.py"
+  INPUT=$(build_edit_input file_path="$SRC_DIR/manyshort.py")
+  run_gate
+  assert_alert_contains "超过提醒阈值 500"
+  [[ "$HOOK_STDOUT" != *"超长函数"* ]]
+}
+
+@test "structural: go function > 150 lines triggers HIGH" {
+  {
+    printf 'package main\n\nfunc longOne() int {\n'
+    i=1
+    while [ "$i" -le 155 ]; do printf '\tx := %d\n' "$i"; i=$((i + 1)); done
+    printf '\treturn 0\n}\n'
+  } > "$SRC_DIR/f.go"
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.go")
+  run_gate
+  assert_alert_contains "超长函数"
+}
+
+@test "structural: rust function > 150 lines triggers HIGH" {
+  {
+    printf 'fn long_one() -> i32 {\n'
+    i=1
+    while [ "$i" -le 155 ]; do printf '    let x%d = %d;\n' "$i" "$i"; i=$((i + 1)); done
+    printf '    0\n}\n'
+  } > "$SRC_DIR/f.rs"
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.rs")
+  run_gate
+  assert_alert_contains "超长函数"
+}
+
+@test "structural: typescript arrow function > 150 lines triggers HIGH" {
+  {
+    printf 'const longArrow = (): number => {\n'
+    i=1
+    while [ "$i" -le 155 ]; do printf '  const x%d = %d;\n' "$i" "$i"; i=$((i + 1)); done
+    printf '  return 0;\n};\n'
+  } > "$SRC_DIR/f.ts"
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.ts")
+  run_gate
+  assert_alert_contains "超长函数"
+}
+
+@test "structural: .sh file has no fn-length signal (not in ast-grep kind map) but line tier still applies" {
+  make_lines_file "$SRC_DIR/f.sh" 501
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.sh")
+  run_gate
+  assert_alert_contains "超过提醒阈值 500"
+  [[ "$HOOK_STDOUT" != *"超长函数"* ]]
+}
+
+@test "structural: both file-size AND fn-length alerts fire together, combined message" {
+  # total lines > hard threshold AND contains an oversized function
+  make_py_with_long_function "$SRC_DIR/big.py" 2001 200
+  INPUT=$(build_edit_input file_path="$SRC_DIR/big.py")
+  run_gate
+  assert_alert_contains "超过强提醒阈值 2000"
+  assert_alert_contains "超长函数"
+}
+
+# ============================================================
+# Graceful degradation — ast-grep absent, jq absent
+# ============================================================
+
+@test "degrade: ast-grep absent → line-count tier still works, no crash" {
+  make_lines_file "$SRC_DIR/f.py" 501
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  PATH="/usr/bin:/bin" BATS_RUN_BASH="/opt/homebrew/bin/bash" HOOK_SCRIPT="$HOOK_SCRIPT" run_gate
+  assert_alert_contains "超过提醒阈值 500"
+}
+
+@test "degrade: ast-grep absent → fn-length signal silently skipped (no crash, no fn alert)" {
+  make_py_with_long_function "$SRC_DIR/f.py" 201 200
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  PATH="/usr/bin:/bin" BATS_RUN_BASH="/opt/homebrew/bin/bash" HOOK_SCRIPT="$HOOK_SCRIPT" run_gate
+  assert_silent
+}
+
+@test "degrade: jq absent → silent allow, exit 0 (jq is a hard precondition)" {
+  local mock_bin="${TEST_TEMP_DIR}/nojq"
+  mkdir -p "$mock_bin"
+  # mktemp itself is needed by run_gate() for its stderr capture file, and
+  # bats' own machinery may shell out too — carry the whole core-utils set,
+  # just omit jq.
+  # dirname is required by the plugin's top-level `source _gate_common.sh`
+  # line (doc-gate-style shared-lib loading) — added during the guardrails
+  # migration; carry it here so this fixture keeps probing "jq absent" only,
+  # not "dirname absent too".
+  for tool in bash cat printf mkdir find grep cut wc shasum awk mktemp rm ast-grep dirname; do
+    local src
+    src=$(command -v "$tool" 2>/dev/null) || continue
+    ln -sf "$src" "$mock_bin/$tool"
+  done
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  PATH="$mock_bin" run_gate
+  assert_silent
+}
+
+# ============================================================
+# Fail-open — malformed input, wrong tool, missing fields
+# ============================================================
+
+@test "fail-open: empty stdin → silent, exit 0" {
+  run_gate_raw_stdin ""
+  assert_silent
+}
+
+@test "fail-open: corrupt JSON → silent, exit 0" {
+  run_gate_raw_stdin "not-json{{"
+  assert_silent
+}
+
+@test "fail-open: wrong tool_name (Bash) → silent" {
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(jq -n --arg fp "$SRC_DIR/f.py" '{tool_name:"Bash", session_id:"s1", cwd:"", tool_input:{file_path:$fp}}')
+  run_gate
+  assert_silent
+}
+
+@test "fail-open: wrong tool_name (Read) → silent" {
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(jq -n --arg fp "$SRC_DIR/f.py" '{tool_name:"Read", session_id:"s1", cwd:"", tool_input:{file_path:$fp}}')
+  run_gate
+  assert_silent
+}
+
+@test "fail-open: missing session_id → silent" {
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id=)
+  run_gate
+  assert_silent
+}
+
+@test "fail-open: missing tool_name field entirely → silent" {
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(jq -n --arg fp "$SRC_DIR/f.py" '{session_id:"s1", cwd:"", tool_input:{file_path:$fp}}')
+  run_gate
+  assert_silent
+}
+
+@test "fail-open: null tool_input → silent, no crash" {
+  INPUT='{"tool_name":"Edit","session_id":"s1","cwd":""}'
+  run_gate_raw_stdin "$INPUT"
+  assert_silent
+}
+
+# ============================================================
+# Kill switch
+# ============================================================
+
+@test "kill switch: CODE_SIZE_GATE_DISABLED=1 → silent even for a huge file" {
+  export CODE_SIZE_GATE_DISABLED=1
+  make_lines_file "$SRC_DIR/f.py" 5000
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_silent
+}
+
+@test "kill switch: CODE_SIZE_GATE_DISABLED=0 (explicit) → normal operation" {
+  export CODE_SIZE_GATE_DISABLED=0
+  make_lines_file "$SRC_DIR/f.py" 501
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_alert_contains "超过提醒阈值 500"
+}
+
+# ============================================================
+# Watermark anti-spam
+# ============================================================
+
+@test "watermark: first HARD crossing alerts" {
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id=wm1)
+  run_gate
+  assert_alert_contains "PARTIAL view"
+}
+
+@test "watermark: second run at same HARD tier → silent (no re-alert at steady state)" {
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id=wm2)
+  run_gate
+  assert_alert_contains "PARTIAL view"
+
+  make_lines_file "$SRC_DIR/f.py" 2050
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id=wm2)
+  run_gate
+  assert_silent
+}
+
+@test "watermark: SOFT then grows to HARD → alerts again (tier increased)" {
+  make_lines_file "$SRC_DIR/f.py" 501
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id=wm3)
+  run_gate
+  assert_alert_contains "超过提醒阈值 500"
+
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id=wm3)
+  run_gate
+  assert_alert_contains "PARTIAL view"
+}
+
+@test "watermark: different session_id for same file → independent state, both alert" {
+  make_lines_file "$SRC_DIR/f.py" 2001
+
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id=sessA)
+  run_gate
+  assert_alert_contains "PARTIAL view"
+
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id=sessB)
+  run_gate
+  assert_alert_contains "PARTIAL view"
+}
+
+@test "watermark: re-arm — HARD alerts, shrinks to NONE (silent), regrows to HARD → alerts again" {
+  local sess="rearm"
+
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id="$sess")
+  run_gate
+  assert_alert_contains "PARTIAL view"
+
+  make_lines_file "$SRC_DIR/f.py" 10
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id="$sess")
+  run_gate
+  assert_silent
+
+  local marker
+  marker=$(marker_path "$SRC_DIR/f.py" "$sess")
+  [ -f "$marker" ]
+  grep -q '^FILE_TIER=NONE$' "$marker"
+
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id="$sess")
+  run_gate
+  assert_alert_contains "PARTIAL view"
+}
+
+@test "watermark: fn-tier re-arm independent of file-tier — shrink fn, regrow fn re-alerts" {
+  local sess="fn-rearm"
+
+  make_py_with_long_function "$SRC_DIR/f.py" 201 200
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id="$sess")
+  run_gate
+  assert_alert_contains "超长函数"
+
+  # Shrink function back under threshold (file total stays under soft too)
+  make_py_with_long_function "$SRC_DIR/f.py" 60 5
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id="$sess")
+  run_gate
+  assert_silent
+
+  # Regrow the function past threshold again
+  make_py_with_long_function "$SRC_DIR/f.py" 201 200
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id="$sess")
+  run_gate
+  assert_alert_contains "超长函数"
+}
+
+@test "watermark: marker file uses .code-size- prefix, distinct from doc-gate markers" {
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id=prefix-test)
+  run_gate
+  local marker
+  marker=$(marker_path "$SRC_DIR/f.py" "prefix-test")
+  [ -f "$marker" ]
+  [[ "$(basename "$marker")" == .code-size-* ]]
+}
+
+@test "watermark: GATE_DIR not writable → silent allow, no crash" {
+  chmod 000 "$CODE_SIZE_GATE_DIR"
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py")
+  run_gate
+  assert_exit_zero
+  chmod 755 "$CODE_SIZE_GATE_DIR"
+}
+
+@test "watermark: stale marker (>120min) is cleaned up on next run" {
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id=stale-sess)
+  run_gate
+  local marker
+  marker=$(marker_path "$SRC_DIR/f.py" "stale-sess")
+  [ -f "$marker" ]
+
+  local old_time
+  if old_time=$(date -v -130M +%Y%m%d%H%M 2>/dev/null); then
+    touch -t "$old_time" "$marker"
+  else
+    touch -d "130 minutes ago" "$marker" 2>/dev/null || skip "cannot backdate on this platform"
+  fi
+
+  # A second, unrelated file triggers the stale sweep (find over GATE_DIR).
+  make_lines_file "$SRC_DIR/other.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/other.py" session_id=other-sess)
+  run_gate
+
+  [ ! -f "$marker" ]
+}
+
+@test "watermark: custom CODE_SIZE_GATE_STALE_MIN respected" {
+  make_lines_file "$SRC_DIR/f.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/f.py" session_id=stale-custom)
+  run_gate
+  local marker
+  marker=$(marker_path "$SRC_DIR/f.py" "stale-custom")
+  [ -f "$marker" ]
+
+  # Backdate by 15 minutes — should survive a 120min default but not a 10min custom.
+  local old_time
+  if old_time=$(date -v -15M +%Y%m%d%H%M 2>/dev/null); then
+    touch -t "$old_time" "$marker"
+  else
+    touch -d "15 minutes ago" "$marker" 2>/dev/null || skip "cannot backdate on this platform"
+  fi
+
+  export CODE_SIZE_GATE_STALE_MIN=10
+  make_lines_file "$SRC_DIR/other.py" 2001
+  INPUT=$(build_edit_input file_path="$SRC_DIR/other.py" session_id=other-sess2)
+  run_gate
+
+  [ ! -f "$marker" ]
+}

--- a/plugins/guardrails/tests/git-push-guard.bats
+++ b/plugins/guardrails/tests/git-push-guard.bats
@@ -62,6 +62,11 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "pass: git -C main push origin feature-x (push_args extraction must strip the git..push prefix, not leak the -C dir name into branch matching)" {
+  run_push_guard "$(mk_payload 'git -C main push origin feature-x')"
+  [ "$status" -eq 0 ]
+}
+
 # ============================================================
 # BLOCK cases
 # ============================================================
@@ -152,6 +157,36 @@ teardown() {
 
 @test "block: git -c key=val push origin main" {
   run_push_guard "$(mk_payload 'git -c http.sslVerify=false push origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push origin +main (force-push shorthand prefix)" {
+  run_push_guard "$(mk_payload 'git push origin +main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push origin +master (force-push shorthand prefix)" {
+  run_push_guard "$(mk_payload 'git push origin +master')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push origin refs/heads/main (full ref, no colon)" {
+  run_push_guard "$(mk_payload 'git push origin refs/heads/main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test 'block: git push origin "main" (double-quoted branch name)' {
+  run_push_guard "$(mk_payload 'git push origin "main"')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push origin 'main' (single-quoted branch name)" {
+  run_push_guard "$(mk_payload "git push origin 'main'")"
   [ "$status" -eq 2 ]
   [[ "$stderr" == *"git-push-guard"* ]]
 }

--- a/plugins/guardrails/tests/git-push-guard.bats
+++ b/plugins/guardrails/tests/git-push-guard.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+# BDD tests for git-push-guard.sh (PreToolUse:Bash hook)
+#
+# Converted from hooks/tests/test-pre-git-push-guard.sh (ad-hoc PASS/FAIL
+# counter script) to bats. Case set and expectations preserved 1:1.
+#
+# BLOCK:  git push to main/master, --all, --mirror, refspec, compound commands
+# PASS:   non-git, feature branches, bare push, main-prefix names, bypass env
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load 'test_helper/common-setup'
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+# ============================================================
+# PASS cases
+# ============================================================
+
+@test "pass: non-git command" {
+  run_push_guard "$(mk_payload 'npm install')"
+  [ "$status" -eq 0 ]
+}
+
+@test "pass: git status" {
+  run_push_guard "$(mk_payload 'git status')"
+  [ "$status" -eq 0 ]
+}
+
+@test "pass: git push origin feature-x" {
+  run_push_guard "$(mk_payload 'git push origin feature-x')"
+  [ "$status" -eq 0 ]
+}
+
+@test "pass: bare git push (fail-open)" {
+  run_push_guard "$(mk_payload 'git push')"
+  [ "$status" -eq 0 ]
+}
+
+@test "pass: git push origin (no branch)" {
+  run_push_guard "$(mk_payload 'git push origin')"
+  [ "$status" -eq 0 ]
+}
+
+@test "pass: git push origin main-backup (prefix, not exact branch)" {
+  run_push_guard "$(mk_payload 'git push origin main-backup')"
+  [ "$status" -eq 0 ]
+}
+
+@test "pass: git push origin maintain" {
+  run_push_guard "$(mk_payload 'git push origin maintain')"
+  [ "$status" -eq 0 ]
+}
+
+@test "pass: empty stdin" {
+  run_push_guard ""
+  [ "$status" -eq 0 ]
+}
+
+# ============================================================
+# BLOCK cases
+# ============================================================
+
+@test "block: git push origin main" {
+  run_push_guard "$(mk_payload 'git push origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push origin master" {
+  run_push_guard "$(mk_payload 'git push origin master')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push -u origin main" {
+  run_push_guard "$(mk_payload 'git push -u origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push --force origin main" {
+  run_push_guard "$(mk_payload 'git push --force origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push origin HEAD:main (refspec)" {
+  run_push_guard "$(mk_payload 'git push origin HEAD:main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push origin HEAD:refs/heads/main" {
+  run_push_guard "$(mk_payload 'git push origin HEAD:refs/heads/main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push origin HEAD:master" {
+  run_push_guard "$(mk_payload 'git push origin HEAD:master')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push origin feature main (multi)" {
+  run_push_guard "$(mk_payload 'git push origin feature main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push --all" {
+  run_push_guard "$(mk_payload 'git push --all')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push --mirror" {
+  run_push_guard "$(mk_payload 'git push --mirror')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git push origin --all" {
+  run_push_guard "$(mk_payload 'git push origin --all')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: compound with && — git add . && git push origin main" {
+  run_push_guard "$(mk_payload 'git add . && git push origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: compound with ; — cd proj; git push origin main" {
+  run_push_guard "$(mk_payload 'cd proj; git push origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git -C /path push origin main" {
+  run_push_guard "$(mk_payload 'git -C /tmp/repo push origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git -c key=val push origin main" {
+  run_push_guard "$(mk_payload 'git -c http.sslVerify=false push origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+# ============================================================
+# BYPASS case
+# ============================================================
+
+@test "bypass: ALLOW_PUSH_MAIN=1 allows push to main" {
+  run_push_guard "$(mk_payload 'git push origin main')" ALLOW_PUSH_MAIN=1
+  [ "$status" -eq 0 ]
+}

--- a/plugins/guardrails/tests/test_helper/common-setup.bash
+++ b/plugins/guardrails/tests/test_helper/common-setup.bash
@@ -1,0 +1,243 @@
+#!/bin/bash
+# Test infrastructure for guardrails plugin BDD tests (code-size.bats +
+# git-push-guard.bats). Pattern mirrors cc-plugins doc-gate test_helper
+# (mock/assert/setup-teardown style).
+
+HOOK_SCRIPT="${BATS_TEST_DIRNAME}/../scripts/code-size.sh"
+GIT_PUSH_SCRIPT="${BATS_TEST_DIRNAME}/../scripts/git-push-guard.sh"
+
+# --- Setup / Teardown ---
+
+common_setup() {
+  TEST_TEMP_DIR=$(mktemp -d)
+
+  export CODE_SIZE_GATE_DIR="${TEST_TEMP_DIR}/markers"
+  mkdir -p "$CODE_SIZE_GATE_DIR"
+
+  export CODE_SIZE_GATE_DISABLED="0"
+  export CODE_SIZE_GATE_STALE_MIN="120"
+  unset CODE_SIZE_SOFT_LINES
+  unset CODE_SIZE_HARD_LINES
+  unset CODE_SIZE_MAX_FN_LINES
+
+  # Scratch dir for generated source fixtures — cleaned by teardown.
+  SRC_DIR="${TEST_TEMP_DIR}/src"
+  mkdir -p "$SRC_DIR"
+
+  unset ALLOW_PUSH_MAIN
+}
+
+common_teardown() {
+  # Restore GATE_DIR perms in case a test chmod'd it 000 and failed before restore.
+  [ -n "${CODE_SIZE_GATE_DIR:-}" ] && chmod 755 "$CODE_SIZE_GATE_DIR" 2>/dev/null || true
+  rm -rf "$TEST_TEMP_DIR"
+}
+
+# --- Fixture Generation ---
+
+# make_lines_file <path> <line_count> — every line is a harmless python comment,
+# so line-count tier is exercised independently of the function-length signal.
+make_lines_file() {
+  local path="$1"
+  local count="$2"
+  : > "$path"
+  local i=1
+  while [ "$i" -le "$count" ]; do
+    printf '# line %d\n' "$i" >> "$path"
+    i=$((i + 1))
+  done
+}
+
+# make_py_with_long_function <path> <total_lines> <fn_body_lines>
+# Produces a .py file with a leading pad of comments, then one function whose
+# body has exactly <fn_body_lines> statement lines (so the function's own
+# span is fn_body_lines + 1 for the `def` line), so total file line count is
+# controllable independently of the function's length.
+make_py_with_long_function() {
+  local path="$1"
+  local total_lines="$2"
+  local fn_body_lines="$3"
+
+  : > "$path"
+  {
+    printf 'def long_one():\n'
+    local i=1
+    while [ "$i" -le "$fn_body_lines" ]; do
+      printf '    x = %d\n' "$i"
+      i=$((i + 1))
+    done
+  } >> "$path"
+
+  local fn_lines=$((fn_body_lines + 1))
+  local pad=$((total_lines - fn_lines))
+  local j=1
+  while [ "$j" -le "$pad" ]; do
+    printf '# pad %d\n' "$j" >> "$path"
+    j=$((j + 1))
+  done
+}
+
+# --- Input Construction (code-size) ---
+
+# build_input tool_name=X file_path=Y [session_id=Z] [notebook_path=W] [cwd=C]
+build_input() {
+  local tool_name="Edit"
+  local file_path=""
+  local notebook_path=""
+  local session_id="test-session"
+  local cwd=""
+  local use_notebook=0
+
+  for arg in "$@"; do
+    local key="${arg%%=*}"
+    local val="${arg#*=}"
+    case "$key" in
+      tool_name)     tool_name="$val" ;;
+      file_path)     file_path="$val" ;;
+      notebook_path) notebook_path="$val"; use_notebook=1 ;;
+      session_id)    session_id="$val" ;;
+      cwd)           cwd="$val" ;;
+    esac
+  done
+
+  if [ "$use_notebook" = "1" ]; then
+    jq -n \
+      --arg tn "$tool_name" --arg sid "$session_id" \
+      --arg np "$notebook_path" --arg cwd "$cwd" \
+      '{tool_name: $tn, session_id: $sid, cwd: $cwd, tool_input: {notebook_path: $np}}'
+  else
+    jq -n \
+      --arg tn "$tool_name" --arg sid "$session_id" \
+      --arg fp "$file_path" --arg cwd "$cwd" \
+      '{tool_name: $tn, session_id: $sid, cwd: $cwd, tool_input: {file_path: $fp}}'
+  fi
+}
+
+# build_edit_input file_path=X [session_id=Y] [cwd=Z] — convenience wrapper
+build_edit_input() {
+  build_input tool_name=Edit "$@"
+}
+
+# build_write_input file_path=X [session_id=Y] [cwd=Z]
+build_write_input() {
+  build_input tool_name=Write "$@"
+}
+
+# --- Run Helpers (code-size) ---
+
+# run_gate — invokes hook with $INPUT (or default) on stdin, using $BATS_RUN_BASH if set
+run_gate() {
+  local input="${INPUT:-$(build_edit_input file_path=/nonexistent)}"
+  local runner="${BATS_RUN_BASH:-bash}"
+
+  HOOK_STDOUT=""
+  HOOK_STDERR=""
+  HOOK_EXIT=0
+
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  HOOK_STDOUT=$("$runner" "$HOOK_SCRIPT" <<< "$input" 2>"$stderr_file") || HOOK_EXIT=$?
+  HOOK_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+# run_gate_raw_stdin <literal_input>
+run_gate_raw_stdin() {
+  local raw_input="$1"
+  local runner="${BATS_RUN_BASH:-bash}"
+  HOOK_STDOUT="" HOOK_STDERR="" HOOK_EXIT=0
+  local stderr_file
+  stderr_file=$(mktemp)
+  HOOK_STDOUT=$(printf '%s' "$raw_input" | "$runner" "$HOOK_SCRIPT" 2>"$stderr_file") || HOOK_EXIT=$?
+  HOOK_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+# --- Assertion Helpers (code-size) ---
+
+# assert_silent — exit 0, empty stdout
+assert_silent() {
+  [ "$HOOK_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $HOOK_EXIT"
+    echo "stderr: $HOOK_STDERR"
+    return 1
+  }
+  [ -z "$HOOK_STDOUT" ] || {
+    echo "Expected empty stdout, got: $HOOK_STDOUT"
+    return 1
+  }
+}
+
+# assert_exit_zero — exit 0 regardless of stdout content
+assert_exit_zero() {
+  [ "$HOOK_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $HOOK_EXIT"
+    echo "stderr: $HOOK_STDERR"
+    return 1
+  }
+}
+
+# assert_alert_contains <pattern> — exit 0, valid JSON, additionalContext contains pattern
+assert_alert_contains() {
+  local pattern="$1"
+  [ "$HOOK_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $HOOK_EXIT"
+    echo "stderr: $HOOK_STDERR"
+    return 1
+  }
+  echo "$HOOK_STDOUT" | jq . >/dev/null 2>&1 || {
+    echo "stdout is not valid JSON: $HOOK_STDOUT"
+    return 1
+  }
+  local event_name
+  event_name=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.hookEventName')
+  [ "$event_name" = "PostToolUse" ] || {
+    echo "Expected hookSpecificOutput.hookEventName=PostToolUse, got: '$event_name'"
+    return 1
+  }
+  local ctx
+  ctx=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.additionalContext')
+  case "$ctx" in
+    *"$pattern"*) ;;
+    *)
+      echo "Pattern '$pattern' not found in additionalContext: $ctx"
+      return 1
+      ;;
+  esac
+}
+
+# marker_path <abs_path> <session_id> — replicate hook's marker filename derivation
+marker_path() {
+  local abs_path="$1"
+  local session_id="$2"
+  local safe_session="${session_id//\//_}"
+  local hash
+  hash=$(printf '%s' "$abs_path" | shasum -a 256 | awk '{print $1}')
+  printf '%s/.code-size-%s_%s' "$CODE_SIZE_GATE_DIR" "$safe_session" "$hash"
+}
+
+# --- Input Construction + Run Helpers (git-push-guard) ---
+
+# mk_payload <command> — build the PreToolUse:Bash tool_input payload
+mk_payload() {
+  jq -n --arg cmd "$1" '{"tool_input":{"command":$cmd}}'
+}
+
+# run_push_guard <payload> [ENV=val ...] — invokes git-push-guard.sh with
+# $payload on stdin via bats' `run`, setting $status/$output/$stderr.
+# Extra positional args are passed to `env` (e.g. ALLOW_PUSH_MAIN=1) —
+# mirrors the original test script's `env $env_prefix bash "$HOOK"` shape.
+# Respects $BATS_RUN_BASH (same convention as run_gate in code-size tests)
+# so the whole suite can be re-run against a specific bash binary, e.g.
+# BATS_RUN_BASH=/bin/bash for the macOS system bash 3.2 pitfall.
+run_push_guard() {
+  local payload="$1"
+  shift
+  local runner="${BATS_RUN_BASH:-bash}"
+  if [ "$#" -gt 0 ]; then
+    run --separate-stderr env "$@" "$runner" "$GIT_PUSH_SCRIPT" <<< "$payload"
+  else
+    run --separate-stderr "$runner" "$GIT_PUSH_SCRIPT" <<< "$payload"
+  fi
+}


### PR DESCRIPTION
## 概述

将纯通用防护类 gate 插件化对外分发。纯 hook plugin(范式同 plan-review,无 skill),收两个 gate。close #116

## 内容

- **code-size**(PostToolUse Edit|Write): 源码规模门禁,additionalContext 提示,锚定 2000 行 Read 截断点
- **git-push**(PreToolUse Bash): 拦直接 push main/master, exit 2 硬阻断
- **包内 `_gate_common.sh`**: 只抽无副作用样板(jq探测/字段提取/bypass),**不抽顶层兜底**(两者 fail-open 哲学相反)。跨包不共享 lib(自足优先于 DRY)
- marketplace.json 注册 v1.0.0

## 验证

- bats 双版本(bash 5.3.3 / 3.2.57)全绿 **73 例**(code-size 49 + git-push 24)
- smoke 实测: push main→exit2 / feature→0 / `ALLOW_PUSH_MAIN=1`→0 / `--all`→2; code-size 2100 行→additionalContext

## 已知限制(首版)

git-push 保护分支硬编码 `main/master`,用 `trunk/develop` 的仓库暂不适用; bypass=`ALLOW_PUSH_MAIN=1`。通用化(`PROTECTED_BRANCHES` env)留后续版本,README 已注明。

## 后续(不在本 PR)

- 本机撤 `~/.claude` 本地 hook 改吃 plugin(另仓 PR,先装后撤)
- dispatch-economy 独立包(批次2)