### PR TITLE
feat(guardrails): git-push-guard 边界健壮化 + PROTECTED_BRANCHES 通用化 (v1.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,7 +63,7 @@
     {
       "name": "guardrails",
       "description": "Guardrail hooks — code size gate (informational) + git push guard (guards against accidental direct push to main/master)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/doc-gate/skills/doc-maintenance/SKILL.md
+++ b/plugins/doc-gate/skills/doc-maintenance/SKILL.md
@@ -15,6 +15,8 @@ description: |
 
 在文档写入前强制预检、写入后强制自查，防止层位违规和索引腐烂。
 
+平台兼容性：在 Claude Code 中，doc-gate 插件 hook 会自动执行 skill-gate/recall-gate；在 opencode 中，除非另行安装 opencode adapter，本 skill 只提供人工遵循的文档维护流程，不承诺自动门禁。
+
 ## 1. 操作类型判定
 
 | 类型 | 判定信号 |

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guardrails",
   "description": "Guardrail hooks — code size gate (informational) + git push guard (guards against accidental direct push to main/master)",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": { "name": "WooDragon" }
 }

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -49,7 +49,7 @@ Environment variables:
 **Known limitations (guards against slips, not against deliberate evasion).** [#118](https://github.com/WooDragon/cc-plugins/issues/118) closed the previously-tracked gaps (long options, `sudo -E`, `env`, `GIT_DIR=` prefix, full binary path, hard-coded `main`/`master`) — the remaining items below are accepted, still-open gaps:
 
 - **Nested shells bypass detection entirely** — `bash -c 'git push origin main'`, `(git push origin main)` — since the hook only pattern-matches the literal command string, not commands executed inside a spawned sub-shell.
-- **`sudo -u user git push ...`** is not recognized: the prefix stripper only skips *flag* tokens after `sudo`/`env`, so a non-flag argument like a username still breaks normalization.
+- **Only `sudo`/`env`/`VAR=val` invocation prefixes are normalized.** Other command wrappers pass through undetected — `time git push origin main`, `command git push ...`, `nice git push ...`, and `sudo -u user git push ...` (a non-flag argument like a username after `sudo` also breaks normalization). Recognizing every wrapper is an arms race a slip-catcher does not chase.
 - **False positive**: a remote literally named `main` (e.g. `git push main HEAD:feature`) is not distinguished from the `main` *branch* and may be flagged even though no protected branch is being pushed to. Use `ALLOW_PUSH_MAIN=1` to push through this case.
 - **`PROTECTED_BRANCHES` values containing regex metacharacters** have undefined matching behavior, since the list is spliced directly into the detection regex's alternation.
 

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -37,11 +37,14 @@ Guards against `git push` (and compound commands containing one, split on `&&`, 
 
 Before matching, the command is normalized to strip leading invocation-prefix tokens — environment-variable assignments (`GIT_DIR=... git push`), `sudo`/`env` and their own flags (`sudo -E git push`, `env git push`) — so these collapse to a bare `git ... push ...` before pattern matching runs. The detection regex itself recognizes long options (`git --no-pager push`, `git --git-dir=.git push`) and an optional full/relative path prefix on the `git` binary (`/usr/bin/git push`).
 
-Protected branches default to `main master` and are configurable via `PROTECTED_BRANCHES` (space-separated branch names, e.g. `PROTECTED_BRANCHES="trunk develop"`).
-
 This is a **slip-catcher, not a security boundary** — it is pattern-matching over the literal command text, not a real shell parser, so it stops the common accidental-push shapes without attempting to be adversarially unevadable. See "Known limitations" below for what it does not cover.
 
-Bypass: `export ALLOW_PUSH_MAIN=1` (temporary, intended for genuine emergencies — not a standing override).
+Environment variables:
+
+| Var | Default | Purpose |
+|---|---|---|
+| `PROTECTED_BRANCHES` | `main master` | space-separated branch names to guard (e.g. `PROTECTED_BRANCHES="trunk develop"`) |
+| `ALLOW_PUSH_MAIN` | `0` | bypass switch (`1` allows a push to a protected branch); temporary, for genuine emergencies — not a standing override. Name retained for backward compatibility even though `PROTECTED_BRANCHES` generalized the guarded set beyond `main`. |
 
 **Known limitations (guards against slips, not against deliberate evasion).** [#118](https://github.com/WooDragon/cc-plugins/issues/118) closed the previously-tracked gaps (long options, `sudo -E`, `env`, `GIT_DIR=` prefix, full binary path, hard-coded `main`/`master`) — the remaining items below are accepted, still-open gaps:
 

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -33,22 +33,22 @@ Environment variables:
 
 ### git-push-guard.sh — `PreToolUse: Bash` (5s timeout)
 
-Guards against `git push` (and compound commands containing one, split on `&&`, `||`, `;`, newline) that target `main` or `master` — exact branch name (bare, `+`-prefixed force shorthand, or full `refs/heads/` path), refspec (`:main`, `:refs/heads/main`), or `--all`/`--mirror`. On a hit: `exit 2` + explanatory `stderr`, blocking that tool call. All other cases (parse ambiguity, missing fields, non-matching branch) fail open with `exit 0`.
+Guards against `git push` (and compound commands containing one, split on `&&`, `||`, `;`, newline) that target a protected branch — exact branch name (bare, `+`-prefixed force shorthand, or full `refs/heads/` path), refspec (`:main`, `:refs/heads/main`), or `--all`/`--mirror`. On a hit: `exit 2` + explanatory `stderr`, blocking that tool call. All other cases (parse ambiguity, missing fields, non-matching branch) fail open with `exit 0`.
+
+Before matching, the command is normalized to strip leading invocation-prefix tokens — environment-variable assignments (`GIT_DIR=... git push`), `sudo`/`env` and their own flags (`sudo -E git push`, `env git push`) — so these collapse to a bare `git ... push ...` before pattern matching runs. The detection regex itself recognizes long options (`git --no-pager push`, `git --git-dir=.git push`) and an optional full/relative path prefix on the `git` binary (`/usr/bin/git push`).
+
+Protected branches default to `main master` and are configurable via `PROTECTED_BRANCHES` (space-separated branch names, e.g. `PROTECTED_BRANCHES="trunk develop"`).
 
 This is a **slip-catcher, not a security boundary** — it is pattern-matching over the literal command text, not a real shell parser, so it stops the common accidental-push shapes without attempting to be adversarially unevadable. See "Known limitations" below for what it does not cover.
 
 Bypass: `export ALLOW_PUSH_MAIN=1` (temporary, intended for genuine emergencies — not a standing override).
 
-**Known limitations (guards against slips, not against deliberate evasion).** These are known, accepted gaps — not yet implemented — tracked in [#118](https://github.com/WooDragon/cc-plugins/issues/118):
+**Known limitations (guards against slips, not against deliberate evasion).** [#118](https://github.com/WooDragon/cc-plugins/issues/118) closed the previously-tracked gaps (long options, `sudo -E`, `env`, `GIT_DIR=` prefix, full binary path, hard-coded `main`/`master`) — the remaining items below are accepted, still-open gaps:
 
-- **Hard-coded protected branches.** Only `main`/`master` are recognized. Repos using `trunk`, `develop`, or other default-branch conventions are **not protected** — pushes to those branches pass through untouched. Planned fix: a configurable `PROTECTED_BRANCHES` env var.
-- **Alternate git invocations bypass detection entirely**, since the hook only pattern-matches the literal command string:
-  - Full binary path — `/usr/bin/git push origin main`
-  - `sudo -E git push origin main` (only bare `sudo git` is recognized)
-  - `env git push origin main`
-  - `GIT_DIR=... git push origin main` (env-var prefix before `git`)
-  - Nested shells — `bash -c 'git push origin main'`
-- **False positive**: a remote literally named `main` (e.g. `git push main HEAD:feature`) is not distinguished from the `main` *branch* and may be flagged even though no protected branch is being pushed to.
+- **Nested shells bypass detection entirely** — `bash -c 'git push origin main'`, `(git push origin main)` — since the hook only pattern-matches the literal command string, not commands executed inside a spawned sub-shell.
+- **`sudo -u user git push ...`** is not recognized: the prefix stripper only skips *flag* tokens after `sudo`/`env`, so a non-flag argument like a username still breaks normalization.
+- **False positive**: a remote literally named `main` (e.g. `git push main HEAD:feature`) is not distinguished from the `main` *branch* and may be flagged even though no protected branch is being pushed to. Use `ALLOW_PUSH_MAIN=1` to push through this case.
+- **`PROTECTED_BRANCHES` values containing regex metacharacters** have undefined matching behavior, since the list is spliced directly into the detection regex's alternation.
 
 ## Shared library
 
@@ -66,4 +66,4 @@ Run against both bash 5.x (Homebrew) and bash 3.2 (macOS system `/bin/bash`) —
 
 ## TODO (future version)
 
-See "Known limitations" above and [#118](https://github.com/WooDragon/cc-plugins/issues/118) for the tracked follow-up work (evasion-vector hardening, `PROTECTED_BRANCHES` generalization).
+See "Known limitations" above and [#118](https://github.com/WooDragon/cc-plugins/issues/118) for the remaining tracked follow-up work (nested-shell detection, `sudo -u user` recognition).

--- a/plugins/guardrails/scripts/git-push-guard.sh
+++ b/plugins/guardrails/scripts/git-push-guard.sh
@@ -52,9 +52,10 @@ normalize_git_prefix() {
       [A-Za-z_]*=*) ;;
       sudo)         ;;
       env)          ;;
-      # sudo/env flags (e.g. -E, -i) — only stripped mid-prefix, i.e. after
-      # we have already seen sudo/env, so a bare leading `-x` (not a valid
-      # command start) will not falsely trigger. Guarded by prev token below.
+      # Anything else (including a bare leading `-x`) ends the prefix run.
+      # sudo/env's own flags are NOT handled here — they are consumed by the
+      # dedicated inner loop below, only after sudo/env has been seen, so a
+      # statement starting with a stray `-x` never falsely strips.
       *) break ;;
     esac
     # Drop this token and continue.
@@ -99,20 +100,24 @@ check_push_target() {
   # which do NOT support \s: it silently fails to match as a metachar,
   # degrading the sed extraction below to a no-op (push_args ends up as
   # the whole original statement instead of just the push arguments).
-  # After normalize_git_prefix the statement starts at the git token (bare
-  # or full-path), so no leading anchor alternation is needed — keeping the
-  # fragment anchor-free lets the SAME fragment be reused inside the sed
-  # `s/^.*RE//` extraction (a leading `(^|...)` alternation breaks BSD sed).
+  # After normalize_git_prefix the statement STARTS at the git token (bare or
+  # full-path), so the regex is anchored to `^`: git must be in command
+  # position. This is what keeps `echo git push origin main` and
+  # `grep "git push origin main" f` from being flagged — the literal string
+  # `git push ...` appearing as an *argument* is not a command invocation.
+  # (Nested shells like `bash -c '...'` are still out of scope — see README.)
   local git_push_re='([^[:space:]]*/)?git([[:space:]]+(-[-a-zA-Z][^[:space:]]*|[^[:space:]-][^[:space:]]*))*[[:space:]]+push'
-  if ! grep -Eq "$git_push_re" <<< "$stmt"; then
+  if ! grep -Eq "^${git_push_re}" <<< "$stmt"; then
     return 1
   fi
 
-  # Extract everything after "push" (the push arguments). Use `#` as the sed
-  # delimiter — the path-prefix group ([^space]*/) contains a literal `/`,
-  # which would otherwise be parsed as the s/// delimiter and break the RE.
+  # Extract everything after "push" (the push arguments). Anchored `^` (not
+  # `^.*`) so the match starts at the git token, mirroring the detection
+  # above. Use `#` as the sed delimiter — the path-prefix group ([^space]*/)
+  # contains a literal `/`, which would otherwise be parsed as the s///
+  # delimiter and break the RE.
   local push_args
-  push_args=$(sed -E "s#^.*${git_push_re}##" <<< "$stmt")
+  push_args=$(sed -E "s#^${git_push_re}##" <<< "$stmt")
 
   # Strip quote characters so quoted branch names (e.g. "main", 'main')
   # line up with the same bare word-boundary checks below.

--- a/plugins/guardrails/scripts/git-push-guard.sh
+++ b/plugins/guardrails/scripts/git-push-guard.sh
@@ -24,29 +24,95 @@ COMMAND=$(_gate_field "$INPUT" '.tool_input.command // empty') || exit 0
 [ -z "$COMMAND" ] && exit 0
 [[ "$COMMAND" != *"push"* ]] && exit 0
 
+# Protected branch names (space-separated), default main/master. Built into
+# an alternation fragment for the branch-matching regexes below. Only plain
+# word chars are expected; names containing regex metacharacters are a
+# documented limitation (see README).
+PROTECTED_BRANCHES="${PROTECTED_BRANCHES:-main master}"
+PROTECTED_ALT=$(printf '%s' "$PROTECTED_BRANCHES" | tr -s '[:space:]' '|')
+PROTECTED_ALT="${PROTECTED_ALT#|}"
+PROTECTED_ALT="${PROTECTED_ALT%|}"
+[ -z "$PROTECTED_ALT" ] && exit 0
+
+# Strip a leading run of prefix tokens that precede the actual `git` command
+# so alternate invocation shapes normalize to a bare `git ... push ...`:
+#   - environment assignments   GIT_DIR=.git git push ...   (VAR=val)
+#   - sudo (and its own flags)   sudo -E git push ...
+#   - env                        env git push ...
+# This is a slip-catcher: `sudo -u user`, nested shells (bash -c), etc. are
+# still out of scope (see README "Known limitations").
+normalize_git_prefix() {
+  local stmt="$1" tok
+  # Strip leading whitespace each round.
+  while :; do
+    stmt="${stmt#"${stmt%%[![:space:]]*}"}"
+    tok="${stmt%%[[:space:]]*}"
+    case "$tok" in
+      # env-var assignment: NAME=value (NAME starts with letter/underscore)
+      [A-Za-z_]*=*) ;;
+      sudo)         ;;
+      env)          ;;
+      # sudo/env flags (e.g. -E, -i) — only stripped mid-prefix, i.e. after
+      # we have already seen sudo/env, so a bare leading `-x` (not a valid
+      # command start) will not falsely trigger. Guarded by prev token below.
+      *) break ;;
+    esac
+    # Drop this token and continue.
+    stmt="${stmt#"$tok"}"
+    # After sudo/env, also drop any immediately-following short flags.
+    if [ "$tok" = "sudo" ] || [ "$tok" = "env" ]; then
+      while :; do
+        stmt="${stmt#"${stmt%%[![:space:]]*}"}"
+        local nxt="${stmt%%[[:space:]]*}"
+        case "$nxt" in
+          -*) stmt="${stmt#"$nxt"}" ;;
+          *)  break ;;
+        esac
+      done
+    fi
+  done
+  printf '%s' "$stmt"
+}
+
 # Split compound command into sub-statements on &&, ||, ;, newline
 # then check each for git push to main/master
 check_push_target() {
   local stmt="$1"
 
-  # Strip leading whitespace
+  # Strip leading whitespace, then peel off invocation-prefix tokens
+  # (VAR=val / sudo / env and their flags) so all shapes normalize to a
+  # bare `git ... push ...` before pattern matching.
   stmt="${stmt#"${stmt%%[![:space:]]*}"}"
+  stmt=$(normalize_git_prefix "$stmt")
 
-  # Must contain "git" in command position followed (eventually) by "push"
-  # Allow global options between git and push: git -C path push, git -c k=v push
+  # Must contain "git" in command position (optionally a full/relative path
+  # like /usr/bin/git) followed (eventually) by "push". Options between git
+  # and push are matched by:
+  #   -[-a-zA-Z][^space]*   short or long option (git -C, git --no-pager,
+  #                          git --git-dir=.git) — one dash-or-letter after
+  #                          the leading dash, then any non-space run, so
+  #                          =value / dotted paths inside the token are fine
+  #   [^space-][^space]*    non-option arg token (git -C's path, -c's k=v)
   #
   # NOTE: [[:space:]] (not \s) throughout this function — \s is a GNU
   # grep/sed extension. macOS ships BSD grep/sed as /usr/bin/{grep,sed},
   # which do NOT support \s: it silently fails to match as a metachar,
   # degrading the sed extraction below to a no-op (push_args ends up as
   # the whole original statement instead of just the push arguments).
-  if ! grep -Eq '(^|sudo[[:space:]]+)git([[:space:]]+(-[a-zA-Z][^ ]*|[^ -][^ ]*))*[[:space:]]+push' <<< "$stmt"; then
+  # After normalize_git_prefix the statement starts at the git token (bare
+  # or full-path), so no leading anchor alternation is needed — keeping the
+  # fragment anchor-free lets the SAME fragment be reused inside the sed
+  # `s/^.*RE//` extraction (a leading `(^|...)` alternation breaks BSD sed).
+  local git_push_re='([^[:space:]]*/)?git([[:space:]]+(-[-a-zA-Z][^[:space:]]*|[^[:space:]-][^[:space:]]*))*[[:space:]]+push'
+  if ! grep -Eq "$git_push_re" <<< "$stmt"; then
     return 1
   fi
 
-  # Extract everything after "push" (the push arguments)
+  # Extract everything after "push" (the push arguments). Use `#` as the sed
+  # delimiter — the path-prefix group ([^space]*/) contains a literal `/`,
+  # which would otherwise be parsed as the s/// delimiter and break the RE.
   local push_args
-  push_args=$(sed -E 's/^.*git([[:space:]]+(-[a-zA-Z][^ ]*|[^ -][^ ]*))*[[:space:]]+push//' <<< "$stmt")
+  push_args=$(sed -E "s#^.*${git_push_re}##" <<< "$stmt")
 
   # Strip quote characters so quoted branch names (e.g. "main", 'main')
   # line up with the same bare word-boundary checks below.
@@ -57,16 +123,17 @@ check_push_target() {
     return 0
   fi
 
-  # Check for main/master as exact branch name (optionally prefixed with
-  # the force-push shorthand "+" and/or the full "refs/heads/" ref path)
-  # or as a colon-refspec destination.
+  # Check for a protected branch as exact branch name (optionally prefixed
+  # with the force-push shorthand "+" and/or the full "refs/heads/" ref path)
+  # or as a colon-refspec destination. $PROTECTED_ALT is the pipe-joined
+  # alternation of PROTECTED_BRANCHES (default "main|master").
   # Word-boundary: preceded by space/start(/plus), followed by space/end
   # Bare/prefixed: main, +main, refs/heads/main, +refs/heads/main
   # Refspec: :main, :refs/heads/main, :master, :refs/heads/master
-  if grep -Eq '(^|[[:space:]])\+?(refs/heads/)?(main|master)([[:space:]]|$)' <<< "$push_args"; then
+  if grep -Eq "(^|[[:space:]])\+?(refs/heads/)?(${PROTECTED_ALT})([[:space:]]|\$)" <<< "$push_args"; then
     return 0
   fi
-  if grep -Eq ':(refs/heads/)?(main|master)([[:space:]]|$)' <<< "$push_args"; then
+  if grep -Eq ":(refs/heads/)?(${PROTECTED_ALT})([[:space:]]|\$)" <<< "$push_args"; then
     return 0
   fi
 
@@ -76,7 +143,7 @@ check_push_target() {
 # Split on ;, &&, ||, newline — process each sub-statement
 while IFS= read -r stmt; do
   if [ -n "$stmt" ] && check_push_target "$stmt"; then
-    printf '[git-push-guard] 禁止直接 push 到 main/master。请推送到功能分支并提 PR。\n' >&2
+    printf '[git-push-guard] 禁止直接 push 到保护分支 (%s)。请推送到功能分支并提 PR。\n' "$PROTECTED_BRANCHES" >&2
     printf '[git-push-guard] 无特殊情况不得绕过此检查。紧急放行: export ALLOW_PUSH_MAIN=1\n' >&2
     exit 2
   fi

--- a/plugins/guardrails/tests/git-push-guard.bats
+++ b/plugins/guardrails/tests/git-push-guard.bats
@@ -94,6 +94,19 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+# --- git must be in COMMAND position: the literal "git push ... main" as an
+#     argument to another command must NOT be flagged (anchor regression) ---
+
+@test "pass: echo git push origin main (git is an echo argument, not a command)" {
+  run_push_guard "$(mk_payload 'echo git push origin main')"
+  [ "$status" -eq 0 ]
+}
+
+@test "pass: grep \"git push origin main\" README.md (literal string search)" {
+  run_push_guard "$(mk_payload 'grep "git push origin main" README.md')"
+  [ "$status" -eq 0 ]
+}
+
 # ============================================================
 # BLOCK cases
 # ============================================================

--- a/plugins/guardrails/tests/git-push-guard.bats
+++ b/plugins/guardrails/tests/git-push-guard.bats
@@ -67,6 +67,33 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+# --- prefix/long-option forms must still PASS on feature branches (no FP after hardening) ---
+
+@test "pass: git --no-pager push origin feature-x (long option, feature branch)" {
+  run_push_guard "$(mk_payload 'git --no-pager push origin feature-x')"
+  [ "$status" -eq 0 ]
+}
+
+@test "pass: env git push origin feature-x (env prefix, feature branch)" {
+  run_push_guard "$(mk_payload 'env git push origin feature-x')"
+  [ "$status" -eq 0 ]
+}
+
+@test "pass: sudo -E git push origin feature-x (sudo+flag prefix, feature branch)" {
+  run_push_guard "$(mk_payload 'sudo -E git push origin feature-x')"
+  [ "$status" -eq 0 ]
+}
+
+@test "pass: /usr/bin/git push origin feature-x (full path, feature branch)" {
+  run_push_guard "$(mk_payload '/usr/bin/git push origin feature-x')"
+  [ "$status" -eq 0 ]
+}
+
+@test "pass: GIT_DIR=.git git push origin feature-x (env-var prefix, feature branch)" {
+  run_push_guard "$(mk_payload 'GIT_DIR=.git git push origin feature-x')"
+  [ "$status" -eq 0 ]
+}
+
 # ============================================================
 # BLOCK cases
 # ============================================================
@@ -187,6 +214,73 @@ teardown() {
 
 @test "block: git push origin 'main' (single-quoted branch name)" {
   run_push_guard "$(mk_payload "git push origin 'main'")"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+# ============================================================
+# BLOCK cases — long options, prefixes, full path (#118 hardening)
+# ============================================================
+
+@test "block: git --no-pager push origin main (long option, real bug)" {
+  run_push_guard "$(mk_payload 'git --no-pager push origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: git --git-dir=.git push origin main (long option with =value)" {
+  run_push_guard "$(mk_payload 'git --git-dir=.git push origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: sudo -E git push origin main (sudo with flag)" {
+  run_push_guard "$(mk_payload 'sudo -E git push origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: env git push origin main (env prefix)" {
+  run_push_guard "$(mk_payload 'env git push origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: GIT_DIR=.git git push origin main (env-var assignment prefix)" {
+  run_push_guard "$(mk_payload 'GIT_DIR=.git git push origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: /usr/bin/git push origin main (full binary path)" {
+  run_push_guard "$(mk_payload '/usr/bin/git push origin main')"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+# ============================================================
+# PROTECTED_BRANCHES generalization (#118)
+# ============================================================
+
+@test "block: PROTECTED_BRANCHES=trunk — git push origin trunk" {
+  run_push_guard "$(mk_payload 'git push origin trunk')" PROTECTED_BRANCHES=trunk
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "block: PROTECTED_BRANCHES='trunk develop' — git push origin develop" {
+  run_push_guard "$(mk_payload 'git push origin develop')" "PROTECTED_BRANCHES=trunk develop"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"git-push-guard"* ]]
+}
+
+@test "pass: PROTECTED_BRANCHES=trunk — git push origin main (main no longer protected)" {
+  run_push_guard "$(mk_payload 'git push origin main')" PROTECTED_BRANCHES=trunk
+  [ "$status" -eq 0 ]
+}
+
+@test "block: default PROTECTED_BRANCHES still protects main when unset" {
+  run_push_guard "$(mk_payload 'git push origin main')"
   [ "$status" -eq 2 ]
   [[ "$stderr" == *"git-push-guard"* ]]
 }

--- a/plugins/guardrails/tests/test_helper/common-setup.bash
+++ b/plugins/guardrails/tests/test_helper/common-setup.bash
@@ -25,6 +25,10 @@ common_setup() {
   mkdir -p "$SRC_DIR"
 
   unset ALLOW_PUSH_MAIN
+  # Prevent a PROTECTED_BRANCHES exported in the parent env from polluting the
+  # default-protection cases (git-push-guard defaults to "main master" only
+  # when unset). Tests that need a custom list pass it explicitly via env.
+  unset PROTECTED_BRANCHES
 }
 
 common_teardown() {


### PR DESCRIPTION
## Summary

git-push-guard 边界健壮化 + `PROTECTED_BRANCHES` 通用化（v1.1.0），落地 #118。修复实测确认的漏拦向量，定位仍是**防手滑 slip-catcher 非安全边界**。

## 修的漏拦（实测驱动，档 B）

| 向量 | 性质 |
|------|------|
| `git --no-pager push origin main` | 真 bug：原选项正则 `-[a-zA-Z]` 不认 `--长选项`，整条失配放行 |
| `git --git-dir=.git push origin main` | 同上（长选项带 `=` 值） |
| `sudo -E git push` / `env git push` / `GIT_DIR=x git push` / `/usr/bin/git push` | 前缀类，AI 高频自然形态 |

## 通用化

`PROTECTED_BRANCHES` env（空格分隔，默认 `main master`），支持 `trunk`/`develop` 等命名的仓库。

## 设计

- `normalize_git_prefix()` 剥离前导 token（`VAR=`/`sudo`/`env` 及其 flag），把"前缀识别"与"push 目标匹配"拆成两个各自简单的关注点，不堆单条巨正则。
- 选项正则改用长短合并式 `-[-a-zA-Z][^space]*`（实测证明字符类式 `--[a-zA-Z0-9-]*` 漏 `--git-dir=.git`）。
- 两个 BSD sed 坑：前导锚点破坏 `s///`（改用无锚点共用片段）、路径前缀组的字面 `/` 撞分隔符（改用 `#`）。

## 不修（保留为文档限制）

嵌套 shell（`bash -c`/子 shell）、`sudo -u user git`、remote 名恰为 main 的 FP、分支名含正则元字符——均在 README "Known limitations" 诚实标注。

## 测试

45/45 双 bash（5.x Homebrew + 3.2 macOS 系统）全绿：6 新 block（前缀/长选项/全路径）+ 5 pass 保护（前缀形态 feature 分支不误伤）+ 4 PROTECTED_BRANCHES 组。code-size 套件 49/49 不受牵连。FP 控制组（`main:feature` src 位、commit message、grep、`maintain`/`main-backup` 前缀名）全部正确放行。

## 附带

`doc-maintenance/SKILL.md` 补一段 opencode 平台兼容性说明——与本 issue 无关的工作区既有改动，一并纳入本 PR。

Closes #118
