### PR TITLE
fix(doc-gate): exclude deliverables from gate — ADR-010 conflict resolved (v1.6.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
     {
       "name": "doc-gate",
       "description": "Document editing governance — doc-maintenance skill + hard gate + recall advisory",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/doc-gate/.claude-plugin/plugin.json
+++ b/plugins/doc-gate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "doc-gate",
   "description": "Document editing governance — doc-maintenance skill + hard gate + recall advisory",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "author": { "name": "woodragon" },
   "skills": ["./skills/doc-maintenance"]
 }

--- a/plugins/doc-gate/README.md
+++ b/plugins/doc-gate/README.md
@@ -70,11 +70,17 @@ Both gates skip files that shouldn't be governed:
 | Category | Examples |
 |----------|---------|
 | **Basename** | `MEMORY.md`, `SKILL.md`, `CHANGELOG.md`, `LICENSE.md` (case-insensitive) |
-| **Path** | `.claude/*`, `.claude-plugin/*`, `.agents/directives/*`, `node_modules/*`, `.git/*`, `logs/*`, `pipeline/*` |
+| **Path** | `.claude/*`, `.claude-plugin/*`, `.agents/directives/*`, `node_modules/*`, `.git/*`, `logs/*`, `pipeline/*`, `intake/*`, `deliverables/*` |
 | **Temp dirs** | `/tmp/*`, `/var/tmp/*`, `/var/folders/*`, `/private/tmp/*` |
 | **Non-.md** | Any file not ending in `.md` (case-insensitive) |
 
-`pipeline/*` covers deep-research's machine-generated intermediate artifacts (e.g. `pipeline/verification/*.json`-adjacent notes) — the doc-maintenance workflow doesn't apply to them. `deliverables/*` is intentionally **not** excluded: final research output is prose documentation and stays governed. Both gates share this exclusion list from a single source, `scripts/_doc_gate_exclude.sh` (and its `EXCLUDED_DIRS` mirror in `tools/_doc_gate_common.py` for the recall-gate link graph) — add new exclusions there, not per-script.
+`pipeline/*` covers deep-research's machine-generated intermediate artifacts (e.g. `pipeline/verification/*.json`-adjacent notes) — the doc-maintenance workflow doesn't apply to them. `intake/*` covers deep-research's G0 requirement-gate products (e.g. `intake/requirements/research-goal.md`), which the Lead generates semi-automatically before doc-maintenance is relevant.
+
+As of **v1.6.0**, `*/deliverables/*` is also excluded from the gate. It used to stay governed, but that conflicted structurally with ADR-010 (main-session cost remediation): deliverables writes always go through a subagent, and the gate marker is keyed by `session_id` — since each subagent gets its own session id, no legitimate pass-through path exists, and the gate measured a 100% bypass rate on deliverables edits in practice. deliverables content is governed by its own quality system instead (G1–G3 sufficiency gates + Stage 6 validation review), so excluding it removes pure friction without losing coverage.
+
+All path exclusions match on path *components* at any nesting depth, not just the project root — `*/deliverables/*` fires equally on `deliverables/final/report.md` and on `projects/x/deliverables/final/report.md`.
+
+Both gates share this exclusion list from a single source, `scripts/_doc_gate_exclude.sh` — add new gate exclusions there, not per-script. This list is allowed to **diverge** from the `EXCLUDED_DIRS` list in `tools/_doc_gate_common.py` (used for the recall-gate's link-graph corpus): the gate governs which edits require the doc-maintenance workflow, while the corpus governs which files are indexed for BM25/link-graph analysis — different concerns, different audiences. `pipeline/*` and `intake/*` are excluded from both (machine-generated, not real content to recall against). `deliverables/*` is excluded from the gate only — the corpus still indexes it, since deliverables remain real documentation worth surfacing in recall/orphan/broken-link checks even though editing them bypasses the workflow gate.
 
 **Exception**: `~/.claude/CLAUDE.md` is always gated despite living under `.claude/` — it's the global config with the highest pollution surface.
 
@@ -159,7 +165,7 @@ python3 -m unittest tests/test_recall_gate.py -v
 | `skill-gate.bats` | 57 | Filters, exclusions, gate enforcement, fail-open, CLAUDE.md governance, stale cleanup, e2e |
 | `skill-marker.bats` | 13 | Tracked/untracked skills, marker creation, namespacing, kill switch |
 | `recall-gate.bats` | 37 | Filters, kill switch, fail-open, markers, double-deny, BM25 integration, orphan, broken outlinks, monorepo root detection, e2e |
-| `exclude.bats` | 8 | Shared `_doc_gate_exclude.sh` predicate — pipeline/logs/tmp/git/node_modules excluded, deliverables/docs/CLAUDE.md governed |
+| `exclude.bats` | 12 | Shared `_doc_gate_exclude.sh` predicate — pipeline/intake/logs/tmp/git/node_modules/deliverables (incl. relative & nested paths) excluded, docs/CLAUDE.md governed |
 | `test_recall_gate.py` | 67 | Tokenization, BM25 scoring, link extraction/resolution, corpus building, orphan/broken checks, cmd_gate output, detect_root |
 | `test_exclude.py` | 1 | `build_corpus_and_graph` excludes `pipeline/`, includes `deliverables/` and `docs/` |
 
@@ -167,6 +173,7 @@ python3 -m unittest tests/test_recall_gate.py -v
 
 See [GitHub Issues](https://github.com/WooDragon/cc-plugins/issues) for detailed change logs:
 
+- **v1.6.0** — `*/deliverables/*` excluded from the gate (ADR-010 conflict: no legitimate pass-through path under subagent-scoped markers, 100% observed bypass); gate exclusion list intentionally diverges from the recall-gate corpus's `EXCLUDED_DIRS`, which still indexes deliverables (#124)
 - **v1.5.0** — Path exclusions collapsed to single source (`_doc_gate_exclude.sh`); added `pipeline/*` exclusion for deep-research intermediate artifacts, `deliverables/*` remains governed
 - **v1.2.1** — Root detection: CLAUDE.md co-occurrence anchor for monorepo support (#22)
 - **v1.2.0** — Recall gate: BM25 lexical recall + link graph triple-dimension gate

--- a/plugins/doc-gate/scripts/_doc_gate_exclude.sh
+++ b/plugins/doc-gate/scripts/_doc_gate_exclude.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # doc-gate 路径排除单一来源 — skill-gate.sh / recall-gate.sh 共享。
-# 新增排除只改此处；对齐 tools/_doc_gate_common.py 的 EXCLUDED_DIRS 设计意图。
+# 新增排除只改此处。本清单与 tools/_doc_gate_common.py 的 EXCLUDED_DIRS
+# 允许分叉——两者管辖对象不同：本清单决定哪些编辑豁免 doc-maintenance
+# 工作流门禁，EXCLUDED_DIRS 决定 recall-gate 语料库（BM25/link graph）索引
+# 哪些文件。例如 deliverables/*：本清单排除（见下方注释），但
+# EXCLUDED_DIRS 仍索引它——deliverables 依然是应被 recall/orphan/断链检查
+# 覆盖的真实文档，只是编辑它不需要走门禁。不要求两边清单一致。
 # 命中排除→return 0；否则→return 1。
 doc_gate_is_excluded_path() {
   local fp="$1"

--- a/plugins/doc-gate/scripts/_doc_gate_exclude.sh
+++ b/plugins/doc-gate/scripts/_doc_gate_exclude.sh
@@ -7,9 +7,11 @@ doc_gate_is_excluded_path() {
   # location 排除（prepend / 统一处理相对路径）
   # pipeline: deep-research 机器生成中间产物，doc-maintenance 工作流不适用。
   # intake: deep-research G0 需求门产物（research-goal 等），Lead 半自动生成。
-  # deliverables 刻意【不】排除——最终交付散文档受治理。
+  # deliverables: 与 ADR-010（主 session 成本根治）结构性冲突而排除——
+  # deliverables 写入必走 subagent、marker 按 session_id 落盘，合法过门路径不存在，
+  # 实测 100% 旁路率；且有自己的质量体系（G1-G3 + Stage 6），管辖对象与本 gate 不同。
   case "/$fp" in
-    */.claude/*|*/.claude-plugin/*|*/.agents/directives/*|*/node_modules/*|*/.git/*|*/logs/*|*/pipeline/*|*/intake/*) return 0 ;;
+    */.claude/*|*/.claude-plugin/*|*/.agents/directives/*|*/node_modules/*|*/.git/*|*/logs/*|*/pipeline/*|*/intake/*|*/deliverables/*) return 0 ;;
   esac
   # 临时目录排除（绝对路径直配）
   case "$fp" in

--- a/plugins/doc-gate/tests/exclude.bats
+++ b/plugins/doc-gate/tests/exclude.bats
@@ -44,14 +44,14 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-# ============================================================
-# NOT excluded (return 1) — deliverables stays governed
-# ============================================================
-
-@test "not excluded: deliverables/final/report.md (final deliverable, governed)" {
+@test "excluded: deliverables/final/report.md (ADR-010 conflict, own quality system)" {
   run doc_gate_is_excluded_path "/project/deliverables/final/report.md"
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
 }
+
+# ============================================================
+# NOT excluded (return 1)
+# ============================================================
 
 @test "not excluded: docs/guide.md" {
   run doc_gate_is_excluded_path "/project/docs/guide.md"

--- a/plugins/doc-gate/tests/exclude.bats
+++ b/plugins/doc-gate/tests/exclude.bats
@@ -49,6 +49,16 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "excluded: deliverables via relative path (projects/x/deliverables/final/report.md)" {
+  run doc_gate_is_excluded_path "projects/x/deliverables/final/report.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "excluded: deliverables nested arbitrarily deep (a/b/c/deliverables/drafts/v2/report.md)" {
+  run doc_gate_is_excluded_path "/project/a/b/c/deliverables/drafts/v2/report.md"
+  [ "$status" -eq 0 ]
+}
+
 # ============================================================
 # NOT excluded (return 1)
 # ============================================================

--- a/plugins/doc-gate/tests/skill-gate.bats
+++ b/plugins/doc-gate/tests/skill-gate.bats
@@ -189,10 +189,10 @@ teardown() {
   [ -z "$HOOK_STDOUT" ]
 }
 
-@test "gate: deliverables/final/report.md without marker → deny (final deliverable, governed)" {
+@test "path exclude: deliverables/final/report.md → silent allow (ADR-010 conflict, own quality system)" {
   INPUT=$(build_edit_input file_path=/project/deliverables/final/report.md)
   run_gate
-  assert_deny_json
+  assert_allowed
 }
 
 @test "path exclude: logs/run.md → silent allow (drift regression)" {


### PR DESCRIPTION
## 变更摘要

`_doc_gate_exclude.sh` 的 location 排除 case 新增 `*/deliverables/*`（与既有 `pipeline/`、`intake/` 同风格同粒度），废止原「deliverables 刻意不排除」决策。

该决策与 ADR-010（主 session 成本根治）结构性冲突：deliverables 写入必走 subagent，doc-gate marker 按 session_id 落盘，subagent 各有独立 session id，合法过门路径不存在，实测 100% 旁路率。deliverables 数据产品另有自己的质量体系（G1-G3 + Stage 6 + 交付契约），与 doc-gate 的 prose 文档卫生管辖对象不同。

### 改动文件
- `plugins/doc-gate/scripts/_doc_gate_exclude.sh` — location case 新增 `*/deliverables/*`；L10 注释改写说明废止原因
- `plugins/doc-gate/tests/exclude.bats` — `deliverables/final/report.md` 断言从 NOT excluded 翻转为 excluded
- `plugins/doc-gate/tests/skill-gate.bats` — 对应 e2e gate 测试从 `deny` 翻转为 `silent allow`（同一行为面的直接连带，未改动范围外文件）
- `plugins/doc-gate/.claude-plugin/plugin.json` / `.claude-plugin/marketplace.json` — 版本 1.5.1 → 1.6.0 双同步

`tools/_doc_gate_common.py` 及其 `test_exclude.py`（recall 语料库收录，独立机制）未改动。

## 测试结果

- `bats plugins/doc-gate/tests/*.bats` — 81/81 pass
- `pytest plugins/doc-gate/tests/` — 2/2 pass
- 回归确认：`docs/guide.md`、`CLAUDE.md` 等仍不被排除（现有用例覆盖，未变化）

## 设计权威

https://github.com/WooDragon/research/issues/49

Closes #124