### PR TITLE
feat(plan-review): 新增 codex 审阅引擎 (v1.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
   "plugins": [
     {
       "name": "plan-review",
-      "description": "Adversarial plan review via cross-model consultation (agy/Claude)",
-      "version": "1.3.1",
+      "description": "Adversarial plan review via cross-model consultation (agy/Claude/Codex)",
+      "version": "1.4.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/plan-review/.claude-plugin/plugin.json
+++ b/plugins/plan-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-review",
-  "description": "Adversarial plan review via cross-model consultation (agy/Claude)",
-  "version": "1.3.1",
+  "description": "Adversarial plan review via cross-model consultation (agy/Claude/Codex)",
+  "version": "1.4.0",
   "author": {
     "name": "woodragon"
   }

--- a/plugins/plan-review/README.md
+++ b/plugins/plan-review/README.md
@@ -20,9 +20,11 @@ claude --plugin-dir ~/.claude/dev-plugins/plan-review
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `REVIEW_ENGINE` | `gemini` | Review engine: `gemini` (routed through the local `agy` CLI) or `claude` (`claude -p` subprocess) |
+| `REVIEW_ENGINE` | `gemini` | Review engine: `gemini` (default, routed through the local `agy` CLI), `claude` (`claude -p` subprocess), or `codex` (`codex exec` subprocess) |
 | `AGY_MODEL` | `Gemini 3.1 Pro (High)` | Model id passed to the `agy` CLI when `REVIEW_ENGINE=gemini` |
 | `CLAUDE_MODEL` | `opus` | Claude model when `REVIEW_ENGINE=claude` |
+| `CODEX_BIN` | _(empty)_ | Path to the `codex` binary. Default: `codex` as resolved on `PATH`. Set this when codex is not on `PATH` |
+| `CODEX_MODEL` | _(empty)_ | Model id passed to `codex exec` when `REVIEW_ENGINE=codex`. Empty means inherit whatever `~/.codex/config.toml` specifies |
 | `GEMINI_MODEL` | `gemini-3.1-pro-preview` | Model id used only by the REST fallback payload (not the `agy` CLI path) |
 | `REVIEW_DISABLED` | `0` | Set `1` to bypass entirely |
 | `REVIEW_DRY_RUN` | `0` | Set `1` to skip engine call (synthetic APPROVE) |
@@ -86,6 +88,19 @@ When `REVIEW_ENGINE=claude`, the script spawns `claude -p` with triple isolation
 3. **`--tools ""`** — no tool calls = no PreToolUse events = no hook re-entry
 
 `unset CLAUDECODE` and `unset CLAUDE_CODE_ENTRYPOINT` prevent the subprocess from inheriting parent's internal state. This is implementation-dependent but necessary: user authenticates via OAuth (`claude login`), no `ANTHROPIC_API_KEY` available, making `claude -p` the only viable invocation path.
+
+## Engine Isolation (Codex)
+
+When `REVIEW_ENGINE=codex`, the script spawns `codex exec` with a parallel set of isolation flags:
+
+1. **`-s read-only`** — sandbox policy; the reviewer process cannot write to disk
+2. **`-C <fresh empty temp dir>`** — the working root is a throwaway empty directory, not the user's project. The codex reviewer sees only the prompt, exactly like the `agy --sandbox` and `claude --tools ""` paths — its review is pure-text and it does not read project source
+3. **`--ephemeral`** — no session files persisted to disk
+4. **`--skip-git-repo-check`** — required because the isolated temp dir is not a git repo
+
+The prompt is fed via stdin (no `ARG_MAX` limit, unlike the agy path which needs a 256KB guard), and the final message is captured via `-o <file>`.
+
+**stderr handling**: `codex exec` echoes the entire prompt to stderr. Because of this, codex's stderr is deliberately **not** appended to the plan-review log (unlike the other engines) — doing so would duplicate the full prompt into the log file. On a failed call, only a filtered diagnostic is written to the log: the banner plus trailing `warning:`/`ERROR:` lines, with any line matching the prompt stripped out, truncated to 500 chars.
 
 ## Session Reuse (agy, v1.2.0)
 

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -18,10 +18,12 @@
 #   REVIEW_DRY_RUN=1             — skip engine call, synthetic APPROVE (fallback: GEMINI_DRY_RUN)
 #   REVIEW_MAX_ROUNDS=N          — max non-Critical consultation rounds, default 3 (fallback: GEMINI_MAX_REVIEWS)
 #   REVIEW_MAX_TOTAL_ROUNDS=N    — absolute max total rounds (incl. REJECT), default 20
-#   REVIEW_ENGINE=gemini         — review engine: "gemini" (default) or "claude"
+#   REVIEW_ENGINE=gemini         — review engine: "gemini" (default), "claude", or "codex"
 #   CLAUDE_MODEL=opus            — Claude engine model (default: opus)
 #   AGY_MODEL=<id>               — agy CLI model (default: Gemini 3.1 Pro (High))
 #   GEMINI_MODEL=<id>            — REST fallback model id (default: gemini-3.1-pro-preview)
+#   CODEX_BIN=<path>             — codex engine binary override (default: codex on PATH)
+#   CODEX_MODEL=<id>             — codex engine model (default: inherit ~/.codex/config.toml)
 #   REVIEW_ENGINE_TIMEOUT=N      — engine call timeout seconds (default: 595; needs timeout/gtimeout)
 #   REVIEW_REST_TIMEOUT=N        — REST API fallback curl timeout, default 115 (equals HOOK_BUDGET; clamp logic caps actual value to remaining-3)
 #   REVIEW_REST_STALL_TIMEOUT=N  — REST SSE stall watchdog seconds, default 90 (curl --speed-time)
@@ -661,6 +663,8 @@ PROMPT_FILE=$(mktemp)
 # and HUP (terminal disconnect). Idempotent — safe to call multiple times.
 _cleanup() {
   rm -f "$PROMPT_FILE" "${ENGINE_OUT:-}" "${ENGINE_STATUS:-}" "${REQ_FILE:-}"
+  rm -f "${ENGINE_ERR:-}" "${CODEX_PROMPT_FILE:-}" "${CODEX_PROMPT_FILE:+${CODEX_PROMPT_FILE}.u8}"
+  [ -z "${CODEX_WORKDIR:-}" ] || rmdir "${CODEX_WORKDIR}" 2>/dev/null || true
   [ -z "${ENGINE_PID:-}" ] || kill "$ENGINE_PID" 2>/dev/null || true
 }
 trap '_cleanup' EXIT
@@ -709,7 +713,10 @@ if [ "$REVIEW_DRY_RUN" = "1" ]; then
 else
   # --- Pre-flight: CLI existence check (permanent failure, no retry) ---
   ENGINE_CMD="agy"
-  [ "$REVIEW_ENGINE" != "claude" ] || ENGINE_CMD="claude"
+  case "$REVIEW_ENGINE" in
+    claude) ENGINE_CMD="claude" ;;
+    codex)  ENGINE_CMD="${CODEX_BIN:-codex}" ;;
+  esac
   if ! command -v "$ENGINE_CMD" >/dev/null 2>&1; then
     log_decision "decision=allow reason=engine-not-found engine=$REVIEW_ENGINE"
     allow_with_reason "[WARNING] REVIEW_ENGINE=$REVIEW_ENGINE but '$ENGINE_CMD' not found"
@@ -718,6 +725,9 @@ else
   # Engine model variables (outside retry loop, avoid repeat assignment)
   if [ "$REVIEW_ENGINE" = "claude" ]; then
     CLAUDE_MODEL="${CLAUDE_MODEL:-opus}"
+  elif [ "$REVIEW_ENGINE" = "codex" ]; then
+    # Empty CODEX_MODEL means inherit codex's own ~/.codex/config.toml default.
+    CODEX_MODEL="${CODEX_MODEL:-}"
   else
     # GEMINI_MODEL retained as the REST fallback's model id (OpenAI-compatible payload).
     GEMINI_MODEL="${GEMINI_MODEL:-gemini-3.1-pro-preview}"
@@ -765,6 +775,46 @@ else
   ENGINE_STATUS="${ENGINE_OUT}.status"
   REVIEW=""
   HOOK_BUDGET="${REVIEW_HOOK_BUDGET:-595}"
+
+  # codex-only temp resources: a sandboxed workdir (-C target, deliberately NOT
+  # the project cwd — codex runs read-only but there's no reason to hand it the
+  # real tree), a merged prompt file (system instructions + PROMPT_FILE's
+  # dynamic content — kept SEPARATE from PROMPT_FILE itself so the REST
+  # fallback's --rawfile read of PROMPT_FILE doesn't double-send the system
+  # instructions), and an isolated stderr capture (codex echoes the FULL
+  # prompt to stderr — see the diagnostic backfill below, never let this reach
+  # LOG_FILE wholesale). Declared as empty defaults unconditionally so set -u
+  # never fires on the gemini/claude paths, and created only when
+  # REVIEW_ENGINE=codex so those paths gain zero new mktemp calls.
+  CODEX_WORKDIR="" CODEX_PROMPT_FILE="" ENGINE_ERR="" PROMPT_LINES=0
+  if [ "$REVIEW_ENGINE" = "codex" ]; then
+    CODEX_WORKDIR=$(mktemp -d)
+    CODEX_PROMPT_FILE=$(mktemp)
+    ENGINE_ERR="${ENGINE_OUT}.err"
+    { printf '%s\n\n' "$SYSTEM_INSTRUCTIONS"; cat "$PROMPT_FILE"; } > "$CODEX_PROMPT_FILE"
+    printf '\n' >> "$CODEX_PROMPT_FILE"
+    # UTF-8 sanitation (codex-only — the other engines never see this file).
+    # GLOBAL_MD/PROJECT_MD are truncated by BYTE count (`head -c 3000` / `-c 8000`),
+    # which slices a multi-byte character in half whenever a CLAUDE.md is non-ASCII
+    # near the cut. codex hard-rejects such input — it does not degrade, it aborts:
+    #   "Failed to read prompt from stdin: input is not valid UTF-8 (invalid byte
+    #    at offset N). Convert it to UTF-8 and retry"
+    # …making REVIEW_ENGINE=codex unusable for anyone with a non-ASCII CLAUDE.md.
+    # `iconv -c` drops only the orphaned bytes and keeps every valid character.
+    # Guarded on iconv's presence and on success (`&& mv || rm`), so a missing or
+    # failing iconv degrades to the unsanitized file rather than an empty prompt.
+    if command -v iconv >/dev/null 2>&1; then
+      if iconv -f UTF-8 -t UTF-8 -c < "$CODEX_PROMPT_FILE" > "${CODEX_PROMPT_FILE}.u8" 2>/dev/null; then
+        mv -f "${CODEX_PROMPT_FILE}.u8" "$CODEX_PROMPT_FILE"
+      else
+        rm -f "${CODEX_PROMPT_FILE}.u8"
+      fi
+    fi
+    # Counted AFTER sanitation: PROMPT_LINES drives the diagnostic backfill's
+    # positional cut, which must match the file codex actually received.
+    PROMPT_LINES=$(wc -l < "$CODEX_PROMPT_FILE")
+  fi
+
   for (( engine_attempt=1; engine_attempt<=2; engine_attempt++ )); do
     # Degraded-state skip: jump out of CLI retry immediately on first iteration.
     if (( engine_attempt == 1 )) && [ "$_gemini_skip_cli" = "1" ]; then
@@ -804,6 +854,67 @@ else
       ENGINE_PID=$!
       wait "$ENGINE_PID" 2>/dev/null || engine_exit=$?
       ENGINE_PID=""
+    elif [ "$REVIEW_ENGINE" = "codex" ]; then
+      # Model id can contain spaces (see AGY_MODEL's default "Gemini 3.1 Pro
+      # (High)" precedent above) — must be an array, not ${VAR:+...} word-splitting.
+      CODEX_MODEL_ARGS=()
+      [ -z "$CODEX_MODEL" ] || CODEX_MODEL_ARGS=(-m "$CODEX_MODEL")
+      ${TIMEOUT_CMD:+$TIMEOUT_CMD -k 5 $ENGINE_TIMEOUT} "$ENGINE_CMD" exec \
+        --skip-git-repo-check -s read-only --ephemeral --color never \
+        -C "$CODEX_WORKDIR" ${CODEX_MODEL_ARGS[@]+"${CODEX_MODEL_ARGS[@]}"} \
+        -o "$ENGINE_OUT" - < "$CODEX_PROMPT_FILE" > /dev/null 2> "$ENGINE_ERR" &
+      ENGINE_PID=$!
+      wait "$ENGINE_PID" 2>/dev/null || engine_exit=$?
+      ENGINE_PID=""
+
+      if [ "$engine_exit" != "0" ]; then
+        # --- Privacy boundary: codex echoes the FULL prompt to stderr before
+        # its real diagnostics (global CLAUDE.md + project CLAUDE.md + recent
+        # conversation + the plan). Never let ENGINE_ERR reach LOG_FILE
+        # wholesale — backfill only a filtered tail, two-layer defense:
+        #   Layer A (positional): locate the banner's SECOND "--------" line
+        #     (within the first 20 lines) followed by a line that is exactly
+        #     "user" — that marks where the echoed prompt begins; cut it out
+        #     using PROMPT_LINES (captured once, outside the retry loop) to
+        #     find where it ends, keeping the banner + the real tail after it.
+        #     Any of the three guards failing falls through to the fail-closed
+        #     `tail -n 20` branch, which still preserves diagnostics for
+        #     failures that happen before codex echoes anything (auth/network).
+        #   Layer B (content-based): grep -Fvxf strips any surviving line that
+        #     is byte-identical to a prompt line — this is what survives codex
+        #     version drift in line counts (banner shape / prompt line count
+        #     changing between versions).
+        # `|| true` on the ECHO_END lookup and the final pipe are MANDATORY:
+        # set -euo pipefail means a grep returning 1 (no match / everything
+        # filtered out) would otherwise kill the hook before it emits its
+        # decision JSON.
+        # LC_ALL=C on both greps (command-scoped, not exported — deliberately
+        # narrower than the LC_ALL=C prefix-assignment pattern avoided
+        # elsewhere in this file): CODEX_PROMPT_FILE embeds GLOBAL_MD/
+        # PROJECT_MD truncated by BYTE count (`head -c`), which can slice a
+        # multi-byte UTF-8 character in half. Under the active UTF-8 locale
+        # that makes grep abort with "illegal byte sequence" — silently
+        # emptying CODEX_DIAG (the trailing `|| true` hides the failure).
+        # Forcing the C locale makes grep treat input as raw bytes, matching
+        # this pipeline's real behavior anyway: -F is already a fixed-string
+        # byte match, and -x needs no locale-aware collation.
+        CODEX_DIAG=$(
+          ECHO_END=$(head -n 20 "$ENGINE_ERR" | grep -n '^--------$' | sed -n '2p' | cut -d: -f1) || true
+          NEXT_LINE=$(sed -n "$(( ${ECHO_END:-0} + 1 ))p" "$ENGINE_ERR" 2>/dev/null)
+          if [ -n "$ECHO_END" ] && [ "$ECHO_END" -le 20 ] && [ "$NEXT_LINE" = "user" ]; then
+            { head -n "$ECHO_END" "$ENGINE_ERR"
+              tail -n "+$(( ECHO_END + PROMPT_LINES + 2 ))" "$ENGINE_ERR"; }
+          else
+            tail -n 20 "$ENGINE_ERR"
+          fi \
+          | LC_ALL=C grep -Fvxf "$CODEX_PROMPT_FILE" \
+          | LC_ALL=C grep '[^[:space:]]' \
+          | head -c 500 || true
+        )
+        # tr -d '\000-\037': strip control chars, keep log single-line safe
+        # (mirrors the existing rest-debug body_prefix backfill).
+        log_decision "codex-diag $(printf '%s' "$CODEX_DIAG" | tr -d '\000-\037')"
+      fi
     else
       # --- agy multi-round session reuse ---
       # Read back a previously-captured agy conversation_id (if any) so this
@@ -861,7 +972,7 @@ ${PLAN}"
       wait "$ENGINE_PID" 2>/dev/null || engine_exit=$?
       ENGINE_PID=""
     fi
-    if [ "$REVIEW_ENGINE" = "claude" ]; then
+    if [ "$REVIEW_ENGINE" = "claude" ] || [ "$REVIEW_ENGINE" = "codex" ]; then
       REVIEW=$(cat "$ENGINE_OUT" 2>/dev/null || true)
     else
       # --- agy JSON response unwrap (--output-format json) ---

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -2975,3 +2975,324 @@ MOCK_INNER
   run_hook
   [ ! -f "${REVIEW_COUNTER_DIR}/.conversation-test-session" ]
 }
+
+# =============================================================================
+# codex engine (REVIEW_ENGINE=codex)
+# =============================================================================
+
+# codex: 1. APPROVE verdict → ack-deny, approve marker written
+@test "codex: APPROVE verdict → ack-deny, approve marker written" {
+  export REVIEW_ENGINE="codex"
+  create_mock_codex "<verdict>APPROVE</verdict>
+Looks solid."
+  INPUT=$(build_input)
+  run_hook
+
+  assert_ack_approve_json
+  [ -f "${REVIEW_COUNTER_DIR}/.review-approved-test-session" ]
+}
+
+# codex: 2. CONCERNS verdict → deny, ATTEMPT/TOTAL counters correct
+@test "codex: CONCERNS verdict → deny, ATTEMPT/TOTAL incremented" {
+  export REVIEW_ENGINE="codex"
+  create_mock_codex "<verdict>CONCERNS</verdict>
+[Major] Missing error handling."
+  INPUT=$(build_input)
+  run_hook
+
+  assert_deny_json
+  [ "$(get_counter_value)" -eq 1 ]
+  [ "$(get_total_rounds)" -eq 1 ]
+}
+
+# codex: 3. REJECT verdict → deny, ATTEMPT reset to 0 (TOTAL still increments)
+@test "codex: REJECT verdict → deny, ATTEMPT reset to 0" {
+  export REVIEW_ENGINE="codex"
+  set_counter_value 2 test-session 2
+  create_mock_codex "<verdict>REJECT</verdict>
+[Critical] Fundamentally flawed approach."
+  INPUT=$(build_input)
+  run_hook
+
+  assert_deny_json
+  [ "$(get_counter_value)" -eq 0 ]
+  [ "$(get_total_rounds)" -eq 3 ]
+}
+
+# codex: 4. codex binary missing → fail-open allow + stderr/reason WARNING
+@test "codex: binary missing → fail-open allow with WARNING" {
+  export REVIEW_ENGINE="codex"
+  INPUT=$(build_input)
+
+  # Mirror the "engine: CLI not found" guard test: rebuild PATH excluding any
+  # directory that happens to have a real `codex` installed (this plugin repo
+  # ships a codex companion, so a real binary may well be on the dev PATH).
+  local clean_path="${MOCK_BIN}"
+  local orig_path="$PATH"
+  while IFS=: read -r -d: dir || [ -n "$dir" ]; do
+    if [ -d "$dir" ] && [ ! -x "${dir}/codex" ]; then
+      clean_path="${clean_path}:${dir}"
+    fi
+  done <<< "${orig_path}:"
+
+  export PATH="$clean_path"
+  run_hook
+  export PATH="$orig_path"
+
+  assert_approve_json
+  local reason
+  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+  [[ "$reason" == *"[WARNING]"* ]]
+  [[ "$reason" == *"not found"* ]]
+}
+
+# codex: 5. CODEX_BIN pointing at a binary OUTSIDE PATH → is actually used
+@test "codex: CODEX_BIN outside PATH → used directly" {
+  export REVIEW_ENGINE="codex"
+  local outside_dir="${TEST_TEMP_DIR}/outside-path"
+  mkdir -p "$outside_dir"
+  local saved_mock_bin="$MOCK_BIN"
+  MOCK_BIN="$outside_dir"
+  create_mock_codex "<verdict>APPROVE</verdict>
+Used the CODEX_BIN override."
+  MOCK_BIN="$saved_mock_bin"
+  export CODEX_BIN="${outside_dir}/codex"
+
+  # Sanity: the override binary must NOT be reachable via bare PATH lookup.
+  ! command -v codex >/dev/null 2>&1 || [ "$(command -v codex)" != "${outside_dir}/codex" ]
+
+  INPUT=$(build_input)
+  run_hook
+
+  assert_ack_approve_json
+}
+
+# codex: 6. CODEX_MODEL empty → no -m flag; CODEX_MODEL set → -m <value> present
+@test "codex: CODEX_MODEL empty → no -m; CODEX_MODEL set → -m <value> present" {
+  export REVIEW_ENGINE="codex"
+  create_mock_codex "<verdict>APPROVE</verdict>
+ok"
+  INPUT=$(build_input)
+  run_hook
+  assert_ack_approve_json
+  [[ "$(agy_args codex)" != *"-m "* ]]
+
+  # New session_id: reusing test-session would just hit the ack-round guard
+  # (unchanged plan hash → allow without calling codex again).
+  export CODEX_MODEL="gpt-5.1-codex-max"
+  INPUT=$(build_input session_id=session-with-model)
+  run_hook
+  assert_ack_approve_json
+  [[ "$(agy_args codex)" == *"-m gpt-5.1-codex-max"* ]]
+}
+
+# codex: 7. non-zero exit → retry exhausted → REST fallback takes over
+@test "codex: non-zero exit → retry exhausted → REST fallback takes over" {
+  export REVIEW_ENGINE="codex"
+  create_failing_codex 1
+  export REVIEW_API_URL="http://localhost:9999"
+  export REVIEW_API_KEY="test-key"
+  create_mock_curl_sse '<verdict>APPROVE</verdict>\nApproved via REST.'
+  INPUT=$(build_input)
+  run_hook
+
+  assert_ack_approve_json
+  [[ "$HOOK_STDERR" == *"REST API fallback succeeded"* ]]
+}
+
+# codex: 8. empty response → retry then allow JSON with WARNING
+@test "codex: empty response → retry then allow JSON with WARNING" {
+  export REVIEW_ENGINE="codex"
+  create_mock_codex ""
+  INPUT=$(build_input)
+  run_hook
+
+  assert_approve_json
+  local reason
+  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+  [[ "$reason" == *"[WARNING]"* ]]
+}
+
+# codex: 9. invocation args carry the isolation flags; -C is NOT the project cwd
+@test "codex: invocation args include isolation flags; -C differs from project cwd" {
+  export REVIEW_ENGINE="codex"
+  create_mock_codex "<verdict>APPROVE</verdict>
+ok"
+  INPUT=$(build_input cwd=/project/dir)
+  run_hook
+  assert_ack_approve_json
+
+  local args cwd_arg
+  args=$(agy_args codex)
+  [[ "$args" == *"-s read-only"* ]]
+  [[ "$args" == *"--ephemeral"* ]]
+  [[ "$args" == *"-C "* ]]
+
+  cwd_arg=$(printf '%s' "$args" | awk '{for(i=1;i<=NF;i++) if($i=="-C"){print $(i+1); exit}}')
+  [ -n "$cwd_arg" ]
+  [ "$cwd_arg" != "/project/dir" ]
+}
+
+# codex: 10. failure path → LOG_FILE has ERROR diagnostics, no prompt body leak
+@test "codex: failure path → LOG_FILE has ERROR diagnostics, no prompt body leak" {
+  export REVIEW_ENGINE="codex"
+  create_failing_codex 1
+  # SYSTEM_INSTRUCTIONS itself contains the literal phrase "missing error
+  # handling" — this falsifies a naive keyword-based ("contains 'error'")
+  # filter, since the real diagnostic ("ERROR: mock codex failure") also
+  # contains "error" and must survive while the prompt phrase must not.
+  INPUT=$(build_input plan="Plan with an error handling gap to review.")
+  run_hook
+
+  assert_deny_json
+  assert_log_contains "ERROR: mock codex failure"
+  run grep -F "missing error handling" "${REVIEW_LOG_DIR}/plan-review.log"
+  [ "$status" -ne 0 ]
+  run grep -F "Plan with an error handling gap to review." "${REVIEW_LOG_DIR}/plan-review.log"
+  [ "$status" -ne 0 ]
+}
+
+# codex: 11. banner drift (missing second --------) → fail-closed branch still filters prompt
+@test "codex: banner drift (no second dashes) → fail-closed branch, still no prompt leak" {
+  export REVIEW_ENGINE="codex"
+  export MOCK_CODEX_NO_SECOND_DASHES=1
+  create_failing_codex 1
+  INPUT=$(build_input plan="Plan with an error handling gap to review.")
+  run_hook
+
+  assert_deny_json
+  assert_log_contains "ERROR: mock codex failure"
+  run grep -F "missing error handling" "${REVIEW_LOG_DIR}/plan-review.log"
+  [ "$status" -ne 0 ]
+  run grep -F "Plan with an error handling gap to review." "${REVIEW_LOG_DIR}/plan-review.log"
+  [ "$status" -ne 0 ]
+}
+
+# codex: 12. line-count drift (extra blank line) → Layer B content filter saves it
+@test "codex: line-count drift (extra blank) → Layer B still strips prompt content" {
+  export REVIEW_ENGINE="codex"
+  export MOCK_CODEX_EXTRA_BLANK=1
+  create_failing_codex 1
+  INPUT=$(build_input plan="Plan with an error handling gap to review.")
+  run_hook
+
+  assert_deny_json
+  assert_log_contains "ERROR: mock codex failure"
+  run grep -F "missing error handling" "${REVIEW_LOG_DIR}/plan-review.log"
+  [ "$status" -ne 0 ]
+  run grep -F "Plan with an error handling gap to review." "${REVIEW_LOG_DIR}/plan-review.log"
+  [ "$status" -ne 0 ]
+}
+
+# codex: 13. retry cycle (fail then succeed) → temp resources reclaimed, no leftover prompt content
+@test "codex: retry cycle (fail then succeed) → no leftover temp file with prompt content" {
+  export REVIEW_ENGINE="codex"
+  # Ad-hoc flaky mock (create_flaky_engine's stdout-based contract doesn't
+  # fit codex's -o-file contract): fails attempt 1 (reproducing the real
+  # stderr shape), succeeds attempt 2 by writing to the -o file.
+  local state_file="${TEST_TEMP_DIR}/.codex-flaky-state"
+  local args_file="${MOCK_BIN}/../.agy-args-codex"
+  cat > "${MOCK_BIN}/codex" << MOCK_EOF
+#!/bin/bash
+printf '%s\n' "\$*" > '${args_file}'
+out_file=""
+prev=""
+for arg in "\$@"; do
+  if [ "\$prev" = "-o" ]; then out_file="\$arg"; fi
+  prev="\$arg"
+done
+if [ ! -f "${state_file}" ]; then
+  touch "${state_file}"
+  {
+    echo "codex-cli 0.0.0-mock"
+    echo "--------"
+    echo "workdir: /tmp/mock"
+    echo "model: mock-model"
+    echo "provider: mock"
+    echo "approval: never"
+    echo "sandbox: read-only"
+    echo "reasoning effort: mock"
+    echo "reasoning summaries: mock"
+    echo "session: mock-session"
+    echo "--------"
+    echo "user"
+    cat
+    echo ""
+    echo "warning: mock warning line"
+    echo "ERROR: mock codex failure"
+  } >&2
+  exit 1
+fi
+if [ -n "\$out_file" ]; then
+  cat > "\$out_file" << 'OUTPUT_EOF'
+<verdict>APPROVE</verdict>
+Recovered on retry.
+OUTPUT_EOF
+fi
+exit 0
+MOCK_EOF
+  chmod +x "${MOCK_BIN}/codex"
+
+  INPUT=$(build_input plan="Unique-Marker-Plan-Content-For-Leak-Check")
+  run_hook
+  assert_ack_approve_json
+
+  # ENGINE_OUT and CODEX_WORKDIR are created once, OUTSIDE the retry loop —
+  # both attempts share them, so the (successful) second invocation's
+  # captured args still name the paths used throughout the whole cycle.
+  local args engine_out codex_workdir
+  args=$(agy_args codex)
+  engine_out=$(printf '%s' "$args" | awk '{for(i=1;i<=NF;i++) if($i=="-o"){print $(i+1); exit}}')
+  codex_workdir=$(printf '%s' "$args" | awk '{for(i=1;i<=NF;i++) if($i=="-C"){print $(i+1); exit}}')
+  [ -n "$engine_out" ]
+  [ -n "$codex_workdir" ]
+  [ ! -e "$engine_out" ]
+  [ ! -e "${engine_out}.err" ]
+  [ ! -d "$codex_workdir" ]
+
+  # Best-effort sweep of the shared mktemp parent dir (where CODEX_PROMPT_FILE
+  # — not derivable from captured args — also lived) for the plan's unique
+  # marker, bounded to files touched during this test to avoid false hits
+  # from unrelated concurrent temp files.
+  local tmp_parent
+  tmp_parent=$(dirname "$engine_out")
+  if [ -d "$tmp_parent" ]; then
+    run bash -c "find '$tmp_parent' -maxdepth 1 -type f -newer '$state_file' -exec grep -l 'Unique-Marker-Plan-Content-For-Leak-Check' {} + 2>/dev/null"
+    [ -z "$output" ]
+  fi
+}
+
+@test "codex: byte-truncated non-ASCII CLAUDE.md → prompt sanitized to valid UTF-8" {
+  export REVIEW_ENGINE="codex"
+  # Reproduce the real-world break: PROJECT_MD is read with `head -c 8000`,
+  # a BYTE cut. A CLAUDE.md whose 8000th byte lands inside a multi-byte
+  # character yields an orphaned lead byte in the merged prompt, and codex
+  # hard-rejects such stdin ("input is not valid UTF-8") rather than degrading.
+  # Without the iconv sanitation this test fails with engines-failed.
+  local proj_dir="${TEST_TEMP_DIR}/proj"
+  mkdir -p "$proj_dir"
+  # 7999 ASCII bytes, then a 3-byte CJK char → head -c 8000 keeps only its
+  # first byte (0xE4), producing an invalid sequence at the cut.
+  {
+    printf 'a%.0s' $(seq 1 7999)
+    printf '中文内容\n'
+  } > "${proj_dir}/CLAUDE.md"
+
+  # Sanity-check the fixture itself: the truncated slice MUST be invalid UTF-8,
+  # otherwise this test would pass vacuously.
+  run bash -c "head -c 8000 '${proj_dir}/CLAUDE.md' | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1"
+  [ "$status" -ne 0 ]
+
+  MOCK_CODEX_STRICT_UTF8=1 create_mock_codex "<verdict>APPROVE</verdict>
+Sanitized fine."
+  export MOCK_CODEX_STRICT_UTF8=1
+
+  INPUT=$(build_input cwd="$proj_dir" plan="Test plan content")
+  run_hook
+
+  # The mock rejects invalid stdin with exit 1 → hook would deny with
+  # engines-failed. Reaching the APPROVE ack-deny proves sanitation happened.
+  assert_ack_approve_json
+  [[ "$HOOK_STDOUT" != *"engines-failed"* ]]
+  [[ "$HOOK_STDERR" != *"not valid UTF-8"* ]]
+}

--- a/plugins/plan-review/tests/test_helper/common-setup.bash
+++ b/plugins/plan-review/tests/test_helper/common-setup.bash
@@ -216,6 +216,122 @@ MOCK_EOF
   chmod +x "${MOCK_BIN}/${name}"
 }
 
+# create_mock_codex <output>
+#   Creates an executable mock at MOCK_BIN/codex reproducing the real `codex
+#   exec ... -o <file> -` contract: reads the prompt from stdin, writes
+#   <output> (the final agent message) to the file named by the `-o` flag,
+#   and echoes the REAL codex stderr shape to fd 2 (stdout is discarded by
+#   the production script's `> /dev/null`, so anything meant to be visible
+#   must go to stderr) — this is what the 1.6 diagnostic-backfill filter is
+#   tested against:
+#     line 1:      banner text
+#     line 2:      -------- (first)
+#     lines 3-10:  8 metadata lines
+#     line 11:     -------- (second) — omit via MOCK_CODEX_NO_SECOND_DASHES=1
+#     line 12:     user (extra blank line after it via MOCK_CODEX_EXTRA_BLANK=1)
+#     then:        the prompt, cat'd back verbatim from stdin
+#     then:        blank line + warning: + "ERROR: mock codex failure"
+#   Captures "$*" to .agy-args-codex (same convention as create_mock_engine;
+#   read it back with the existing `agy_args "codex"` helper). Always exits 0
+#   — pair with create_failing_codex for non-zero-exit scenarios.
+create_mock_codex() {
+  local output="$1"
+  local args_file="${MOCK_BIN}/../.agy-args-codex"
+  cat > "${MOCK_BIN}/codex" << MOCK_EOF
+#!/bin/bash
+printf '%s\n' "\$*" > '${args_file}'
+out_file=""
+prev=""
+for arg in "\$@"; do
+  if [ "\$prev" = "-o" ]; then out_file="\$arg"; fi
+  prev="\$arg"
+done
+# Slurp stdin once so it can be validated before being echoed back.
+_mock_stdin=\$(mktemp)
+cat > "\$_mock_stdin"
+# MOCK_CODEX_STRICT_UTF8=1 reproduces the real codex contract: it hard-rejects
+# non-UTF-8 stdin instead of degrading. Byte-truncated CLAUDE.md content
+# (head -c 3000 / -c 8000) can slice a multi-byte char in half, so without
+# sanitation the real binary aborts with exactly this class of error.
+if [ -n "\${MOCK_CODEX_STRICT_UTF8:-}" ] \\
+   && ! iconv -f UTF-8 -t UTF-8 < "\$_mock_stdin" >/dev/null 2>&1; then
+  echo "Failed to read prompt from stdin: input is not valid UTF-8 (invalid byte at offset 0). Convert it to UTF-8 and retry" >&2
+  rm -f "\$_mock_stdin"
+  exit 1
+fi
+{
+  echo "codex-cli 0.0.0-mock"
+  echo "--------"
+  echo "workdir: /tmp/mock"
+  echo "model: mock-model"
+  echo "provider: mock"
+  echo "approval: never"
+  echo "sandbox: read-only"
+  echo "reasoning effort: mock"
+  echo "reasoning summaries: mock"
+  echo "session: mock-session"
+  if [ -z "\${MOCK_CODEX_NO_SECOND_DASHES:-}" ]; then
+    echo "--------"
+  fi
+  echo "user"
+  if [ -n "\${MOCK_CODEX_EXTRA_BLANK:-}" ]; then
+    echo ""
+  fi
+  cat "\$_mock_stdin"
+  echo ""
+  echo "warning: mock warning line"
+  echo "ERROR: mock codex failure"
+} >&2
+rm -f "\$_mock_stdin"
+if [ -n "\$out_file" ]; then
+  cat > "\$out_file" << 'OUTPUT_EOF'
+${output}
+OUTPUT_EOF
+fi
+exit 0
+MOCK_EOF
+  chmod +x "${MOCK_BIN}/codex"
+}
+
+# create_failing_codex <exit_code>
+#   Same stderr shape as create_mock_codex (banner + verbatim stdin echo +
+#   ERROR tail — honors the same MOCK_CODEX_NO_SECOND_DASHES / EXTRA_BLANK
+#   knobs), but exits with the given code and never writes to the -o file
+#   (mirrors a real crash: no final agent message was produced).
+create_failing_codex() {
+  local exit_code="$1"
+  local args_file="${MOCK_BIN}/../.agy-args-codex"
+  cat > "${MOCK_BIN}/codex" << MOCK_EOF
+#!/bin/bash
+printf '%s\n' "\$*" > '${args_file}'
+{
+  echo "codex-cli 0.0.0-mock"
+  echo "--------"
+  echo "workdir: /tmp/mock"
+  echo "model: mock-model"
+  echo "provider: mock"
+  echo "approval: never"
+  echo "sandbox: read-only"
+  echo "reasoning effort: mock"
+  echo "reasoning summaries: mock"
+  echo "session: mock-session"
+  if [ -z "\${MOCK_CODEX_NO_SECOND_DASHES:-}" ]; then
+    echo "--------"
+  fi
+  echo "user"
+  if [ -n "\${MOCK_CODEX_EXTRA_BLANK:-}" ]; then
+    echo ""
+  fi
+  cat
+  echo ""
+  echo "warning: mock warning line"
+  echo "ERROR: mock codex failure"
+} >&2
+exit ${exit_code}
+MOCK_EOF
+  chmod +x "${MOCK_BIN}/codex"
+}
+
 # create_mock_curl <response_body> [http_status]
 #   Creates an executable mock curl at MOCK_BIN/curl that:
 #   - writes <response_body> to the file specified by -o flag (curl -o behavior)


### PR DESCRIPTION
## 动机

plan-review 目前只有两个一等引擎：`gemini`（经 `agy` CLI）与 `claude`（`claude -p`）。虽然已有 OpenAI 兼容的 REST 兜底，但它**只在 CLI 引擎失败后触发**——若 `agy` 二进制不存在，脚本在 pre-flight 阶段就 fail-open 退出，根本到不了 REST。所以 REST 无法充当主引擎。

本 PR 加入第三个一等引擎 `REVIEW_ENGINE=codex`，走 codex 自身的 auth / provider 配置，用户无需另配 key。

**改动是纯增量的**：`agy` / `claude` 两条路径一行未动。

## 为什么 codex 的接入契约比另两个更干净

| 能力 | codex exec | 对比 |
|---|---|---|
| prompt 通道 | **stdin** | agy 只能走命令行参数，需 256KB ARG_MAX 防护 |
| 输出通道 | `-o FILE`，纯文本最终消息 | agy 的 JSON 非良构（`response` 字段含未转义换行），需 awk 手撕 |
| verdict 提取 | **零改动复用**既有提取器 | — |
| 沙箱 | `-s read-only` + `--ephemeral` | — |

实测数据（9.6KB 真实体量 prompt，含完整 `SYSTEM_INSTRUCTIONS`）：

| reasoning effort | 耗时 | verdict |
|---|---|---|
| low | 32s | ✅ |
| medium | 41s | ✅ |
| xhigh | 33s | ✅ |

均远低于 595s hook 预算，故**不 pin 默认 effort**，继承用户 `~/.codex/config.toml`。

## 隔离等价性

`-C` 指向一个**临时空目录**而非项目 cwd，配合 `-s read-only`：codex 只看得到 prompt，不读项目源码，与 `agy --sandbox` / `claude --tools ""` 的可见范围等价。README 的 Privacy Notice 数据边界因此**无需改动**。

## 两处非显然但必需的处理

### 1. stderr 隔离（隐私边界）

`codex exec` 会把**完整 prompt 回显到 stderr**（实测 11760B stderr vs 9634B prompt）。若照搬既有引擎的 `2>>"$LOG_FILE"`，每轮审阅会把全局 CLAUDE.md、项目 CLAUDE.md、近期对话与 plan 正文共约 12KB 写进 `~/.claude/logs/plan-review.log`。

故 codex 用独立 stderr 文件，仅在失败时回填**过滤后**的诊断，双层互补防御：

- **A 层 位置切分**：定位 banner 第 2 个 `--------` + 其后必须是字面量 `user` + 锚点须在前 20 行内（三重守卫，任一不满足即走 fail-closed）。挡的是折行/重排产生的非逐字片段。
- **B 层 `grep -Fvxf`**：逐行剔除与 prompt 字节相同的行。挡的是 codex 换版导致的行数漂移。实测 156 行 stderr → 17 个非空行，7 个 prompt 特征串残留全为 0。

管道末尾 `|| true` 是必需的——脚本是 `set -euo pipefail`，两个 grep 在诊断被全滤净时均返回 1，会在输出决策 JSON **之前**杀死 hook。

### 2. UTF-8 净化

`GLOBAL_MD` / `PROJECT_MD` 用 `head -c 3000` / `-c 8000` 按**字节**截断，CLAUDE.md 只要在切点附近含非 ASCII 就会被腰斩出半个字符。**codex 对 stdin 硬校验 UTF-8——直接 abort，不降级**：

```
Failed to read prompt from stdin: input is not valid UTF-8 (invalid byte at offset 12457)
```

这会让 `REVIEW_ENGINE=codex` 对**任何 CLAUDE.md 含非 ASCII 的用户完全不可用**。拼接 prompt 后经 `iconv -c` 净化（仅 codex 分支，其它引擎不受影响；iconv 缺失或失败则降级为不净化，不会产生空 prompt）。

> 顺带一提：字节截断本身是上游共性问题，只是另两个引擎不校验所以没暴露。如果你倾向从根上修（把 `head -c` 改成字符感知截断），我可以另开一个 PR——本 PR 刻意没碰它，以免影响 agy/claude 行为。

## 未实现

**多轮 session 复用**（`codex exec resume`）。与 `claude` 引擎形态一致，留作后续增强。选择不做的理由：agy 做复用是为了压 Gemini 的 429，codex 无此压力；而 resume 会引入 stale-session 一类新故障（agy 那条路径为此写了 6 处 `CONV_FILE` 清理逻辑），对上限仅 3 轮的磋商收益有限。

## 测试

新增 **14 条**用例，其中 5 条是针对上述设计的**证伪式断言**（刻意构造会让错误实现通过不了的场景）：

| 用例 | 证伪什么 |
|---|---|
| 失败路径日志无 prompt 正文 | 用含 `error` 字样的 prompt 驱动，证伪"关键词过滤"写法（`SYSTEM_INSTRUCTIONS` 原文就含 "missing error handling"，实测 3 行命中） |
| banner 形态漂移 | 证伪 fail-closed 分支丢诊断 |
| 行数漂移（`user` 后插空行） | 证伪"位置切分单层足够" |
| 重试后临时文件残留 | 锁死"临时资源建在重试循环外"的生命周期 |
| 字节截断的非 ASCII CLAUDE.md | 证伪缺少 UTF-8 净化（已验证：移除 `iconv` 后该用例失败） |

**全量结果**：`bats tests/` → 201 条，**199 通过 / 0 跳过**。

余下 2 条（`rest-sse: oversized prompt → skip agy, REST fallback used` 与 `degrade: degraded state + REST fails → deny with degraded + REST reason`）在**未改动的 `b72d89e` 基线上以同样的用例名失败**（基线 187 条 / 185 通过 / 同样 2 条失败），属既有问题，非本 PR 引入。

**真实端到端验证**（非 mock，走真 codex 二进制）：hook 返回合法 JSON、`verdict=REJECT` 由引擎正常产出未 fallback、日志中 4 个 prompt 特征串命中数全为 0、临时目录与临时文件跑完零残留。

## 验证边界（未验证项）

本地 codex 只有一种 provider 配置（OpenAI 兼容代理 + API key）。**未验证** ChatGPT 订阅登录态、`api.openai.com` 直连、`--oss` 本地模型这三种形态下的行为。不声称全配置可用。

## 后续建议

引擎分支已至 3 路，`REVIEW_ENGINE` 的判断散在脚本 5 处。本 PR 刻意保持 additive 以降低回归风险与 review 成本，但后续或可考虑抽象出 `engine_probe` / `engine_invoke` / `engine_extract` 三个钩子。是否值得由你判断。
