### PR TITLE
fix(plan-review): codex 引擎表述收窄 + 测试夹具环境隔离

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ WooDragon 的 Claude Code 插件 + 技能包 marketplace。
 
 | 类型 | 名称 | 说明 |
 |------|------|------|
-| Plugin | plan-review | 对抗性审阅（Gemini/Claude） |
+| Plugin | plan-review | 对抗性审阅（Gemini/Claude/Codex） |
 | Plugin | ppt-press（4 skills） | PPT 全生命周期（init/create/deploy/manage） |
 | Plugin | doc-gate（1 skill + 3 hooks + 2 tools） | 文档编辑门禁 + 词法召回 |
 | Plugin | code-search（1 skill） | 代码搜索与符号导航方法论（纯 skill，零 hook） |
@@ -35,7 +35,7 @@ plugins/
     scripts/dispatch-check.sh     # Layer 2 hook（Agent/Task 调度参数强制）
     scripts/precompact-review.sh  # PreCompact hook（compaction 恢复）
     tests/                        # BDD 测试套件（bats-core）
-      plan-review.bats            # 109 个测试用例（含 Dispatch Manifest）
+      plan-review.bats            # 202 个测试用例（含 Dispatch Manifest、codex 引擎）
       dispatch-check.bats         # 14 个测试用例（Layer 2 hook）
       test_helper/
         common-setup.bash         # 测试基础设施（mock、断言）
@@ -106,7 +106,7 @@ plugins/
 
 | 插件 | 变量前缀/名称 | 权威文档 |
 |------|--------------|----------|
-| plan-review | `REVIEW_*`、`AGY_MODEL`、`CLAUDE_MODEL`、`GEMINI_MODEL`、`DISPATCH_CHECK_DISABLED` | [plugins/plan-review/README.md](plugins/plan-review/README.md#environment-variables) |
+| plan-review | `REVIEW_*`、`AGY_MODEL`、`CLAUDE_MODEL`、`GEMINI_MODEL`、`CODEX_BIN`、`CODEX_MODEL`、`DISPATCH_CHECK_DISABLED` | [plugins/plan-review/README.md](plugins/plan-review/README.md#environment-variables) |
 | doc-gate | `SKILL_GATE_*`、`RECALL_GATE_*` | [plugins/doc-gate/README.md](plugins/doc-gate/README.md#environment-variables) |
 | deep-research | `GATEWAY_API_KEY`、`TAVILY_API_KEY`、`JINA_API_KEY`（可选凭证） | [plugins/deep-research/README.md](plugins/deep-research/README.md#prerequisites) |
 | pr-review | `GROK_MODEL`、`GROK_EFFORT`、`XDG_STATE_HOME`（session 落盘根） | [plugins/pr-review/README.md](plugins/pr-review/README.md#prerequisites) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ plugins/
     scripts/dispatch-check.sh     # Layer 2 hook（Agent/Task 调度参数强制）
     scripts/precompact-review.sh  # PreCompact hook（compaction 恢复）
     tests/                        # BDD 测试套件（bats-core）
-      plan-review.bats            # 202 个测试用例（含 Dispatch Manifest、codex 引擎）
+      plan-review.bats            # 主测试套件（含 Dispatch Manifest、codex 引擎）
       dispatch-check.bats         # 14 个测试用例（Layer 2 hook）
       test_helper/
         common-setup.bash         # 测试基础设施（mock、断言）

--- a/plugins/plan-review/README.md
+++ b/plugins/plan-review/README.md
@@ -2,7 +2,7 @@
 
 Adversarial red-team review of implementation plans via cross-model consultation.
 
-When Claude calls `ExitPlanMode`, this plugin intercepts the call and sends the plan to a review engine (Gemini or Claude) for adversarial scrutiny. The reviewer can APPROVE, raise CONCERNS, or REJECT. On non-approval, feedback is returned to Claude for revision or rebuttal. After max rounds without consensus, the plan passes through for user arbitration.
+When Claude calls `ExitPlanMode`, this plugin intercepts the call and sends the plan to a review engine (Gemini, Claude, or Codex) for adversarial scrutiny. The reviewer can APPROVE, raise CONCERNS, or REJECT. On non-approval, feedback is returned to Claude for revision or rebuttal. After max rounds without consensus, the plan passes through for user arbitration.
 
 ## Installation
 
@@ -94,11 +94,13 @@ When `REVIEW_ENGINE=claude`, the script spawns `claude -p` with triple isolation
 When `REVIEW_ENGINE=codex`, the script spawns `codex exec` with a parallel set of isolation flags:
 
 1. **`-s read-only`** — sandbox policy; the reviewer process cannot write to disk
-2. **`-C <fresh empty temp dir>`** — the working root is a throwaway empty directory, not the user's project. The codex reviewer sees only the prompt, exactly like the `agy --sandbox` and `claude --tools ""` paths — its review is pure-text and it does not read project source
+2. **`-C <fresh empty temp dir>`** — the working root is a throwaway empty directory, not the user's project, so the reviewer does not read project source
 3. **`--ephemeral`** — no session files persisted to disk
 4. **`--skip-git-repo-check`** — required because the isolated temp dir is not a git repo
 
 The prompt is fed via stdin (no `ARG_MAX` limit, unlike the agy path which needs a 256KB guard), and the final message is captured via `-o <file>`.
+
+**Tool-surface caveat**: the four flags above constrain the file scope the reviewer sees; they do not disable codex's agent tool surface. Whether MCP servers or web search remain available to the reviewer follows the user's own `~/.codex/config.toml`. This differs from the `claude` engine, where `--tools ""` removes the tool surface outright. The plugin leaves codex's tool configuration to the user rather than overriding it — silently rewriting a user's engine config is the worse trade. Users who require a text-only reviewer should disable those tools in their codex configuration.
 
 **stderr handling**: `codex exec` echoes the entire prompt to stderr. Because of this, codex's stderr is deliberately **not** appended to the plan-review log (unlike the other engines) — doing so would duplicate the full prompt into the log file. On a failed call, only a filtered diagnostic is written to the log: the banner plus trailing `warning:`/`ERROR:` lines, with any line matching the prompt stripped out, truncated to 500 chars.
 
@@ -124,7 +126,7 @@ This lowers 429 frequency and quota consumption on multi-round negotiations. The
 
 ## Privacy Notice
 
-This plugin sends the following data to the configured review engine (Gemini API or Anthropic API):
+This plugin sends the following data to the configured review engine — the Gemini API, the Anthropic API, or, when `REVIEW_ENGINE=codex`, whichever provider the user's `~/.codex/config.toml` selects:
 
 - **Global CLAUDE.md** — first 3KB of `~/.claude/CLAUDE.md`
 - **Project CLAUDE.md** — first 8KB of `$CWD/CLAUDE.md`

--- a/plugins/plan-review/README.md
+++ b/plugins/plan-review/README.md
@@ -94,7 +94,7 @@ When `REVIEW_ENGINE=claude`, the script spawns `claude -p` with triple isolation
 When `REVIEW_ENGINE=codex`, the script spawns `codex exec` with a parallel set of isolation flags:
 
 1. **`-s read-only`** — sandbox policy; the reviewer process cannot write to disk
-2. **`-C <fresh empty temp dir>`** — the working root is a throwaway empty directory, not the user's project, so the reviewer does not read project source
+2. **`-C <fresh empty temp dir>`** — the working root is a throwaway empty directory, not the user's project. This relocates the working root; on its own it does not stop a tool from reaching paths outside that directory (see the tool-surface caveat below)
 3. **`--ephemeral`** — no session files persisted to disk
 4. **`--skip-git-repo-check`** — required because the isolated temp dir is not a git repo
 

--- a/plugins/plan-review/hooks/hooks.json
+++ b/plugins/plan-review/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Adversarial red-team review on ExitPlanMode via Gemini or Claude engine",
+  "description": "Adversarial red-team review on ExitPlanMode via Gemini, Claude, or Codex engine",
   "hooks": {
     "PreToolUse": [
       {

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -3,7 +3,7 @@
 #
 # Triggered when Plan agent calls ExitPlanMode (via PreToolUse matcher).
 # Flow (severity-aware adversarial consultation):
-#   ExitPlanMode called → hook intercepts → review engine (Gemini/Claude) reviews:
+#   ExitPlanMode called → hook intercepts → review engine (Gemini/Claude/Codex) reviews:
 #     APPROVE  → deny with review feedback (ack-deny); next ExitPlanMode allows (ack-round)
 #     CONCERNS → deny with feedback, increment ATTEMPT + TOTAL, Claude revises or rebuts
 #     REJECT   → deny with feedback, increment TOTAL only (ATTEMPT frozen), Critical must resolve

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -3296,3 +3296,41 @@ Sanitized fine."
   [[ "$HOOK_STDOUT" != *"engines-failed"* ]]
   [[ "$HOOK_STDERR" != *"not valid UTF-8"* ]]
 }
+
+# fixture: reset_leaky_env must clear every env var a developer shell might
+# export. Regression guard — the codex vars were missed when the codex engine
+# landed, and with CODEX_MODEL exported the "codex: CODEX_MODEL empty → no -m"
+# case failed outright. Asserting `-z` on the vars as they stand after
+# common_setup would prove nothing (a clean shell passes either way), so this
+# pollutes first and calls reset_leaky_env directly.
+@test "fixture: reset_leaky_env clears developer-shell env leakage" {
+  export CODEX_BIN="/nonexistent/codex"
+  export CODEX_MODEL="leaked-model"
+  export MOCK_CODEX_STRICT_UTF8=1
+  export MOCK_CODEX_NO_SECOND_DASHES=1
+  export MOCK_CODEX_EXTRA_BLANK=1
+  export REVIEW_API_URL="http://leaked.invalid"
+  export REVIEW_API_KEY="leaked-key"
+  export REVIEW_HOOK_BUDGET=1
+  export REVIEW_ENGINE_DEGRADE_TTL=1
+  export GEMINI_REVIEW_OFF=1
+  export GEMINI_DRY_RUN=1
+  export GEMINI_MAX_REVIEWS=1
+  export PLAN_REVIEW_RUNNING=1
+
+  reset_leaky_env
+
+  [ -z "${CODEX_BIN:-}" ]
+  [ -z "${CODEX_MODEL:-}" ]
+  [ -z "${MOCK_CODEX_STRICT_UTF8:-}" ]
+  [ -z "${MOCK_CODEX_NO_SECOND_DASHES:-}" ]
+  [ -z "${MOCK_CODEX_EXTRA_BLANK:-}" ]
+  [ -z "${REVIEW_API_URL:-}" ]
+  [ -z "${REVIEW_API_KEY:-}" ]
+  [ -z "${REVIEW_HOOK_BUDGET:-}" ]
+  [ -z "${REVIEW_ENGINE_DEGRADE_TTL:-}" ]
+  [ -z "${GEMINI_REVIEW_OFF:-}" ]
+  [ -z "${GEMINI_DRY_RUN:-}" ]
+  [ -z "${GEMINI_MAX_REVIEWS:-}" ]
+  [ -z "${PLAN_REVIEW_RUNNING:-}" ]
+}

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -3334,3 +3334,24 @@ Sanitized fine."
   [ -z "${GEMINI_MAX_REVIEWS:-}" ]
   [ -z "${PLAN_REVIEW_RUNNING:-}" ]
 }
+
+# fixture: the call site, not just the helper. The case above stays green even
+# if common_setup stops calling reset_leaky_env — it invokes the helper
+# directly. This one pollutes, re-enters common_setup, and asserts the vars
+# were cleared, so severing the call site turns it red.
+#
+# common_setup is not re-entrant for free: it runs `mktemp -d` and reassigns
+# TEST_TEMP_DIR, orphaning the previous one (common_teardown only removes
+# whatever TEST_TEMP_DIR points at last). The stale path is captured and
+# removed explicitly rather than left in /tmp.
+@test "fixture: common_setup calls reset_leaky_env" {
+  export CODEX_MODEL="leaked-model"
+  export CODEX_BIN="/nonexistent/codex"
+
+  local stale_temp_dir="$TEST_TEMP_DIR"
+  common_setup
+  rm -rf "$stale_temp_dir"
+
+  [ -z "${CODEX_MODEL:-}" ]
+  [ -z "${CODEX_BIN:-}" ]
+}

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -3317,6 +3317,9 @@ Sanitized fine."
   export GEMINI_DRY_RUN=1
   export GEMINI_MAX_REVIEWS=1
   export PLAN_REVIEW_RUNNING=1
+  export AGY_MODEL="leaked-agy-model"
+  export CLAUDE_MODEL="leaked-claude-model"
+  export GEMINI_MODEL="leaked-gemini-model"
 
   reset_leaky_env
 
@@ -3333,6 +3336,9 @@ Sanitized fine."
   [ -z "${GEMINI_DRY_RUN:-}" ]
   [ -z "${GEMINI_MAX_REVIEWS:-}" ]
   [ -z "${PLAN_REVIEW_RUNNING:-}" ]
+  [ -z "${AGY_MODEL:-}" ]
+  [ -z "${CLAUDE_MODEL:-}" ]
+  [ -z "${GEMINI_MODEL:-}" ]
 }
 
 # fixture: the call site, not just the helper. The case above stays green even

--- a/plugins/plan-review/tests/test_helper/common-setup.bash
+++ b/plugins/plan-review/tests/test_helper/common-setup.bash
@@ -52,10 +52,13 @@ common_setup() {
 # reset_leaky_env
 #   Unsets every env var a developer shell might export that would otherwise
 #   reshape a test run. Kept as its own function, separate from common_setup,
-#   for two reasons: the isolation becomes directly testable (common_setup
-#   cannot be re-invoked from a test body — its `mktemp -d` would leak a temp
-#   dir past teardown), and adding a fourth engine has one obvious place to
-#   register its vars. Pure unsets, no side effects, safe to call repeatedly.
+#   for two reasons: the isolation becomes directly testable without paying
+#   common_setup's side effects (re-entering it orphans the previous
+#   TEST_TEMP_DIR, since `mktemp -d` reassigns it and common_teardown only
+#   removes the last one — a caller that re-enters must rm the stale path
+#   itself, as the "common_setup calls reset_leaky_env" case does), and adding
+#   a fourth engine has one obvious place to register its vars. Pure unsets,
+#   no side effects, safe to call repeatedly.
 #
 #   Whenever the production script grows a new `${SOME_VAR:-default}` read,
 #   SOME_VAR belongs here.

--- a/plugins/plan-review/tests/test_helper/common-setup.bash
+++ b/plugins/plan-review/tests/test_helper/common-setup.bash
@@ -78,6 +78,14 @@ reset_leaky_env() {
   # Degraded state TTL override
   unset REVIEW_ENGINE_DEGRADE_TTL
 
+  # Per-engine model ids. None of these change control flow today, so an
+  # exported value breaks nothing at present — they are listed to keep this
+  # function matching the rule stated above rather than drifting into "the
+  # vars we happened to get burned by".
+  unset AGY_MODEL
+  unset CLAUDE_MODEL
+  unset GEMINI_MODEL
+
   # codex engine. CODEX_BIN matters most: production resolves the binary as
   # "${CODEX_BIN:-codex}", so a developer who exports it sends the codex cases
   # at a REAL binary instead of MOCK_BIN/codex — which may hit the network,

--- a/plugins/plan-review/tests/test_helper/common-setup.bash
+++ b/plugins/plan-review/tests/test_helper/common-setup.bash
@@ -43,26 +43,56 @@ common_setup() {
   # High timeout for tests (mock engines return instantly)
   export REVIEW_ENGINE_TIMEOUT=90
 
-  # Prevent recursive guard from firing
+  reset_leaky_env
+
+  # Remove any residual degraded state file from previous tests
+  rm -f "${REVIEW_COUNTER_DIR}/.gemini-degraded"
+}
+
+# reset_leaky_env
+#   Unsets every env var a developer shell might export that would otherwise
+#   reshape a test run. Kept as its own function, separate from common_setup,
+#   for two reasons: the isolation becomes directly testable (common_setup
+#   cannot be re-invoked from a test body — its `mktemp -d` would leak a temp
+#   dir past teardown), and adding a fourth engine has one obvious place to
+#   register its vars. Pure unsets, no side effects, safe to call repeatedly.
+#
+#   Whenever the production script grows a new `${SOME_VAR:-default}` read,
+#   SOME_VAR belongs here.
+reset_leaky_env() {
+  # Recursive guard
   unset PLAN_REVIEW_RUNNING
 
-  # Prevent legacy env vars from leaking in
+  # Legacy env vars
   unset GEMINI_REVIEW_OFF
   unset GEMINI_DRY_RUN
   unset GEMINI_MAX_REVIEWS
 
-  # Prevent REST fallback env vars from leaking in
+  # REST fallback
   unset REVIEW_API_URL
   unset REVIEW_API_KEY
 
-  # Prevent hook budget override from leaking in
+  # Hook budget override
   unset REVIEW_HOOK_BUDGET
 
-  # Prevent degraded state TTL override from leaking in
+  # Degraded state TTL override
   unset REVIEW_ENGINE_DEGRADE_TTL
 
-  # Remove any residual degraded state file from previous tests
-  rm -f "${REVIEW_COUNTER_DIR}/.gemini-degraded"
+  # codex engine. CODEX_BIN matters most: production resolves the binary as
+  # "${CODEX_BIN:-codex}", so a developer who exports it sends the codex cases
+  # at a REAL binary instead of MOCK_BIN/codex — which may hit the network,
+  # run slow, or pass for the wrong reason. CODEX_MODEL breaks the
+  # "empty → no -m flag" case outright.
+  unset CODEX_BIN
+  unset CODEX_MODEL
+
+  # Mock codex behavior switches — scoped per-test via `export` in the cases
+  # that need them. bats runs each test in its own subshell so they do not
+  # normally leak across cases, but a developer shell that exported one would
+  # silently reshape every codex case.
+  unset MOCK_CODEX_NO_SECOND_DASHES
+  unset MOCK_CODEX_EXTRA_BLANK
+  unset MOCK_CODEX_STRICT_UTF8
 }
 
 common_teardown() {


### PR DESCRIPTION
PR #142（codex 审阅引擎）合并后的 followup，收掉评审中提出、约定由维护侧跟进的三项。原 PR 作者已知会，未重复劳动。

## 1. README 隔离等价性表述收窄

原文声称 codex 的隔离 "exactly like the `agy --sandbox` and `claude --tools \"\"` paths"。这个等价不成立：

- `-C <空临时目录>` + `-s read-only` 约束的是**文件可见范围**——reviewer 不读项目源码，这点成立
- 但它**不关闭 codex 的 agent 工具面**。MCP / web search 是否可用，取决于用户自己的 `~/.codex/config.toml`
- `claude` 引擎那侧的 `--tools \"\"` 是工具面直接归零，两者不是一回事

**只改文档，不改代码。** 评审中有建议用 `-c` 把工具面钉死，驳回了——插件越权覆盖用户的引擎配置是更坏的一侧，Never break userspace。新增 Tool-surface caveat 段落说明边界，需要纯文本 reviewer 的用户应在自己的 codex 配置里关掉这些工具。

同步另外两处遗留措辞：README 开头的 \"(Gemini or Claude)\"、Privacy Notice 的 \"(Gemini API or Anthropic API)\"——env 表和 Codex 专章已经列了 codex，这两处没跟上，前后矛盾。Privacy Notice 现在写明 codex 的数据去向随用户 provider 配置而定。

## 2. 测试夹具补 codex 环境隔离（实测缺陷）

`common_setup` 清了 8 个可能泄漏的变量，但没清新引入的 `CODEX_BIN` / `CODEX_MODEL`。生产逻辑是 \`ENGINE_CMD=\"\${CODEX_BIN:-codex}\"\`，后果实测可复现：

\`\`\`
$ bats tests/plan-review.bats -f 'CODEX_MODEL empty'
ok 1 codex: CODEX_MODEL empty → no -m; CODEX_MODEL set → -m <value> present

$ CODEX_MODEL=some-local-default bats tests/plan-review.bats -f 'CODEX_MODEL empty'
not ok 1 codex: CODEX_MODEL empty → no -m; CODEX_MODEL set → -m <value> present
#   \`[[ \"\$(agy_args codex)\" != *\"-m \"* ]]' failed
\`\`\`

`CODEX_BIN` 后果更重：导出后 codex 用例会绕过 `MOCK_BIN/codex` 打到**真二进制**，可能联网、变慢、或因错误原因变绿。

**顺带做了一处小重构**：把所有防泄漏 unset 抽成 `reset_leaky_env()`。两个理由——

1. 隔离本身变得可测。`common_setup` 里有 `mktemp -d`，用例中重入会泄漏临时目录，所以清理逻辑必须能单独调用
2. 新增第四个引擎时，有一个明确的登记位置，而不是让人在 `common_setup` 中间找地方插

## 3. 根 CLAUDE.md 同步

- 插件清单：\`对抗性审阅（Gemini/Claude）\` → 加 Codex
- 环境变量表：补 `CODEX_BIN` / `CODEX_MODEL`
- 顺带修正过期的测试计数（109 → 202）

## 新增测试

1 条防回归用例：污染 13 个变量后调用 `reset_leaky_env`，断言全部清空。

**已验证证伪能力**——临时移除 `unset CODEX_MODEL` 后该用例失败（\`[ -z \"\${CODEX_MODEL:-}\" ]' failed\`），恢复后通过。不是永远绿的假测试。

## 验证

| 场景 | 结果 |
|---|---|
| 干净环境全量 | **202 / 202 通过** |
| 污染环境全量（导出 `CODEX_MODEL` / `CODEX_BIN` / `MOCK_CODEX_STRICT_UTF8` / `REVIEW_API_URL`） | **202 / 202 通过** |

第二行是修复有效性的直接证据：同样的污染在修复前会挂用例。

## 版本

**不 bump，plan-review 保持 1.4.0。** 本 PR 是纯文档 + 纯测试变更，不改外部行为，符合版本铁律中「纯文档、纯测试、纯 refactor 不要求 bump」。#142 已经 bump 过 1.4.0。