### PR TITLE
refactor(plan-review): 引擎三钩子接口 + codex capacity 修复 — 阶段二 (v1.4.1, #112)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "plan-review",
       "description": "Adversarial plan review via cross-model consultation (agy/Claude/Codex)",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "author": {
         "name": "WooDragon"
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,24 @@ plugins/
   plan-review/                    # 对抗性审阅插件
     .claude-plugin/plugin.json    # 插件元数据
     hooks/hooks.json              # PreToolUse + PreCompact hook 声明
-    scripts/plan-review.sh        # 核心脚本（ExitPlanMode 拦截 + Layer 1 manifest 检查）
-    scripts/dispatch-check.sh     # Layer 2 hook（Agent/Task 调度参数强制）
-    scripts/precompact-review.sh  # PreCompact hook（compaction 恢复）
-    tests/                        # BDD 测试套件（bats-core）
-      plan-review.bats            # 主测试套件（含 Dispatch Manifest、codex 引擎）
+    scripts/
+      plan-review.sh             # 编排器：守卫→计数→双安全阀→预检→prompt 组装→重试驱动→verdict 分支
+      lib/
+        common.sh                # 日志三件套 + backfill_engine_err + allow_with_reason + plan_hash
+        plan-source.sh           # transcript 反查三重安全门 + 提取链 + RESOLVE_REASON 三态文案
+        verdict.sh               # verdict 提取 + APPROVE/CONCERNS/REJECT 三种反馈渲染
+        manifest.sh              # Manifest 检测三函数 + MANIFEST_EXAMPLE + JSON 序列化
+        engines/                 # 引擎三钩子接口（engine_probe/engine_invoke/engine_extract）
+          agy.sh                 # gemini 引擎（默认，agy CLI，含 JSON 文本切片 + conversation 复用）
+          claude.sh              # REVIEW_ENGINE=claude
+          codex.sh               # REVIEW_ENGINE=codex（含 engine_err_filter 隐私过滤钩子）
+          rest.sh                # REST SSE 降级通道（rest_ 前缀独立函数，不实现三钩子）
+      assets/
+        review-system-prompt.md  # SYSTEM_INSTRUCTIONS 提示词正文（纯数据）
+      dispatch-check.sh          # Layer 2 hook（Agent/Task 调度参数强制）
+      precompact-review.sh       # PreCompact hook（compaction 恢复）
+    tests/                        # BDD 测试套件（bats-core，205 个测试用例）
+      plan-review.bats            # 主测试套件（191 个，含 Dispatch Manifest、codex 引擎）
       dispatch-check.bats         # 14 个测试用例（Layer 2 hook）
       test_helper/
         common-setup.bash         # 测试基础设施（mock、断言）

--- a/plugins/plan-review/.claude-plugin/plugin.json
+++ b/plugins/plan-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-review",
   "description": "Adversarial plan review via cross-model consultation (agy/Claude/Codex)",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "woodragon"
   }

--- a/plugins/plan-review/README.md
+++ b/plugins/plan-review/README.md
@@ -14,6 +14,51 @@ claude plugin add plan-review@WooDragon-cc-plugins
 claude --plugin-dir ~/.claude/dev-plugins/plan-review
 ```
 
+## Architecture
+
+```
+scripts/
+  plan-review.sh              Orchestrator: guards → counters → dual safety valves →
+                               pre-check → prompt assembly → retry driver → verdict branching
+  lib/
+    common.sh                 Logging helpers, backfill_engine_err, allow_with_reason, plan_hash
+    plan-source.sh            Transcript triple-gated lookup + extraction chain +
+                               RESOLVE_REASON tri-state messaging
+    verdict.sh                Verdict extraction + APPROVE/CONCERNS/REJECT feedback rendering
+    manifest.sh               Dispatch Manifest detection + MANIFEST_EXAMPLE + JSON serialization
+    engines/
+      agy.sh                   engine_probe/invoke/extract for the default gemini (agy CLI) engine
+      claude.sh                engine_probe/invoke/extract for REVIEW_ENGINE=claude
+      codex.sh                 engine_probe/invoke/extract for REVIEW_ENGINE=codex, plus an
+                                engine_err_filter privacy-redaction hook
+      rest.sh                  REST SSE fallback (see "Engine interface" below)
+  assets/
+    review-system-prompt.md   SYSTEM_INSTRUCTIONS prompt text (pure data, no shell logic)
+  dispatch-check.sh           Layer 2 hook — Agent/Task dispatch-parameter enforcement
+  precompact-review.sh        PreCompact hook — plan recovery across compaction
+```
+
+### Engine interface
+
+Each review engine implements three hooks that the orchestrator calls uniformly:
+
+- **`engine_probe`** — called once, outside the retry loop: check the CLI is present, resolve
+  model variables, and prepare any one-off temp resources. Returns non-zero if unusable.
+- **`engine_invoke`** — called once per retry round: run the CLI, write raw output to
+  `$ENGINE_OUT`, set `engine_exit`.
+- **`engine_extract`** — read `$ENGINE_OUT` and set `REVIEW` to the review text. Verdict parsing
+  happens later, in `lib/verdict.sh` — engines never see it.
+
+Adding a new engine means adding one `lib/engines/<name>.sh` file that implements these three
+functions, then adding one line to the orchestrator's engine whitelist `case` in `plan-review.sh`
+— no other file needs to change.
+
+`rest.sh` is the exception: it is a fallback channel, not a fourth first-class engine. It only
+activates after the CLI retry budget is exhausted, and it always runs alongside whichever engine
+was already sourced in the same process — so its functions use a `rest_` prefix instead of
+implementing the three-hook interface, to avoid colliding with the active engine's own function
+names.
+
 ## Environment Variables
 
 ### `plan-review.sh` (ExitPlanMode adversarial review)
@@ -63,7 +108,7 @@ on that second call permits execution.
 
 ## Review Criteria
 
-Nine criteria — authoritative text lives in `SYSTEM_INSTRUCTIONS` inside `scripts/plan-review.sh`.
+Nine criteria — authoritative text lives in `scripts/assets/review-system-prompt.md`.
 
 | # | Criterion | Focus |
 |---|-----------|-------|

--- a/plugins/plan-review/scripts/lib/common.sh
+++ b/plugins/plan-review/scripts/lib/common.sh
@@ -62,11 +62,20 @@ EOF
 #         diagnostics, so the raw file must NEVER be appended wholesale.
 #         Only on failure ($1 != "0"), call the engine's own
 #         engine_err_filter() hook (if it defines one) and log ONLY its
-#         already-filtered, length-bounded return value.
-#     Deliberately does NOT truncate $ENGINE_ERR — the caller's capacity
-#     detection (grep for RESOURCE_EXHAUSTED|MODEL_CAPACITY) reads the same
-#     file immediately after this runs; it is naturally replaced next round
-#     by the engine's own `2>"$ENGINE_ERR"` redirection.
+#         already-filtered, length-bounded return value under the engine's
+#         own self-declared $ENGINE_ERR_LOG_TAG (set in its engine_probe();
+#         falls back to the generic "engine-diag" for engines that don't
+#         declare one) — this generic layer must not hardcode a
+#         codex-private label.
+#     Truncates $ENGINE_ERR after backfilling (both branches, whether or not
+#     engine_err_filter actually ran) so a LATER call against the SAME
+#     $ENGINE_ERR — e.g. plan-review.sh's _cleanup() defensively re-invoking
+#     this on hook-kill — is a harmless no-op via the `[ -s ]` guard above,
+#     instead of double-appending/double-logging this round's content. The
+#     caller's capacity detection (grep for RESOURCE_EXHAUSTED|MODEL_CAPACITY)
+#     therefore MUST read $ENGINE_ERR itself BEFORE calling this function —
+#     see plan-review.sh's retry loop, which captures that grep result into a
+#     flag ahead of the backfill_engine_err call for exactly this reason.
 backfill_engine_err() {
   local exit_code="${1:-0}"
   [ -s "${ENGINE_ERR:-}" ] || return 0
@@ -74,11 +83,12 @@ backfill_engine_err() {
     if [ "$exit_code" != "0" ] && declare -F engine_err_filter >/dev/null 2>&1; then
       local diag
       diag=$(engine_err_filter)
-      log_decision "codex-diag $(printf '%s' "$diag" | tr -d '\000-\037')"
+      log_decision "${ENGINE_ERR_LOG_TAG:-engine-diag} $(printf '%s' "$diag" | tr -d '\000-\037')"
     fi
   else
     cat "$ENGINE_ERR" >> "$LOG_FILE" 2>/dev/null || true
   fi
+  : > "$ENGINE_ERR" 2>/dev/null || true
 }
 
 # --- Plan content hasher (portable: sha256sum > shasum > cksum POSIX fallback) ---

--- a/plugins/plan-review/scripts/lib/common.sh
+++ b/plugins/plan-review/scripts/lib/common.sh
@@ -47,6 +47,40 @@ EOF
   exit 0
 }
 
+# --- Engine stderr backfill: the orchestrator owns the CHANNEL ($ENGINE_ERR,
+#     allocated once in plan-review.sh as "${ENGINE_OUT}.err" for every
+#     engine), but each engine owns the CONTENT policy via its own
+#     $ENGINE_ERR_POLICY (set in its engine_probe()):
+#       "verbatim" (agy/claude) — non-empty $ENGINE_ERR is appended into
+#         LOG_FILE UNCONDITIONALLY, on success AND on failure. This mirrors
+#         the old inline `2>>"$LOG_FILE"` behavior exactly: success-path CLI
+#         warnings (deprecation notices, internal retries, near-limit
+#         throttle warnings) still land in the log. Backfilling only on
+#         failure would silently drop those — a regression, not a fix.
+#       "filtered" (codex) — codex's stderr echoes the FULL prompt (global +
+#         project CLAUDE.md + conversation + plan) before its real
+#         diagnostics, so the raw file must NEVER be appended wholesale.
+#         Only on failure ($1 != "0"), call the engine's own
+#         engine_err_filter() hook (if it defines one) and log ONLY its
+#         already-filtered, length-bounded return value.
+#     Deliberately does NOT truncate $ENGINE_ERR — the caller's capacity
+#     detection (grep for RESOURCE_EXHAUSTED|MODEL_CAPACITY) reads the same
+#     file immediately after this runs; it is naturally replaced next round
+#     by the engine's own `2>"$ENGINE_ERR"` redirection.
+backfill_engine_err() {
+  local exit_code="${1:-0}"
+  [ -s "${ENGINE_ERR:-}" ] || return 0
+  if [ "${ENGINE_ERR_POLICY:-verbatim}" = "filtered" ]; then
+    if [ "$exit_code" != "0" ] && declare -F engine_err_filter >/dev/null 2>&1; then
+      local diag
+      diag=$(engine_err_filter)
+      log_decision "codex-diag $(printf '%s' "$diag" | tr -d '\000-\037')"
+    fi
+  else
+    cat "$ENGINE_ERR" >> "$LOG_FILE" 2>/dev/null || true
+  fi
+}
+
 # --- Plan content hasher (portable: sha256sum > shasum > cksum POSIX fallback) ---
 # All branches pipe through awk '{print $1}' to strip filename/extra fields.
 plan_hash() {

--- a/plugins/plan-review/scripts/lib/engines/agy.sh
+++ b/plugins/plan-review/scripts/lib/engines/agy.sh
@@ -1,0 +1,194 @@
+# lib/engines/agy.sh — agy (Gemini) engine implementation of the three-hook
+# contract (engine_probe / engine_invoke / engine_extract). Sourced (not
+# executed) by plan-review.sh when REVIEW_ENGINE is "gemini" (default) or
+# any unrecognized value — see plan-review.sh's engine-selection case for
+# why unrecognized values fall through here (current-behavior preservation).
+#
+# Orchestrator pre-sets before calling these hooks: PROMPT_FILE,
+# SYSTEM_INSTRUCTIONS, PLAN, TOTAL_ROUNDS, ENGINE_OUT, ENGINE_TIMEOUT,
+# TIMEOUT_CMD, CONV_FILE, LOG_FILE, ENGINE_CMD.
+#
+# engine_invoke may set _ENGINE_ABORT_RETRY=1 to signal the caller's retry
+# loop to break immediately (deliberately NOT a bare `break` inside this
+# function — bash 3.2 propagates a function-body `break` out to the CALLER's
+# enclosing loop, but bash 5.x does not (it errors "only meaningful in a
+# for/while/until loop" and falls through) — a verified cross-version
+# divergence, not a hypothetical one. An explicit flag variable is the only
+# portable signal.).
+#
+# bash 3.2 compatible: no associative arrays, no ${var^^}, no &>>.
+
+# --- One-time setup (called once, outside the retry loop): CLI existence
+#     check + model resolution. Returns 0 if usable, 1 (with
+#     ENGINE_PROBE_REASON set) otherwise. ---
+engine_probe() {
+  if ! command -v "$ENGINE_CMD" >/dev/null 2>&1; then
+    ENGINE_PROBE_REASON="$ENGINE_CMD"
+    return 1
+  fi
+  # GEMINI_MODEL retained as the REST fallback's model id (OpenAI-compatible payload).
+  GEMINI_MODEL="${GEMINI_MODEL:-gemini-3.1-pro-preview}"
+  AGY_MODEL="${AGY_MODEL:-Gemini 3.1 Pro (High)}"
+  return 0
+}
+
+# --- Actual call (called every round inside the retry loop). Writes raw
+#     output to $ENGINE_OUT, sets $engine_exit, maintains $ENGINE_PID so the
+#     caller's trap can kill it on hook timeout. ---
+engine_invoke() {
+  # --- agy multi-round session reuse ---
+  # Read back a previously-captured agy conversation_id (if any) so this
+  # round can resume it instead of resending the full static prefix — the
+  # prefix (system instructions + GLOBAL_MD/PROJECT_MD/USER_REQ) already
+  # lives in agy's server-side session history, which lets the provider
+  # hit prompt cache on it. Validate strictly (36-char UUID) since a
+  # malformed/stale value would make `--conversation` resume garbage.
+  CONV_ID=$(cat "${CONV_FILE:-}" 2>/dev/null | tr 'A-F' 'a-f' || true)
+  [[ "$CONV_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] || CONV_ID=""
+  CONV_ARGS=()
+  [ -z "$CONV_ID" ] || CONV_ARGS=(--conversation "$CONV_ID")
+
+  # agy does not read stdin as a prompt — must pass inline via -p. ANSI-C
+  # quoting ($'\n\n') for a real newline separator; a plain "\n" inside
+  # double quotes is a literal backslash-n, not a newline.
+  if [ -z "$CONV_ID" ]; then
+    # First round (no session to resume yet): send the full static+dynamic prompt.
+    AGY_PROMPT="$SYSTEM_INSTRUCTIONS"$'\n\n'"$(cat "$PROMPT_FILE")"
+  else
+    # Reuse round: static prefix already lives in agy's session history —
+    # resend only the volatile tail. Mirror the first-round Consultation
+    # Context framing (round number + "APPROVE if prior concerns addressed")
+    # so the reuse round carries the same negotiation semantics, not a bare
+    # plan dump. Resending the delta only (not the static context) is the
+    # point — it gets appended to session history, so duplicating context
+    # would cost tokens, not save them.
+    AGY_PROMPT="## Consultation Context
+This is round $((TOTAL_ROUNDS + 1)) of adversarial review.
+The plan author may have revised or added rebuttals since the previous round.
+Evaluate the CURRENT plan on its merits — if prior concerns have been addressed, APPROVE.
+
+## Plan to Review
+${PLAN}"
+  fi
+
+  # ARG_MAX defense: agy only accepts the prompt as a command-line argument,
+  # so an oversized prompt trips E2BIG. Treat this as a CLI failure and
+  # fall straight through to REST fallback rather than exec'ing a doomed command.
+  # Count BYTES, not characters: the ARG_MAX limit is byte-denominated, but
+  # ${#VAR} counts characters under a UTF-8 locale, so a CJK plan (3 bytes/
+  # char) would undercount ~3x and defeat the 256KB guard. `wc -c` counts
+  # bytes regardless of locale — one fork per hook invocation is negligible,
+  # and it sidesteps the LC_ALL=C prefix-assignment locale-leak footgun.
+  AGY_PROMPT_BYTES=$(printf '%s' "$AGY_PROMPT" | wc -c | tr -d ' ')
+  if [ "$AGY_PROMPT_BYTES" -gt 256000 ]; then
+    log_decision "agy-skip reason=prompt-too-large bytes=$AGY_PROMPT_BYTES"
+    REVIEW=""
+    _fail_reason="agy: prompt too large (${AGY_PROMPT_BYTES}B > 256000B), skipped to REST"
+    _ENGINE_ABORT_RETRY=1
+    return 0
+  fi
+
+  ${TIMEOUT_CMD:+$TIMEOUT_CMD -k 5 $ENGINE_TIMEOUT} agy --model "$AGY_MODEL" --sandbox --dangerously-skip-permissions \
+    ${CONV_ARGS[@]+"${CONV_ARGS[@]}"} --output-format json \
+    -p "$AGY_PROMPT" > "$ENGINE_OUT" 2>>"$LOG_FILE" &
+  ENGINE_PID=$!
+  wait "$ENGINE_PID" 2>/dev/null || engine_exit=$?
+  ENGINE_PID=""
+}
+
+# --- Read $ENGINE_OUT, set $REVIEW. agy's JSON is NOT well-formed (the
+#     "response" field contains raw unescaped newlines), so jq/python
+#     json.loads chokes on it. Everything below is deliberate sed/awk text
+#     slicing — zero jq, zero python. Also persists the conversation_id (for
+#     next-round session reuse) and logs usage observations. ---
+engine_extract() {
+  REVIEW=""
+  if [ "$engine_exit" = "0" ] && [ -s "$ENGINE_OUT" ]; then
+    # Capture the real conversation_id agy assigned (self-chosen server-side
+    # UUID; a client-invented one would not resume anything). `q` after the
+    # first match — no pipe, no SIGPIPE. Tolerate a lowercase-normalized id;
+    # persist is DEFERRED until response extraction succeeds (see below) so a
+    # broken envelope never leaves a CONV_FILE that the next round resumes.
+    NEW_CONV=$(sed -n '/"conversation_id"/{s/.*"conversation_id"[[:space:]]*:[[:space:]]*"\([0-9a-fA-F-]\{36\}\)".*/\1/p;q;}' "$ENGINE_OUT" 2>/dev/null || true)
+    NEW_CONV=$(printf '%s' "$NEW_CONV" | tr 'A-F' 'a-f')
+
+    # Extract the "response" field value and unescape it. Deliberately NOT
+    # keyed to field order/position — scan forward from the "response":"
+    # marker and stop at the first UNESCAPED double-quote, so trailing keys
+    # (usage, etc.) after response in the object don't matter.
+    REVIEW=$(awk '
+      BEGIN { RS="\x01" }
+      {
+        s = $0
+        # Tolerate optional whitespace around the key colon
+        # ("response" : "...") — do not bet on the compact serialization.
+        if (match(s, /"response"[ \t]*:[ \t]*"/) == 0) { exit }
+        s = substr(s, RSTART + RLENGTH)
+        out = ""; i = 1; n = length(s)
+        while (i <= n) {
+          c = substr(s, i, 1)
+          if (c == "\\") {
+            i++
+            nc = substr(s, i, 1)
+            if (nc == "n") out = out "\n"
+            else if (nc == "t") out = out "\t"
+            else if (nc == "\"") out = out "\""
+            else if (nc == "\\") out = out "\\"
+            else if (nc == "r") out = out "\r"
+            else if (nc == "u") {
+              # \uXXXX: Go encoding/json HTML-safe mode escapes <, >, & and
+              # U+2028/U+2029 this way by default (XSS defense) — that set
+              # is what agy actually emits, verified by reproduction. Any
+              # other \uXXXX is passed through literally (backslash intact)
+              # rather than silently dropped, so an unanticipated escape is
+              # visibly wrong instead of corrupting the tag structure.
+              hex = tolower(substr(s, i + 1, 4))
+              if (hex == "003c") out = out "<"
+              else if (hex == "003e") out = out ">"
+              else if (hex == "0026") out = out "&"
+              else if (hex == "2028" || hex == "2029") out = out "\n"
+              else out = out "\\u" substr(s, i + 1, 4)
+              i += 4
+            }
+            else out = out nc
+            i++
+          } else if (c == "\"") {
+            break
+          } else {
+            out = out c
+            i++
+          }
+        }
+        printf "%s", out
+      }
+    ' "$ENGINE_OUT" 2>/dev/null || true)
+
+    # Fallback: never hand the shell-wrapped JSON to the downstream verdict
+    # extractor — the raw envelope can contain echoed-back <verdict> tags
+    # from the prompt and cause a false match. Extraction failure = empty
+    # REVIEW, which the existing empty-response retry/REST path handles.
+    #
+    # CONV_FILE persist policy (only when we got a usable review): persisting
+    # a conversation_id from a call whose response we COULDN'T parse would
+    # make the next round resume a session we can't actually consume — so
+    # persist only on non-empty REVIEW, and drop any stale CONV_FILE on
+    # extract failure (the session may be shaped wrong / unusable this cycle).
+    if [ -n "$REVIEW" ]; then
+      if [[ "$NEW_CONV" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+        printf '%s' "$NEW_CONV" > "${CONV_FILE}.tmp.$$" 2>/dev/null && mv -f "${CONV_FILE}.tmp.$$" "$CONV_FILE" 2>/dev/null || true
+        log_decision "agy-conversation id=$NEW_CONV reuse=$([ -n "$CONV_ID" ] && echo yes || echo no)"
+      fi
+      log_decision "agy-success"
+    else
+      rm -f "${CONV_FILE:-}"
+      log_decision "agy-response-extract-failed conv-cleared"
+    fi
+
+    # Usage observation (best-effort, never fatal if absent/unparseable).
+    # `q` after first match — consistent with the conversation_id sed, no
+    # pipe, no SIGPIPE.
+    AGY_IN=$(sed -n 's/.*"input_tokens"[[:space:]]*:[[:space:]]*\([0-9]\{1,\}\).*/\1/p;/"input_tokens"/q' "$ENGINE_OUT" 2>/dev/null || true)
+    AGY_TOTAL=$(sed -n 's/.*"total_tokens"[[:space:]]*:[[:space:]]*\([0-9]\{1,\}\).*/\1/p;/"total_tokens"/q' "$ENGINE_OUT" 2>/dev/null || true)
+    [ -z "$AGY_IN" ] && [ -z "$AGY_TOTAL" ] || log_decision "agy-usage in=${AGY_IN:-?} total=${AGY_TOTAL:-?}"
+  fi
+}

--- a/plugins/plan-review/scripts/lib/engines/agy.sh
+++ b/plugins/plan-review/scripts/lib/engines/agy.sh
@@ -29,6 +29,10 @@ engine_probe() {
   # GEMINI_MODEL retained as the REST fallback's model id (OpenAI-compatible payload).
   GEMINI_MODEL="${GEMINI_MODEL:-gemini-3.1-pro-preview}"
   AGY_MODEL="${AGY_MODEL:-Gemini 3.1 Pro (High)}"
+  # agy's stderr carries no prompt echo / privacy concern — the orchestrator
+  # may backfill it into LOG_FILE verbatim (see backfill_engine_err in
+  # lib/common.sh), unconditionally on both success and failure.
+  ENGINE_ERR_POLICY="verbatim"
   return 0
 }
 
@@ -90,7 +94,7 @@ ${PLAN}"
 
   ${TIMEOUT_CMD:+$TIMEOUT_CMD -k 5 $ENGINE_TIMEOUT} agy --model "$AGY_MODEL" --sandbox --dangerously-skip-permissions \
     ${CONV_ARGS[@]+"${CONV_ARGS[@]}"} --output-format json \
-    -p "$AGY_PROMPT" > "$ENGINE_OUT" 2>>"$LOG_FILE" &
+    -p "$AGY_PROMPT" > "$ENGINE_OUT" 2>"$ENGINE_ERR" &
   ENGINE_PID=$!
   wait "$ENGINE_PID" 2>/dev/null || engine_exit=$?
   ENGINE_PID=""

--- a/plugins/plan-review/scripts/lib/engines/claude.sh
+++ b/plugins/plan-review/scripts/lib/engines/claude.sh
@@ -21,6 +21,11 @@ engine_probe() {
   # regardless of engine — claude receives SYSTEM_INSTRUCTIONS via its own
   # --system-prompt rail (agy/codex inject it inline into their own prompt).
   SYSTEM_PROMPT="$SYSTEM_INSTRUCTIONS"
+  # claude -p's stderr carries no prompt echo / privacy concern — the
+  # orchestrator may backfill it into LOG_FILE verbatim (see
+  # backfill_engine_err in lib/common.sh), unconditionally on both success
+  # and failure.
+  ENGINE_ERR_POLICY="verbatim"
   return 0
 }
 
@@ -42,7 +47,7 @@ engine_invoke() {
     --tools "" \
     --disable-slash-commands \
     --system-prompt "$SYSTEM_PROMPT" \
-    < "$PROMPT_FILE" > "$ENGINE_OUT" 2>>"$LOG_FILE" &
+    < "$PROMPT_FILE" > "$ENGINE_OUT" 2>"$ENGINE_ERR" &
   ENGINE_PID=$!
   wait "$ENGINE_PID" 2>/dev/null || engine_exit=$?
   ENGINE_PID=""

--- a/plugins/plan-review/scripts/lib/engines/claude.sh
+++ b/plugins/plan-review/scripts/lib/engines/claude.sh
@@ -1,0 +1,55 @@
+# lib/engines/claude.sh — Claude engine implementation of the three-hook
+# contract (engine_probe / engine_invoke / engine_extract). Sourced (not
+# executed) by plan-review.sh when REVIEW_ENGINE=claude.
+#
+# Orchestrator pre-sets before calling these hooks: PROMPT_FILE,
+# SYSTEM_INSTRUCTIONS, PLAN, TOTAL_ROUNDS, ENGINE_OUT, ENGINE_TIMEOUT,
+# TIMEOUT_CMD, CONV_FILE, LOG_FILE, ENGINE_CMD.
+#
+# bash 3.2 compatible: no associative arrays, no ${var^^}, no &>>.
+
+# --- One-time setup (called once, outside the retry loop): CLI existence
+#     check + model resolution + system-prompt prep. Returns 0 if usable,
+#     1 (with ENGINE_PROBE_REASON set) otherwise. ---
+engine_probe() {
+  if ! command -v "$ENGINE_CMD" >/dev/null 2>&1; then
+    ENGINE_PROBE_REASON="$ENGINE_CMD"
+    return 1
+  fi
+  CLAUDE_MODEL="${CLAUDE_MODEL:-opus}"
+  # Engine-specific system injection: PROMPT_FILE holds dynamic content only,
+  # regardless of engine — claude receives SYSTEM_INSTRUCTIONS via its own
+  # --system-prompt rail (agy/codex inject it inline into their own prompt).
+  SYSTEM_PROMPT="$SYSTEM_INSTRUCTIONS"
+  return 0
+}
+
+# --- Actual call (called every round inside the retry loop). Writes raw
+#     output to $ENGINE_OUT, sets $engine_exit, maintains $ENGINE_PID so the
+#     caller's trap can kill it on hook timeout. ---
+engine_invoke() {
+  # Strip Claude Code internal env vars to prevent recursive hook/plugin loading.
+  # Fragile (depends on internal implementation), but necessary: user authenticates
+  # via OAuth (claude login), no ANTHROPIC_API_KEY available, so claude -p is the
+  # only viable path. Triple isolation: --setting-sources local + PLAN_REVIEW_RUNNING
+  # + --tools "" (no tool calls = no PreToolUse events).
+  unset CLAUDECODE
+  unset CLAUDE_CODE_ENTRYPOINT
+  PLAN_REVIEW_RUNNING=1 ${TIMEOUT_CMD:+$TIMEOUT_CMD -k 5 $ENGINE_TIMEOUT} claude -p \
+    --model "$CLAUDE_MODEL" \
+    --setting-sources local \
+    --no-session-persistence \
+    --tools "" \
+    --disable-slash-commands \
+    --system-prompt "$SYSTEM_PROMPT" \
+    < "$PROMPT_FILE" > "$ENGINE_OUT" 2>>"$LOG_FILE" &
+  ENGINE_PID=$!
+  wait "$ENGINE_PID" 2>/dev/null || engine_exit=$?
+  ENGINE_PID=""
+}
+
+# --- Read $ENGINE_OUT, set $REVIEW. Claude's stdout is the raw review text
+#     verbatim — no envelope to unwrap. ---
+engine_extract() {
+  REVIEW=$(cat "$ENGINE_OUT" 2>/dev/null || true)
+}

--- a/plugins/plan-review/scripts/lib/engines/codex.sh
+++ b/plugins/plan-review/scripts/lib/engines/codex.sh
@@ -1,0 +1,138 @@
+# lib/engines/codex.sh — Codex engine implementation of the three-hook
+# contract (engine_probe / engine_invoke / engine_extract). Sourced (not
+# executed) by plan-review.sh when REVIEW_ENGINE=codex.
+#
+# Orchestrator pre-sets before calling these hooks: PROMPT_FILE,
+# SYSTEM_INSTRUCTIONS, PLAN, TOTAL_ROUNDS, ENGINE_OUT, ENGINE_TIMEOUT,
+# TIMEOUT_CMD, CONV_FILE, LOG_FILE, ENGINE_CMD. ENGINE_TMP_FILES/
+# ENGINE_TMP_DIRS arrays are declared (and cleared) by the caller before
+# trap registration — this file only appends its own private temp paths.
+#
+# bash 3.2 compatible: no associative arrays, no ${var^^}, no &>>.
+
+# --- One-time setup (called once, outside the retry loop): CLI existence
+#     check + model resolution + sandboxed workdir/merged-prompt/UTF-8
+#     sanitation prep. Returns 0 if usable, 1 (with ENGINE_PROBE_REASON set)
+#     otherwise. ---
+engine_probe() {
+  if ! command -v "$ENGINE_CMD" >/dev/null 2>&1; then
+    ENGINE_PROBE_REASON="$ENGINE_CMD"
+    return 1
+  fi
+  # Empty CODEX_MODEL means inherit codex's own ~/.codex/config.toml default.
+  CODEX_MODEL="${CODEX_MODEL:-}"
+
+  # codex-only temp resources: a sandboxed workdir (-C target, deliberately NOT
+  # the project cwd — codex runs read-only but there's no reason to hand it the
+  # real tree), a merged prompt file (system instructions + PROMPT_FILE's
+  # dynamic content — kept SEPARATE from PROMPT_FILE itself so the REST
+  # fallback's --rawfile read of PROMPT_FILE doesn't double-send the system
+  # instructions), and an isolated stderr capture (codex echoes the FULL
+  # prompt to stderr — see the diagnostic backfill in engine_invoke, never let
+  # this reach LOG_FILE wholesale). Registered into the generic cleanup arrays
+  # so the caller's trap reaps them without knowing their codex-private names.
+  CODEX_WORKDIR=$(mktemp -d)
+  ENGINE_TMP_DIRS+=("$CODEX_WORKDIR")
+  CODEX_PROMPT_FILE=$(mktemp)
+  ENGINE_TMP_FILES+=("$CODEX_PROMPT_FILE" "${CODEX_PROMPT_FILE}.u8")
+  ENGINE_ERR="${ENGINE_OUT}.err"
+  ENGINE_TMP_FILES+=("$ENGINE_ERR")
+
+  { printf '%s\n\n' "$SYSTEM_INSTRUCTIONS"; cat "$PROMPT_FILE"; } > "$CODEX_PROMPT_FILE"
+  printf '\n' >> "$CODEX_PROMPT_FILE"
+
+  # UTF-8 sanitation (codex-only — the other engines never see this file).
+  # GLOBAL_MD/PROJECT_MD are truncated by BYTE count (`head -c 3000` / `-c 8000`),
+  # which slices a multi-byte character in half whenever a CLAUDE.md is non-ASCII
+  # near the cut. codex hard-rejects such input — it does not degrade, it aborts:
+  #   "Failed to read prompt from stdin: input is not valid UTF-8 (invalid byte
+  #    at offset N). Convert it to UTF-8 and retry"
+  # …making REVIEW_ENGINE=codex unusable for anyone with a non-ASCII CLAUDE.md.
+  # `iconv -c` drops only the orphaned bytes and keeps every valid character.
+  # Guarded on iconv's presence and on success (`&& mv || rm`), so a missing or
+  # failing iconv degrades to the unsanitized file rather than an empty prompt.
+  if command -v iconv >/dev/null 2>&1; then
+    if iconv -f UTF-8 -t UTF-8 -c < "$CODEX_PROMPT_FILE" > "${CODEX_PROMPT_FILE}.u8" 2>/dev/null; then
+      mv -f "${CODEX_PROMPT_FILE}.u8" "$CODEX_PROMPT_FILE"
+    else
+      rm -f "${CODEX_PROMPT_FILE}.u8"
+    fi
+  fi
+  # Counted AFTER sanitation: PROMPT_LINES drives the diagnostic backfill's
+  # positional cut, which must match the file codex actually received.
+  PROMPT_LINES=$(wc -l < "$CODEX_PROMPT_FILE")
+  return 0
+}
+
+# --- Actual call (called every round inside the retry loop). Writes raw
+#     output to $ENGINE_OUT, sets $engine_exit, maintains $ENGINE_PID so the
+#     caller's trap can kill it on hook timeout. On failure, backfills a
+#     privacy-filtered stderr diagnostic into LOG_FILE. ---
+engine_invoke() {
+  # Model id can contain spaces (see AGY_MODEL's default "Gemini 3.1 Pro
+  # (High)" precedent) — must be an array, not ${VAR:+...} word-splitting.
+  CODEX_MODEL_ARGS=()
+  [ -z "$CODEX_MODEL" ] || CODEX_MODEL_ARGS=(-m "$CODEX_MODEL")
+  ${TIMEOUT_CMD:+$TIMEOUT_CMD -k 5 $ENGINE_TIMEOUT} "$ENGINE_CMD" exec \
+    --skip-git-repo-check -s read-only --ephemeral --color never \
+    -C "$CODEX_WORKDIR" ${CODEX_MODEL_ARGS[@]+"${CODEX_MODEL_ARGS[@]}"} \
+    -o "$ENGINE_OUT" - < "$CODEX_PROMPT_FILE" > /dev/null 2> "$ENGINE_ERR" &
+  ENGINE_PID=$!
+  wait "$ENGINE_PID" 2>/dev/null || engine_exit=$?
+  ENGINE_PID=""
+
+  if [ "$engine_exit" != "0" ]; then
+    # --- Privacy boundary: codex echoes the FULL prompt to stderr before
+    # its real diagnostics (global CLAUDE.md + project CLAUDE.md + recent
+    # conversation + the plan). Never let ENGINE_ERR reach LOG_FILE
+    # wholesale — backfill only a filtered tail, two-layer defense:
+    #   Layer A (positional): locate the banner's SECOND "--------" line
+    #     (within the first 20 lines) followed by a line that is exactly
+    #     "user" — that marks where the echoed prompt begins; cut it out
+    #     using PROMPT_LINES (captured once, outside the retry loop) to
+    #     find where it ends, keeping the banner + the real tail after it.
+    #     Any of the three guards failing falls through to the fail-closed
+    #     `tail -n 20` branch, which still preserves diagnostics for
+    #     failures that happen before codex echoes anything (auth/network).
+    #   Layer B (content-based): grep -Fvxf strips any surviving line that
+    #     is byte-identical to a prompt line — this is what survives codex
+    #     version drift in line counts (banner shape / prompt line count
+    #     changing between versions).
+    # `|| true` on the ECHO_END lookup and the final pipe are MANDATORY:
+    # set -euo pipefail means a grep returning 1 (no match / everything
+    # filtered out) would otherwise kill the hook before it emits its
+    # decision JSON.
+    # LC_ALL=C on both greps (command-scoped, not exported — deliberately
+    # narrower than the LC_ALL=C prefix-assignment pattern avoided
+    # elsewhere in this file): CODEX_PROMPT_FILE embeds GLOBAL_MD/
+    # PROJECT_MD truncated by BYTE count (`head -c`), which can slice a
+    # multi-byte UTF-8 character in half. Under the active UTF-8 locale
+    # that makes grep abort with "illegal byte sequence" — silently
+    # emptying CODEX_DIAG (the trailing `|| true` hides the failure).
+    # Forcing the C locale makes grep treat input as raw bytes, matching
+    # this pipeline's real behavior anyway: -F is already a fixed-string
+    # byte match, and -x needs no locale-aware collation.
+    CODEX_DIAG=$(
+      ECHO_END=$(head -n 20 "$ENGINE_ERR" | grep -n '^--------$' | sed -n '2p' | cut -d: -f1) || true
+      NEXT_LINE=$(sed -n "$(( ${ECHO_END:-0} + 1 ))p" "$ENGINE_ERR" 2>/dev/null)
+      if [ -n "$ECHO_END" ] && [ "$ECHO_END" -le 20 ] && [ "$NEXT_LINE" = "user" ]; then
+        { head -n "$ECHO_END" "$ENGINE_ERR"
+          tail -n "+$(( ECHO_END + PROMPT_LINES + 2 ))" "$ENGINE_ERR"; }
+      else
+        tail -n 20 "$ENGINE_ERR"
+      fi \
+      | LC_ALL=C grep -Fvxf "$CODEX_PROMPT_FILE" \
+      | LC_ALL=C grep '[^[:space:]]' \
+      | head -c 500 || true
+    )
+    # tr -d '\000-\037': strip control chars, keep log single-line safe
+    # (mirrors the existing rest-debug body_prefix backfill).
+    log_decision "codex-diag $(printf '%s' "$CODEX_DIAG" | tr -d '\000-\037')"
+  fi
+}
+
+# --- Read $ENGINE_OUT, set $REVIEW. Codex's -o output file is the raw review
+#     text verbatim — no envelope to unwrap. ---
+engine_extract() {
+  REVIEW=$(cat "$ENGINE_OUT" 2>/dev/null || true)
+}

--- a/plugins/plan-review/scripts/lib/engines/codex.sh
+++ b/plugins/plan-review/scripts/lib/engines/codex.sh
@@ -41,6 +41,10 @@ engine_probe() {
   CODEX_PROMPT_FILE=$(mktemp)
   ENGINE_TMP_FILES+=("$CODEX_PROMPT_FILE" "${CODEX_PROMPT_FILE}.u8")
   ENGINE_ERR_POLICY="filtered"
+  # Self-declared log tag for backfill_engine_err()'s filtered-branch
+  # log_decision line (lib/common.sh) — the generic backfill layer must not
+  # know codex's private label, so codex declares it here instead.
+  ENGINE_ERR_LOG_TAG="codex-diag"
 
   { printf '%s\n\n' "$SYSTEM_INSTRUCTIONS"; cat "$PROMPT_FILE"; } > "$CODEX_PROMPT_FILE"
   printf '\n' >> "$CODEX_PROMPT_FILE"

--- a/plugins/plan-review/scripts/lib/engines/codex.sh
+++ b/plugins/plan-review/scripts/lib/engines/codex.sh
@@ -24,19 +24,23 @@ engine_probe() {
 
   # codex-only temp resources: a sandboxed workdir (-C target, deliberately NOT
   # the project cwd — codex runs read-only but there's no reason to hand it the
-  # real tree), a merged prompt file (system instructions + PROMPT_FILE's
+  # real tree) and a merged prompt file (system instructions + PROMPT_FILE's
   # dynamic content — kept SEPARATE from PROMPT_FILE itself so the REST
   # fallback's --rawfile read of PROMPT_FILE doesn't double-send the system
-  # instructions), and an isolated stderr capture (codex echoes the FULL
-  # prompt to stderr — see the diagnostic backfill in engine_invoke, never let
-  # this reach LOG_FILE wholesale). Registered into the generic cleanup arrays
-  # so the caller's trap reaps them without knowing their codex-private names.
+  # instructions). Registered into the generic cleanup arrays so the caller's
+  # trap reaps them without knowing their codex-private names.
+  # NOTE: $ENGINE_ERR is NOT declared here — it is a shared orchestrator-owned
+  # contract channel (plan-review.sh sets ENGINE_ERR="${ENGINE_OUT}.err" for
+  # every engine, and _cleanup hardcodes it alongside PROMPT_FILE/ENGINE_OUT),
+  # not a codex-private resource. codex only declares its CONTENT policy
+  # below (ENGINE_ERR_POLICY) because codex echoes the FULL prompt to stderr
+  # before its real diagnostics — see engine_err_filter() further down,
+  # which must never let that raw content reach LOG_FILE wholesale.
   CODEX_WORKDIR=$(mktemp -d)
   ENGINE_TMP_DIRS+=("$CODEX_WORKDIR")
   CODEX_PROMPT_FILE=$(mktemp)
   ENGINE_TMP_FILES+=("$CODEX_PROMPT_FILE" "${CODEX_PROMPT_FILE}.u8")
-  ENGINE_ERR="${ENGINE_OUT}.err"
-  ENGINE_TMP_FILES+=("$ENGINE_ERR")
+  ENGINE_ERR_POLICY="filtered"
 
   { printf '%s\n\n' "$SYSTEM_INSTRUCTIONS"; cat "$PROMPT_FILE"; } > "$CODEX_PROMPT_FILE"
   printf '\n' >> "$CODEX_PROMPT_FILE"
@@ -66,8 +70,10 @@ engine_probe() {
 
 # --- Actual call (called every round inside the retry loop). Writes raw
 #     output to $ENGINE_OUT, sets $engine_exit, maintains $ENGINE_PID so the
-#     caller's trap can kill it on hook timeout. On failure, backfills a
-#     privacy-filtered stderr diagnostic into LOG_FILE. ---
+#     caller's trap can kill it on hook timeout. $ENGINE_ERR (this round's
+#     raw stderr) is left in place for the orchestrator to dispatch per
+#     ENGINE_ERR_POLICY — see backfill_engine_err() in lib/common.sh and
+#     engine_err_filter() below, NOT handled inline here anymore. ---
 engine_invoke() {
   # Model id can contain spaces (see AGY_MODEL's default "Gemini 3.1 Pro
   # (High)" precedent) — must be an array, not ${VAR:+...} word-splitting.
@@ -80,55 +86,57 @@ engine_invoke() {
   ENGINE_PID=$!
   wait "$ENGINE_PID" 2>/dev/null || engine_exit=$?
   ENGINE_PID=""
+}
 
-  if [ "$engine_exit" != "0" ]; then
-    # --- Privacy boundary: codex echoes the FULL prompt to stderr before
-    # its real diagnostics (global CLAUDE.md + project CLAUDE.md + recent
-    # conversation + the plan). Never let ENGINE_ERR reach LOG_FILE
-    # wholesale — backfill only a filtered tail, two-layer defense:
-    #   Layer A (positional): locate the banner's SECOND "--------" line
-    #     (within the first 20 lines) followed by a line that is exactly
-    #     "user" — that marks where the echoed prompt begins; cut it out
-    #     using PROMPT_LINES (captured once, outside the retry loop) to
-    #     find where it ends, keeping the banner + the real tail after it.
-    #     Any of the three guards failing falls through to the fail-closed
-    #     `tail -n 20` branch, which still preserves diagnostics for
-    #     failures that happen before codex echoes anything (auth/network).
-    #   Layer B (content-based): grep -Fvxf strips any surviving line that
-    #     is byte-identical to a prompt line — this is what survives codex
-    #     version drift in line counts (banner shape / prompt line count
-    #     changing between versions).
-    # `|| true` on the ECHO_END lookup and the final pipe are MANDATORY:
-    # set -euo pipefail means a grep returning 1 (no match / everything
-    # filtered out) would otherwise kill the hook before it emits its
-    # decision JSON.
-    # LC_ALL=C on both greps (command-scoped, not exported — deliberately
-    # narrower than the LC_ALL=C prefix-assignment pattern avoided
-    # elsewhere in this file): CODEX_PROMPT_FILE embeds GLOBAL_MD/
-    # PROJECT_MD truncated by BYTE count (`head -c`), which can slice a
-    # multi-byte UTF-8 character in half. Under the active UTF-8 locale
-    # that makes grep abort with "illegal byte sequence" — silently
-    # emptying CODEX_DIAG (the trailing `|| true` hides the failure).
-    # Forcing the C locale makes grep treat input as raw bytes, matching
-    # this pipeline's real behavior anyway: -F is already a fixed-string
-    # byte match, and -x needs no locale-aware collation.
-    CODEX_DIAG=$(
-      ECHO_END=$(head -n 20 "$ENGINE_ERR" | grep -n '^--------$' | sed -n '2p' | cut -d: -f1) || true
-      NEXT_LINE=$(sed -n "$(( ${ECHO_END:-0} + 1 ))p" "$ENGINE_ERR" 2>/dev/null)
-      if [ -n "$ECHO_END" ] && [ "$ECHO_END" -le 20 ] && [ "$NEXT_LINE" = "user" ]; then
-        { head -n "$ECHO_END" "$ENGINE_ERR"
-          tail -n "+$(( ECHO_END + PROMPT_LINES + 2 ))" "$ENGINE_ERR"; }
-      else
-        tail -n 20 "$ENGINE_ERR"
-      fi \
-      | LC_ALL=C grep -Fvxf "$CODEX_PROMPT_FILE" \
-      | LC_ALL=C grep '[^[:space:]]' \
-      | head -c 500 || true
-    )
-    # tr -d '\000-\037': strip control chars, keep log single-line safe
-    # (mirrors the existing rest-debug body_prefix backfill).
-    log_decision "codex-diag $(printf '%s' "$CODEX_DIAG" | tr -d '\000-\037')"
-  fi
+# --- Privacy-filtered stderr diagnostic hook (ENGINE_ERR_POLICY=filtered).
+#     Called by the orchestrator's backfill_engine_err() (lib/common.sh)
+#     ONLY on failure — its stdout becomes the "codex-diag ..." log line.
+#     Reads $ENGINE_ERR (this round's raw stderr, still un-truncated at this
+#     point) and $CODEX_PROMPT_FILE / $PROMPT_LINES (set once in
+#     engine_probe(), outside the retry loop).
+#
+#     Privacy boundary: codex echoes the FULL prompt to stderr before its
+#     real diagnostics (global CLAUDE.md + project CLAUDE.md + recent
+#     conversation + the plan). Never let ENGINE_ERR reach LOG_FILE
+#     wholesale — return only a filtered tail, two-layer defense:
+#       Layer A (positional): locate the banner's SECOND "--------" line
+#         (within the first 20 lines) followed by a line that is exactly
+#         "user" — that marks where the echoed prompt begins; cut it out
+#         using PROMPT_LINES to find where it ends, keeping the banner +
+#         the real tail after it. Any of the three guards failing falls
+#         through to the fail-closed `tail -n 20` branch, which still
+#         preserves diagnostics for failures that happen before codex
+#         echoes anything (auth/network).
+#       Layer B (content-based): grep -Fvxf strips any surviving line that
+#         is byte-identical to a prompt line — this is what survives codex
+#         version drift in line counts (banner shape / prompt line count
+#         changing between versions).
+#     `|| true` on the ECHO_END lookup and the final pipe are MANDATORY:
+#     set -euo pipefail means a grep returning 1 (no match / everything
+#     filtered out) would otherwise kill the hook before it emits its
+#     decision JSON.
+#     LC_ALL=C on both greps (command-scoped, not exported — deliberately
+#     narrower than the LC_ALL=C prefix-assignment pattern avoided
+#     elsewhere in this file): CODEX_PROMPT_FILE embeds GLOBAL_MD/
+#     PROJECT_MD truncated by BYTE count (`head -c`), which can slice a
+#     multi-byte UTF-8 character in half. Under the active UTF-8 locale
+#     that makes grep abort with "illegal byte sequence" — silently
+#     emptying the diagnostic (the trailing `|| true` hides the failure).
+#     Forcing the C locale makes grep treat input as raw bytes, matching
+#     this pipeline's real behavior anyway: -F is already a fixed-string
+#     byte match, and -x needs no locale-aware collation. ---
+engine_err_filter() {
+  ECHO_END=$(head -n 20 "$ENGINE_ERR" | grep -n '^--------$' | sed -n '2p' | cut -d: -f1) || true
+  NEXT_LINE=$(sed -n "$(( ${ECHO_END:-0} + 1 ))p" "$ENGINE_ERR" 2>/dev/null)
+  if [ -n "$ECHO_END" ] && [ "$ECHO_END" -le 20 ] && [ "$NEXT_LINE" = "user" ]; then
+    { head -n "$ECHO_END" "$ENGINE_ERR"
+      tail -n "+$(( ECHO_END + PROMPT_LINES + 2 ))" "$ENGINE_ERR"; }
+  else
+    tail -n 20 "$ENGINE_ERR"
+  fi \
+  | LC_ALL=C grep -Fvxf "$CODEX_PROMPT_FILE" \
+  | LC_ALL=C grep '[^[:space:]]' \
+  | head -c 500 || true
 }
 
 # --- Read $ENGINE_OUT, set $REVIEW. Codex's -o output file is the raw review

--- a/plugins/plan-review/scripts/lib/engines/rest.sh
+++ b/plugins/plan-review/scripts/lib/engines/rest.sh
@@ -1,0 +1,159 @@
+# lib/engines/rest.sh — REST API fallback (OpenAI-compatible endpoint).
+# Sourced (not executed) UNCONDITIONALLY by plan-review.sh, alongside
+# whichever CLI engine (agy/claude/codex) is selected — REST is a downgrade
+# channel, not a fourth first-class engine, so it deliberately does NOT
+# implement the engine_probe/engine_invoke/engine_extract trio: it fires
+# only AFTER the CLI retry loop is exhausted, meaning it always coexists in
+# the same process with an already-sourced CLI engine. Reusing the
+# engine_invoke/engine_extract names would silently shadow that engine's
+# functions — the single hardest class of bug to chase down at runtime.
+# The rest_ prefix guarantees zero name collision, zero dynamic re-source.
+#
+# Orchestrator-owned policy that stays OUT of this file: the decision of
+# whether to trigger REST at all (CLI exhausted + REVIEW_API_URL/KEY set),
+# the gemini degraded-state bookkeeping, and the post-call ENGINE_OUT
+# truncation / success log — those are engine-agnostic retry/degrade
+# state-machine concerns and live in plan-review.sh itself.
+#
+# Orchestrator globals this file reads (already in scope, same process):
+# PROMPT_FILE, SYSTEM_INSTRUCTIONS, ENGINE_OUT, TIMEOUT_CMD, LOG_FILE,
+# HOOK_BUDGET, REVIEW_API_URL, REVIEW_API_KEY, GEMINI_MODEL,
+# REVIEW_REST_TIMEOUT, REVIEW_REST_STALL_TIMEOUT, _fail_reason.
+#
+# bash 3.2 compatible: no associative arrays, no ${var^^}, no &>>.
+
+# --- Build the request + call the endpoint. Writes body to $ENGINE_OUT,
+#     HTTP status to $ENGINE_STATUS, sets $curl_exit. REQ_FILE/ENGINE_STATUS
+#     are REST-private temp resources — appended to the caller's generic
+#     ENGINE_TMP_FILES cleanup array rather than hardcoded into _cleanup. ---
+rest_invoke() {
+  REQ_FILE=$(mktemp)
+  ENGINE_TMP_FILES+=("$REQ_FILE")
+  # --rawfile (not --arg + $(cat ...)) reads PROMPT_FILE directly inside jq,
+  # keeping the large plan body off the command line entirely (no E2BIG risk
+  # on this side). messages[0]=system stays a stable prefix across rounds —
+  # prefix-cacheable by the upstream provider. stream:true enables SSE below.
+  jq -n --arg model "${GEMINI_MODEL:-gemini-3.1-pro-preview}" \
+        --arg sys "$SYSTEM_INSTRUCTIONS" \
+        --rawfile prompt "$PROMPT_FILE" \
+    '{ model: $model, messages: [{ role: "system", content: $sys }, { role: "user", content: $prompt }], max_tokens: 16000, temperature: 0.1, stream: true }' \
+    > "$REQ_FILE"
+
+  REST_TIMEOUT="${REVIEW_REST_TIMEOUT:-115}"
+  # Stall watchdog: aborts if the stream produces < 1 byte/s for this many
+  # seconds. Set well above legitimate TTFT (time-to-first-token) for
+  # reasoning models, which can sit silent for tens of seconds before the
+  # first SSE chunk arrives — too low a value misfires on a healthy stream.
+  STALL_TIMEOUT="${REVIEW_REST_STALL_TIMEOUT:-90}"
+  # Clamp to remaining budget: ensure curl self-terminates before hook
+  # timeout SIGTERM, preserving diagnostic log writes after curl completes.
+  # 3s margin for jq extraction + log_decision after curl returns.
+  remaining=$(( HOOK_BUDGET - SECONDS ))
+  (( remaining - 3 < REST_TIMEOUT )) && REST_TIMEOUT=$(( remaining - 3 ))
+  (( REST_TIMEOUT < 1 )) && REST_TIMEOUT=1
+
+  ENGINE_STATUS="${ENGINE_OUT}.status"
+  ENGINE_TMP_FILES+=("$ENGINE_STATUS")
+
+  # -sS: -s suppresses progress meter, -S re-enables error messages (connection-level errors
+  # like "Failed to connect" would be silenced by -s alone, making raw_bytes=0 undiagnosable).
+  # --no-buffer: disable curl's output buffering so SSE chunks land in ENGINE_OUT as they
+  # arrive (only matters for anyone tailing the file live; parsing below still reads it
+  # after wait). --speed-limit/--speed-time: curl's own stall watchdog — abort (exit 28)
+  # if throughput drops below 1 byte/s for STALL_TIMEOUT seconds, independent of the
+  # outer TIMEOUT_CMD wall-clock cap.
+  # -w "%{http_code}": write HTTP status to stdout (redirected to ENGINE_STATUS); response
+  # body goes to ENGINE_OUT via -o. Read ENGINE_STATUS only AFTER wait completes.
+  ${TIMEOUT_CMD:+$TIMEOUT_CMD -k 5 $REST_TIMEOUT} curl -sS \
+    --no-buffer --speed-limit 1 --speed-time "$STALL_TIMEOUT" \
+    -X POST "${REVIEW_API_URL}/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${REVIEW_API_KEY}" \
+    -d @"$REQ_FILE" \
+    -o "$ENGINE_OUT" \
+    -w "%{http_code}" \
+    2>>"$LOG_FILE" > "$ENGINE_STATUS" &
+  ENGINE_PID=$!
+  curl_exit=0
+  wait "$ENGINE_PID" 2>/dev/null || curl_exit=$?
+  ENGINE_PID=""
+  rm -f "$REQ_FILE"; REQ_FILE=""
+}
+
+# --- Read $ENGINE_STATUS/$ENGINE_OUT, set $REVIEW (and $_fail_reason on
+#     failure). Handles the SSE stream, non-2xx/non-stream error bodies, and
+#     the stall-timeout case distinctly. ---
+rest_extract() {
+  # Read status after wait — shell creates ENGINE_STATUS on redirect, content written by curl.
+  # Explicit empty check: command substitution strips trailing newlines, but file may be empty
+  # (connection-level failure before HTTP handshake) → use "000" as sentinel for no-response.
+  rest_http_status=$(cat "$ENGINE_STATUS" 2>/dev/null)
+  [ -z "$rest_http_status" ] && rest_http_status="000"
+
+  if [ "$curl_exit" = "28" ]; then
+    # Stall watchdog fired — the provider went silent mid-stream. Don't hand
+    # a truncated partial body to the SSE parser; treat as a clean failure.
+    log_decision "rest-stall-timeout curl_exit=28"
+    REVIEW=""
+    _fail_reason="${_fail_reason:+${_fail_reason}; }REST: stall timeout (curl exit 28, no data for ${STALL_TIMEOUT}s)"
+  else
+    # Non-SSE error bypass: a non-2xx status, or a bare JSON object body (error
+    # response, not an SSE stream), must skip the SSE parser — feeding an error
+    # JSON through the "data: " cleaning pipeline silently drops it and yields an
+    # empty REVIEW with no diagnosis.
+    # SIGPIPE-safe first-char probe: `tr <big-file | head -c 1` lets head close
+    # the pipe after 1 byte while tr is still streaming the whole body, so tr
+    # dies with SIGPIPE (141). Under `set -o pipefail` the pipeline inherits 141
+    # and `set -e` then kills the hook mid-REST-fallback — before any decision
+    # JSON is emitted — on any sizable body (a normal long review response is
+    # enough). Bounding the read with a leading `head -c 100` means no stage
+    # faces an unbounded producer, so nothing gets SIGPIPE; 100 bytes is ample
+    # to find the first non-space char (leading whitespace before '{'/'data:').
+    first_char=$(head -c 100 "$ENGINE_OUT" 2>/dev/null | tr -d '[:space:]' | head -c 1)
+    case "$rest_http_status" in
+      2[0-9][0-9]) is_2xx=1 ;;
+      *) is_2xx=0 ;;
+    esac
+    if [ "$is_2xx" = "0" ] || [ "$first_char" = "{" ]; then
+      REVIEW=""
+      # Only emit rest-debug when there is a body to describe. An empty body
+      # (connection-level failure before the HTTP handshake, status 000) has
+      # nothing to diagnose — [ -s ] guards against a bare "body_prefix=" line.
+      if [ -s "$ENGINE_OUT" ]; then
+        rest_error=$(jq -r '.error.message // empty' "$ENGINE_OUT" 2>/dev/null || true)
+        if [ -n "$rest_error" ]; then
+          log_decision "rest-debug api_error=$(printf '%s' "$rest_error" | head -c 200)"
+        else
+          # tr -d '\000-\037': strip control characters to keep log single-line safe
+          log_decision "rest-debug body_prefix=$(head -c 200 "$ENGINE_OUT" | tr -d '\000-\037')"
+        fi
+      fi
+    else
+      # SSE cleaning pipeline: strip the "data: " prefix, then parse each frame
+      # in isolation and join delta.content across chunks.
+      #   -R  : read each line as a raw string (not pre-parsed JSON), so ONE
+      #         malformed frame cannot abort the whole parse.
+      #   fromjson? : parse the line to JSON, but the trailing "?" swallows a
+      #         parse error on that single line and skips it — a truncated /
+      #         garbled mid-stream frame (transient gateway hiccup) drops just
+      #         itself instead of discarding every chunk after it. The old
+      #         "-rj '.choices...'" form fed the whole stream to jq at once, so
+      #         a single bad frame aborted parsing and SILENTLY truncated the
+      #         review (2>/dev/null || true hid the exit 5) — a partial body can
+      #         carry a stale verdict and wrongly approve. fromjson? also makes
+      #         the non-JSON "[DONE]" terminator a no-op; the explicit grep -v
+      #         below is kept as belt-and-suspenders and to document intent.
+      #   -j  : join output, no per-value newline — O(1) memory, streaming.
+      #   "// empty": role-only first frame / finish_reason-only last frame /
+      #         empty-choices usage tail carry no content key — skip, don't emit "null".
+      REVIEW=$(grep '^data: ' "$ENGINE_OUT" | sed 's/^data: //' | grep -v '^\[DONE\]' | jq -j -R 'fromjson? | .choices[0].delta.content // empty' 2>/dev/null || true)
+    fi
+
+    raw_bytes=$(wc -c < "$ENGINE_OUT" | tr -d ' ')
+    review_bytes=$(printf '%s' "$REVIEW" | wc -c | tr -d ' ')
+    log_decision "rest-result http=$rest_http_status raw_bytes=$raw_bytes review_bytes=$review_bytes"
+    if [ -z "$REVIEW" ]; then
+      _fail_reason="${_fail_reason:+${_fail_reason}; }REST: http=${rest_http_status} raw_bytes=${raw_bytes}"
+    fi
+  fi
+}

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -101,7 +101,9 @@ _source_lib "$LIB_COMMON"
 _source_lib "$LIB_PLAN_SOURCE"
 _source_lib "$LIB_MANIFEST"
 _source_lib "$LIB_VERDICT"
-unset -f _source_lib
+# NOTE: `unset -f _source_lib` deliberately deferred until after the engine
+# libs (rest.sh + the selected engine) are sourced further down — this
+# function is reused there too, see the second bootstrap block below.
 
 # --- Engine temp-resource cleanup registry (MUST be declared before trap
 #     registration below): engines (codex's workdir/prompt/err) and the REST
@@ -187,18 +189,24 @@ LIB_REST="$LIB_ENGINES_DIR/rest.sh"
 LIB_ENGINE_SELECTED="$LIB_ENGINES_DIR/$ENGINE_LIB"
 
 for _lib in "$LIB_REST" "$LIB_ENGINE_SELECTED"; do
-  if [ ! -f "$_lib" ]; then
-    echo "plan-review: missing lib file $_lib, allowing." >&2
-    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"[WARNING] lib file missing, plan-review skipped"}}'
+  # Same `-s` rationale as the first bootstrap block above: an empty file
+  # passes `-f` clean, `source` "succeeds" on zero bytes, and the first call
+  # into a helper this lib was supposed to define (e.g. engine_probe) then
+  # dies with "command not found" (exit 127) — silent fail-closed, no allow
+  # JSON. `-s` catches missing AND empty in one test.
+  if [ ! -s "$_lib" ]; then
+    echo "plan-review: lib file missing or empty: $_lib, allowing." >&2
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"[WARNING] lib file missing or empty, plan-review skipped"}}'
     exit 0
   fi
 done
 unset _lib
 
 # shellcheck source=lib/engines/rest.sh
-source "$LIB_REST"
+_source_lib "$LIB_REST"
 # shellcheck disable=SC1090  # dynamic path — engine chosen by the whitelisted case above
-source "$LIB_ENGINE_SELECTED"
+_source_lib "$LIB_ENGINE_SELECTED"
+unset -f _source_lib
 
 # --- Unified field extraction (single jq fork, reused by guards + logging) ---
 # Pre-initialize so set -u won't fire if read fails (e.g. empty/malformed INPUT).

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -103,6 +103,20 @@ _source_lib "$LIB_MANIFEST"
 _source_lib "$LIB_VERDICT"
 unset -f _source_lib
 
+# --- Engine temp-resource cleanup registry (MUST be declared before trap
+#     registration below): engines (codex's workdir/prompt/err) and the REST
+#     fallback (status/req) append their own private temp paths here instead
+#     of _cleanup hardcoding their names. Declaring these arrays here, before
+#     `trap` is registered, is load-bearing under `set -u` — if the script
+#     exits early (e.g. a pre-flight guard below, before any engine is even
+#     selected), the trap still fires and evaluates `${#ENGINE_TMP_FILES[@]}`;
+#     an array that was NEVER declared throws "unbound variable" there (unlike
+#     a scalar, which `${var:-}` protects even when undeclared), which would
+#     make the trap itself die and skip the `kill "$ENGINE_PID"` cleanup below
+#     it entirely.
+ENGINE_TMP_FILES=()
+ENGINE_TMP_DIRS=()
+
 # --- Cleanup trap (registered here, right after lib sourcing, so any early
 #     exit — including the pre-flight guards below — is covered; previously
 #     this trapped only after PROMPT_FILE=$(mktemp) much later in the script,
@@ -113,9 +127,11 @@ unset -f _source_lib
 #     (normal), INT (Ctrl-C), TERM (framework hook timeout), and HUP (terminal
 #     disconnect). Idempotent — safe to call multiple times.
 _cleanup() {
-  rm -f "${PROMPT_FILE:-}" "${ENGINE_OUT:-}" "${ENGINE_STATUS:-}" "${REQ_FILE:-}"
-  rm -f "${ENGINE_ERR:-}" "${CODEX_PROMPT_FILE:-}" "${CODEX_PROMPT_FILE:+${CODEX_PROMPT_FILE}.u8}"
-  [ -z "${CODEX_WORKDIR:-}" ] || rmdir "${CODEX_WORKDIR:-}" 2>/dev/null || true
+  rm -f "${PROMPT_FILE:-}" "${ENGINE_OUT:-}"
+  [ ${#ENGINE_TMP_FILES[@]} -eq 0 ] || rm -f "${ENGINE_TMP_FILES[@]}"
+  [ ${#ENGINE_TMP_DIRS[@]}  -eq 0 ] || rmdir "${ENGINE_TMP_DIRS[@]}" 2>/dev/null || true
+  ENGINE_TMP_FILES=()
+  ENGINE_TMP_DIRS=()
   [ -z "${ENGINE_PID:-}" ] || kill "${ENGINE_PID:-}" 2>/dev/null || true
 }
 trap '_cleanup' EXIT
@@ -127,6 +143,41 @@ REVIEW_DRY_RUN="${REVIEW_DRY_RUN:-${GEMINI_DRY_RUN:-0}}"
 REVIEW_MAX_ROUNDS="${REVIEW_MAX_ROUNDS:-${GEMINI_MAX_REVIEWS:-3}}"
 REVIEW_MAX_TOTAL_ROUNDS="${REVIEW_MAX_TOTAL_ROUNDS:-20}"
 REVIEW_ENGINE="${REVIEW_ENGINE:-gemini}"
+
+# --- Engine selection: whitelist case, never string-concat into a source
+#     path (REVIEW_ENGINE is externally controlled via env var — string
+#     concatenation into `source` would be a path-injection surface). This
+#     is the ONLY branch on REVIEW_ENGINE's value left in this file; adding a
+#     4th engine is "write lib/engines/<name>.sh, add one line here".
+#     NOTE: the `*)` fallback to agy.sh is CURRENT BEHAVIOR preserved as-is —
+#     an unrecognized REVIEW_ENGINE value (or the default "gemini") has
+#     always fallen through to the agy code path in the pre-refactor script,
+#     since only "claude" and "codex" were ever special-cased. Whether an
+#     unrecognized value should instead fail loudly is a separate, deliberate
+#     policy decision left to a follow-up — out of scope for this zero
+#     behavior-change refactor.
+case "$REVIEW_ENGINE" in
+  claude) ENGINE_LIB="claude.sh" ; ENGINE_CMD="claude" ;;
+  codex)  ENGINE_LIB="codex.sh"  ; ENGINE_CMD="${CODEX_BIN:-codex}" ;;
+  *)      ENGINE_LIB="agy.sh"    ; ENGINE_CMD="agy" ;;
+esac
+LIB_ENGINES_DIR="$SCRIPT_DIR/lib/engines"
+LIB_REST="$LIB_ENGINES_DIR/rest.sh"
+LIB_ENGINE_SELECTED="$LIB_ENGINES_DIR/$ENGINE_LIB"
+
+for _lib in "$LIB_REST" "$LIB_ENGINE_SELECTED"; do
+  if [ ! -f "$_lib" ]; then
+    echo "plan-review: missing lib file $_lib, allowing." >&2
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"[WARNING] lib file missing, plan-review skipped"}}'
+    exit 0
+  fi
+done
+unset _lib
+
+# shellcheck source=lib/engines/rest.sh
+source "$LIB_REST"
+# shellcheck disable=SC1090  # dynamic path — engine chosen by the whitelisted case above
+source "$LIB_ENGINE_SELECTED"
 
 # --- Unified field extraction (single jq fork, reused by guards + logging) ---
 # Pre-initialize so set -u won't fire if read fails (e.g. empty/malformed INPUT).
@@ -391,13 +442,10 @@ PROMPT_FILE=$(mktemp)
 
 # Engine-specific system injection: PROMPT_FILE holds dynamic content only,
 # regardless of engine. Each channel injects SYSTEM_INSTRUCTIONS on its own
-# rail: claude → --system-prompt; agy → inline concat; REST → messages[0].
+# rail: claude → --system-prompt (set in claude.sh's engine_probe); agy →
+# inline concat (agy.sh's engine_invoke); REST → messages[0] (rest.sh's
+# rest_invoke).
 : > "$PROMPT_FILE"
-if [ "$REVIEW_ENGINE" = "claude" ]; then
-  SYSTEM_PROMPT="$SYSTEM_INSTRUCTIONS"
-else
-  SYSTEM_PROMPT=""
-fi
 
 # Shared dynamic content: stable → volatile ordering
 cat >> "$PROMPT_FILE" << DYNEOF
@@ -430,29 +478,6 @@ if [ "$REVIEW_DRY_RUN" = "1" ]; then
   REVIEW="<verdict>APPROVE</verdict>
 [DRY-RUN] 审阅调用已跳过。"
 else
-  # --- Pre-flight: CLI existence check (permanent failure, no retry) ---
-  ENGINE_CMD="agy"
-  case "$REVIEW_ENGINE" in
-    claude) ENGINE_CMD="claude" ;;
-    codex)  ENGINE_CMD="${CODEX_BIN:-codex}" ;;
-  esac
-  if ! command -v "$ENGINE_CMD" >/dev/null 2>&1; then
-    log_decision "decision=allow reason=engine-not-found engine=$REVIEW_ENGINE"
-    allow_with_reason "[WARNING] REVIEW_ENGINE=$REVIEW_ENGINE but '$ENGINE_CMD' not found"
-  fi
-
-  # Engine model variables (outside retry loop, avoid repeat assignment)
-  if [ "$REVIEW_ENGINE" = "claude" ]; then
-    CLAUDE_MODEL="${CLAUDE_MODEL:-opus}"
-  elif [ "$REVIEW_ENGINE" = "codex" ]; then
-    # Empty CODEX_MODEL means inherit codex's own ~/.codex/config.toml default.
-    CODEX_MODEL="${CODEX_MODEL:-}"
-  else
-    # GEMINI_MODEL retained as the REST fallback's model id (OpenAI-compatible payload).
-    GEMINI_MODEL="${GEMINI_MODEL:-gemini-3.1-pro-preview}"
-    AGY_MODEL="${AGY_MODEL:-Gemini 3.1 Pro (High)}"
-  fi
-
   # Portable timeout: timeout (GNU/Homebrew) > gtimeout (coreutils) > none
   TIMEOUT_CMD=""
   if command -v timeout >/dev/null 2>&1; then
@@ -495,43 +520,13 @@ else
   REVIEW=""
   HOOK_BUDGET="${REVIEW_HOOK_BUDGET:-595}"
 
-  # codex-only temp resources: a sandboxed workdir (-C target, deliberately NOT
-  # the project cwd — codex runs read-only but there's no reason to hand it the
-  # real tree), a merged prompt file (system instructions + PROMPT_FILE's
-  # dynamic content — kept SEPARATE from PROMPT_FILE itself so the REST
-  # fallback's --rawfile read of PROMPT_FILE doesn't double-send the system
-  # instructions), and an isolated stderr capture (codex echoes the FULL
-  # prompt to stderr — see the diagnostic backfill below, never let this reach
-  # LOG_FILE wholesale). Declared as empty defaults unconditionally so set -u
-  # never fires on the gemini/claude paths, and created only when
-  # REVIEW_ENGINE=codex so those paths gain zero new mktemp calls.
-  CODEX_WORKDIR="" CODEX_PROMPT_FILE="" ENGINE_ERR="" PROMPT_LINES=0
-  if [ "$REVIEW_ENGINE" = "codex" ]; then
-    CODEX_WORKDIR=$(mktemp -d)
-    CODEX_PROMPT_FILE=$(mktemp)
-    ENGINE_ERR="${ENGINE_OUT}.err"
-    { printf '%s\n\n' "$SYSTEM_INSTRUCTIONS"; cat "$PROMPT_FILE"; } > "$CODEX_PROMPT_FILE"
-    printf '\n' >> "$CODEX_PROMPT_FILE"
-    # UTF-8 sanitation (codex-only — the other engines never see this file).
-    # GLOBAL_MD/PROJECT_MD are truncated by BYTE count (`head -c 3000` / `-c 8000`),
-    # which slices a multi-byte character in half whenever a CLAUDE.md is non-ASCII
-    # near the cut. codex hard-rejects such input — it does not degrade, it aborts:
-    #   "Failed to read prompt from stdin: input is not valid UTF-8 (invalid byte
-    #    at offset N). Convert it to UTF-8 and retry"
-    # …making REVIEW_ENGINE=codex unusable for anyone with a non-ASCII CLAUDE.md.
-    # `iconv -c` drops only the orphaned bytes and keeps every valid character.
-    # Guarded on iconv's presence and on success (`&& mv || rm`), so a missing or
-    # failing iconv degrades to the unsanitized file rather than an empty prompt.
-    if command -v iconv >/dev/null 2>&1; then
-      if iconv -f UTF-8 -t UTF-8 -c < "$CODEX_PROMPT_FILE" > "${CODEX_PROMPT_FILE}.u8" 2>/dev/null; then
-        mv -f "${CODEX_PROMPT_FILE}.u8" "$CODEX_PROMPT_FILE"
-      else
-        rm -f "${CODEX_PROMPT_FILE}.u8"
-      fi
-    fi
-    # Counted AFTER sanitation: PROMPT_LINES drives the diagnostic backfill's
-    # positional cut, which must match the file codex actually received.
-    PROMPT_LINES=$(wc -l < "$CODEX_PROMPT_FILE")
+  # --- Pre-flight: CLI existence check (permanent failure, no retry) + one-
+  #     time per-engine setup (model resolution, temp resource prep) —
+  #     delegated to the sourced engine's engine_probe(), called once outside
+  #     the retry loop below. ---
+  if ! engine_probe; then
+    log_decision "decision=allow reason=engine-not-found engine=$REVIEW_ENGINE"
+    allow_with_reason "[WARNING] REVIEW_ENGINE=$REVIEW_ENGINE but '$ENGINE_PROBE_REASON' not found"
   fi
 
   for (( engine_attempt=1; engine_attempt<=2; engine_attempt++ )); do
@@ -554,240 +549,21 @@ else
     engine_exit=0
     # Snapshot log position before call — used after failure to detect capacity-specific 429
     log_pos_before=$(wc -c < "$LOG_FILE" 2>/dev/null || echo 0)
-    if [ "$REVIEW_ENGINE" = "claude" ]; then
-      # Strip Claude Code internal env vars to prevent recursive hook/plugin loading.
-      # Fragile (depends on internal implementation), but necessary: user authenticates
-      # via OAuth (claude login), no ANTHROPIC_API_KEY available, so claude -p is the
-      # only viable path. Triple isolation: --setting-sources local + PLAN_REVIEW_RUNNING
-      # + --tools "" (no tool calls = no PreToolUse events).
-      unset CLAUDECODE
-      unset CLAUDE_CODE_ENTRYPOINT
-      PLAN_REVIEW_RUNNING=1 ${TIMEOUT_CMD:+$TIMEOUT_CMD -k 5 $ENGINE_TIMEOUT} claude -p \
-        --model "$CLAUDE_MODEL" \
-        --setting-sources local \
-        --no-session-persistence \
-        --tools "" \
-        --disable-slash-commands \
-        --system-prompt "$SYSTEM_PROMPT" \
-        < "$PROMPT_FILE" > "$ENGINE_OUT" 2>>"$LOG_FILE" &
-      ENGINE_PID=$!
-      wait "$ENGINE_PID" 2>/dev/null || engine_exit=$?
-      ENGINE_PID=""
-    elif [ "$REVIEW_ENGINE" = "codex" ]; then
-      # Model id can contain spaces (see AGY_MODEL's default "Gemini 3.1 Pro
-      # (High)" precedent above) — must be an array, not ${VAR:+...} word-splitting.
-      CODEX_MODEL_ARGS=()
-      [ -z "$CODEX_MODEL" ] || CODEX_MODEL_ARGS=(-m "$CODEX_MODEL")
-      ${TIMEOUT_CMD:+$TIMEOUT_CMD -k 5 $ENGINE_TIMEOUT} "$ENGINE_CMD" exec \
-        --skip-git-repo-check -s read-only --ephemeral --color never \
-        -C "$CODEX_WORKDIR" ${CODEX_MODEL_ARGS[@]+"${CODEX_MODEL_ARGS[@]}"} \
-        -o "$ENGINE_OUT" - < "$CODEX_PROMPT_FILE" > /dev/null 2> "$ENGINE_ERR" &
-      ENGINE_PID=$!
-      wait "$ENGINE_PID" 2>/dev/null || engine_exit=$?
-      ENGINE_PID=""
 
-      if [ "$engine_exit" != "0" ]; then
-        # --- Privacy boundary: codex echoes the FULL prompt to stderr before
-        # its real diagnostics (global CLAUDE.md + project CLAUDE.md + recent
-        # conversation + the plan). Never let ENGINE_ERR reach LOG_FILE
-        # wholesale — backfill only a filtered tail, two-layer defense:
-        #   Layer A (positional): locate the banner's SECOND "--------" line
-        #     (within the first 20 lines) followed by a line that is exactly
-        #     "user" — that marks where the echoed prompt begins; cut it out
-        #     using PROMPT_LINES (captured once, outside the retry loop) to
-        #     find where it ends, keeping the banner + the real tail after it.
-        #     Any of the three guards failing falls through to the fail-closed
-        #     `tail -n 20` branch, which still preserves diagnostics for
-        #     failures that happen before codex echoes anything (auth/network).
-        #   Layer B (content-based): grep -Fvxf strips any surviving line that
-        #     is byte-identical to a prompt line — this is what survives codex
-        #     version drift in line counts (banner shape / prompt line count
-        #     changing between versions).
-        # `|| true` on the ECHO_END lookup and the final pipe are MANDATORY:
-        # set -euo pipefail means a grep returning 1 (no match / everything
-        # filtered out) would otherwise kill the hook before it emits its
-        # decision JSON.
-        # LC_ALL=C on both greps (command-scoped, not exported — deliberately
-        # narrower than the LC_ALL=C prefix-assignment pattern avoided
-        # elsewhere in this file): CODEX_PROMPT_FILE embeds GLOBAL_MD/
-        # PROJECT_MD truncated by BYTE count (`head -c`), which can slice a
-        # multi-byte UTF-8 character in half. Under the active UTF-8 locale
-        # that makes grep abort with "illegal byte sequence" — silently
-        # emptying CODEX_DIAG (the trailing `|| true` hides the failure).
-        # Forcing the C locale makes grep treat input as raw bytes, matching
-        # this pipeline's real behavior anyway: -F is already a fixed-string
-        # byte match, and -x needs no locale-aware collation.
-        CODEX_DIAG=$(
-          ECHO_END=$(head -n 20 "$ENGINE_ERR" | grep -n '^--------$' | sed -n '2p' | cut -d: -f1) || true
-          NEXT_LINE=$(sed -n "$(( ${ECHO_END:-0} + 1 ))p" "$ENGINE_ERR" 2>/dev/null)
-          if [ -n "$ECHO_END" ] && [ "$ECHO_END" -le 20 ] && [ "$NEXT_LINE" = "user" ]; then
-            { head -n "$ECHO_END" "$ENGINE_ERR"
-              tail -n "+$(( ECHO_END + PROMPT_LINES + 2 ))" "$ENGINE_ERR"; }
-          else
-            tail -n 20 "$ENGINE_ERR"
-          fi \
-          | LC_ALL=C grep -Fvxf "$CODEX_PROMPT_FILE" \
-          | LC_ALL=C grep '[^[:space:]]' \
-          | head -c 500 || true
-        )
-        # tr -d '\000-\037': strip control chars, keep log single-line safe
-        # (mirrors the existing rest-debug body_prefix backfill).
-        log_decision "codex-diag $(printf '%s' "$CODEX_DIAG" | tr -d '\000-\037')"
-      fi
-    else
-      # --- agy multi-round session reuse ---
-      # Read back a previously-captured agy conversation_id (if any) so this
-      # round can resume it instead of resending the full static prefix — the
-      # prefix (system instructions + GLOBAL_MD/PROJECT_MD/USER_REQ) already
-      # lives in agy's server-side session history, which lets the provider
-      # hit prompt cache on it. Validate strictly (36-char UUID) since a
-      # malformed/stale value would make `--conversation` resume garbage.
-      CONV_ID=$(cat "${CONV_FILE:-}" 2>/dev/null | tr 'A-F' 'a-f' || true)
-      [[ "$CONV_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] || CONV_ID=""
-      CONV_ARGS=()
-      [ -z "$CONV_ID" ] || CONV_ARGS=(--conversation "$CONV_ID")
-
-      # agy does not read stdin as a prompt — must pass inline via -p. ANSI-C
-      # quoting ($'\n\n') for a real newline separator; a plain "\n" inside
-      # double quotes is a literal backslash-n, not a newline.
-      if [ -z "$CONV_ID" ]; then
-        # First round (no session to resume yet): send the full static+dynamic prompt.
-        AGY_PROMPT="$SYSTEM_INSTRUCTIONS"$'\n\n'"$(cat "$PROMPT_FILE")"
-      else
-        # Reuse round: static prefix already lives in agy's session history —
-        # resend only the volatile tail. Mirror the first-round Consultation
-        # Context framing (round number + "APPROVE if prior concerns addressed")
-        # so the reuse round carries the same negotiation semantics, not a bare
-        # plan dump. Resending the delta only (not the static context) is the
-        # point — it gets appended to session history, so duplicating context
-        # would cost tokens, not save them.
-        AGY_PROMPT="## Consultation Context
-This is round $((TOTAL_ROUNDS + 1)) of adversarial review.
-The plan author may have revised or added rebuttals since the previous round.
-Evaluate the CURRENT plan on its merits — if prior concerns have been addressed, APPROVE.
-
-## Plan to Review
-${PLAN}"
-      fi
-      # ARG_MAX defense: agy only accepts the prompt as a command-line argument,
-      # so an oversized prompt trips E2BIG. Treat this as a CLI failure and
-      # fall straight through to REST fallback rather than exec'ing a doomed command.
-      # Count BYTES, not characters: the ARG_MAX limit is byte-denominated, but
-      # ${#VAR} counts characters under a UTF-8 locale, so a CJK plan (3 bytes/
-      # char) would undercount ~3x and defeat the 256KB guard. `wc -c` counts
-      # bytes regardless of locale — one fork per hook invocation is negligible,
-      # and it sidesteps the LC_ALL=C prefix-assignment locale-leak footgun.
-      AGY_PROMPT_BYTES=$(printf '%s' "$AGY_PROMPT" | wc -c | tr -d ' ')
-      if [ "$AGY_PROMPT_BYTES" -gt 256000 ]; then
-        log_decision "agy-skip reason=prompt-too-large bytes=$AGY_PROMPT_BYTES"
-        REVIEW=""
-        _fail_reason="agy: prompt too large (${AGY_PROMPT_BYTES}B > 256000B), skipped to REST"
-        break
-      fi
-      ${TIMEOUT_CMD:+$TIMEOUT_CMD -k 5 $ENGINE_TIMEOUT} agy --model "$AGY_MODEL" --sandbox --dangerously-skip-permissions \
-        ${CONV_ARGS[@]+"${CONV_ARGS[@]}"} --output-format json \
-        -p "$AGY_PROMPT" > "$ENGINE_OUT" 2>>"$LOG_FILE" &
-      ENGINE_PID=$!
-      wait "$ENGINE_PID" 2>/dev/null || engine_exit=$?
-      ENGINE_PID=""
+    # --- Call the sourced engine's invoke hook. agy's invoke may set
+    #     _ENGINE_ABORT_RETRY=1 (oversized prompt, ARG_MAX defense) to signal
+    #     an immediate break BEFORE extraction/exit-code handling — mirroring
+    #     the pre-refactor inline `break`. A literal `break` inside the
+    #     function itself would be bash-version-dependent (verified: bash 3.2
+    #     propagates it to this loop, bash 5.x does not), so an explicit flag
+    #     is the only portable signal.
+    _ENGINE_ABORT_RETRY=0
+    engine_invoke
+    if [ "$_ENGINE_ABORT_RETRY" = "1" ]; then
+      break
     fi
-    if [ "$REVIEW_ENGINE" = "claude" ] || [ "$REVIEW_ENGINE" = "codex" ]; then
-      REVIEW=$(cat "$ENGINE_OUT" 2>/dev/null || true)
-    else
-      # --- agy JSON response unwrap (--output-format json) ---
-      # agy's JSON is NOT well-formed (the "response" field contains raw
-      # unescaped newlines), so jq/python json.loads chokes on it. Everything
-      # below is deliberate sed/awk text slicing — zero jq, zero python.
-      REVIEW=""
-      if [ "$engine_exit" = "0" ] && [ -s "$ENGINE_OUT" ]; then
-        # Capture the real conversation_id agy assigned (self-chosen server-side
-        # UUID; a client-invented one would not resume anything). `q` after the
-        # first match — no pipe, no SIGPIPE. Tolerate a lowercase-normalized id;
-        # persist is DEFERRED until response extraction succeeds (see below) so a
-        # broken envelope never leaves a CONV_FILE that the next round resumes.
-        NEW_CONV=$(sed -n '/"conversation_id"/{s/.*"conversation_id"[[:space:]]*:[[:space:]]*"\([0-9a-fA-F-]\{36\}\)".*/\1/p;q;}' "$ENGINE_OUT" 2>/dev/null || true)
-        NEW_CONV=$(printf '%s' "$NEW_CONV" | tr 'A-F' 'a-f')
 
-        # Extract the "response" field value and unescape it. Deliberately NOT
-        # keyed to field order/position — scan forward from the "response":"
-        # marker and stop at the first UNESCAPED double-quote, so trailing keys
-        # (usage, etc.) after response in the object don't matter.
-        REVIEW=$(awk '
-          BEGIN { RS="\x01" }
-          {
-            s = $0
-            # Tolerate optional whitespace around the key colon
-            # ("response" : "...") — do not bet on the compact serialization.
-            if (match(s, /"response"[ \t]*:[ \t]*"/) == 0) { exit }
-            s = substr(s, RSTART + RLENGTH)
-            out = ""; i = 1; n = length(s)
-            while (i <= n) {
-              c = substr(s, i, 1)
-              if (c == "\\") {
-                i++
-                nc = substr(s, i, 1)
-                if (nc == "n") out = out "\n"
-                else if (nc == "t") out = out "\t"
-                else if (nc == "\"") out = out "\""
-                else if (nc == "\\") out = out "\\"
-                else if (nc == "r") out = out "\r"
-                else if (nc == "u") {
-                  # \uXXXX: Go encoding/json HTML-safe mode escapes <, >, & and
-                  # U+2028/U+2029 this way by default (XSS defense) — that set
-                  # is what agy actually emits, verified by reproduction. Any
-                  # other \uXXXX is passed through literally (backslash intact)
-                  # rather than silently dropped, so an unanticipated escape is
-                  # visibly wrong instead of corrupting the tag structure.
-                  hex = tolower(substr(s, i + 1, 4))
-                  if (hex == "003c") out = out "<"
-                  else if (hex == "003e") out = out ">"
-                  else if (hex == "0026") out = out "&"
-                  else if (hex == "2028" || hex == "2029") out = out "\n"
-                  else out = out "\\u" substr(s, i + 1, 4)
-                  i += 4
-                }
-                else out = out nc
-                i++
-              } else if (c == "\"") {
-                break
-              } else {
-                out = out c
-                i++
-              }
-            }
-            printf "%s", out
-          }
-        ' "$ENGINE_OUT" 2>/dev/null || true)
-
-        # Fallback: never hand the shell-wrapped JSON to the downstream verdict
-        # extractor — the raw envelope can contain echoed-back <verdict> tags
-        # from the prompt and cause a false match. Extraction failure = empty
-        # REVIEW, which the existing empty-response retry/REST path handles.
-        #
-        # CONV_FILE persist policy (only when we got a usable review): persisting
-        # a conversation_id from a call whose response we COULDN'T parse would
-        # make the next round resume a session we can't actually consume — so
-        # persist only on non-empty REVIEW, and drop any stale CONV_FILE on
-        # extract failure (the session may be shaped wrong / unusable this cycle).
-        if [ -n "$REVIEW" ]; then
-          if [[ "$NEW_CONV" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
-            printf '%s' "$NEW_CONV" > "${CONV_FILE}.tmp.$$" 2>/dev/null && mv -f "${CONV_FILE}.tmp.$$" "$CONV_FILE" 2>/dev/null || true
-            log_decision "agy-conversation id=$NEW_CONV reuse=$([ -n "$CONV_ID" ] && echo yes || echo no)"
-          fi
-          log_decision "agy-success"
-        else
-          rm -f "${CONV_FILE:-}"
-          log_decision "agy-response-extract-failed conv-cleared"
-        fi
-
-        # Usage observation (best-effort, never fatal if absent/unparseable).
-        # `q` after first match — consistent with the conversation_id sed, no
-        # pipe, no SIGPIPE.
-        AGY_IN=$(sed -n 's/.*"input_tokens"[[:space:]]*:[[:space:]]*\([0-9]\{1,\}\).*/\1/p;/"input_tokens"/q' "$ENGINE_OUT" 2>/dev/null || true)
-        AGY_TOTAL=$(sed -n 's/.*"total_tokens"[[:space:]]*:[[:space:]]*\([0-9]\{1,\}\).*/\1/p;/"total_tokens"/q' "$ENGINE_OUT" 2>/dev/null || true)
-        [ -z "$AGY_IN" ] && [ -z "$AGY_TOTAL" ] || log_decision "agy-usage in=${AGY_IN:-?} total=${AGY_TOTAL:-?}"
-      fi
-    fi
+    engine_extract
     : > "$ENGINE_OUT"
     if [ "$engine_exit" != "0" ]; then
       REVIEW=""
@@ -860,125 +636,9 @@ ${PLAN}"
     fi
     echo "plan-review: CLI exhausted, trying REST API fallback..." >&2
     log_decision "rest-start url=${REVIEW_API_URL:+(set)} key=${REVIEW_API_KEY:+(set)}"
-    REQ_FILE=$(mktemp)
-    # --rawfile (not --arg + $(cat ...)) reads PROMPT_FILE directly inside jq,
-    # keeping the large plan body off the command line entirely (no E2BIG risk
-    # on this side). messages[0]=system stays a stable prefix across rounds —
-    # prefix-cacheable by the upstream provider. stream:true enables SSE below.
-    jq -n --arg model "${GEMINI_MODEL:-gemini-3.1-pro-preview}" \
-          --arg sys "$SYSTEM_INSTRUCTIONS" \
-          --rawfile prompt "$PROMPT_FILE" \
-      '{ model: $model, messages: [{ role: "system", content: $sys }, { role: "user", content: $prompt }], max_tokens: 16000, temperature: 0.1, stream: true }' \
-      > "$REQ_FILE"
 
-    REST_TIMEOUT="${REVIEW_REST_TIMEOUT:-115}"
-    # Stall watchdog: aborts if the stream produces < 1 byte/s for this many
-    # seconds. Set well above legitimate TTFT (time-to-first-token) for
-    # reasoning models, which can sit silent for tens of seconds before the
-    # first SSE chunk arrives — too low a value misfires on a healthy stream.
-    STALL_TIMEOUT="${REVIEW_REST_STALL_TIMEOUT:-90}"
-    # Clamp to remaining budget: ensure curl self-terminates before hook
-    # timeout SIGTERM, preserving diagnostic log writes after curl completes.
-    # 3s margin for jq extraction + log_decision after curl returns.
-    remaining=$(( HOOK_BUDGET - SECONDS ))
-    (( remaining - 3 < REST_TIMEOUT )) && REST_TIMEOUT=$(( remaining - 3 ))
-    (( REST_TIMEOUT < 1 )) && REST_TIMEOUT=1
-    # -sS: -s suppresses progress meter, -S re-enables error messages (connection-level errors
-    # like "Failed to connect" would be silenced by -s alone, making raw_bytes=0 undiagnosable).
-    # --no-buffer: disable curl's output buffering so SSE chunks land in ENGINE_OUT as they
-    # arrive (only matters for anyone tailing the file live; parsing below still reads it
-    # after wait). --speed-limit/--speed-time: curl's own stall watchdog — abort (exit 28)
-    # if throughput drops below 1 byte/s for STALL_TIMEOUT seconds, independent of the
-    # outer TIMEOUT_CMD wall-clock cap.
-    # -w "%{http_code}": write HTTP status to stdout (redirected to ENGINE_STATUS); response
-    # body goes to ENGINE_OUT via -o. Read ENGINE_STATUS only AFTER wait completes.
-    ${TIMEOUT_CMD:+$TIMEOUT_CMD -k 5 $REST_TIMEOUT} curl -sS \
-      --no-buffer --speed-limit 1 --speed-time "$STALL_TIMEOUT" \
-      -X POST "${REVIEW_API_URL}/v1/chat/completions" \
-      -H "Content-Type: application/json" \
-      -H "Authorization: Bearer ${REVIEW_API_KEY}" \
-      -d @"$REQ_FILE" \
-      -o "$ENGINE_OUT" \
-      -w "%{http_code}" \
-      2>>"$LOG_FILE" > "$ENGINE_STATUS" &
-    ENGINE_PID=$!
-    curl_exit=0
-    wait "$ENGINE_PID" 2>/dev/null || curl_exit=$?
-    ENGINE_PID=""
-    rm -f "$REQ_FILE"; REQ_FILE=""
-
-    # Read status after wait — shell creates ENGINE_STATUS on redirect, content written by curl.
-    # Explicit empty check: command substitution strips trailing newlines, but file may be empty
-    # (connection-level failure before HTTP handshake) → use "000" as sentinel for no-response.
-    rest_http_status=$(cat "$ENGINE_STATUS" 2>/dev/null)
-    [ -z "$rest_http_status" ] && rest_http_status="000"
-
-    if [ "$curl_exit" = "28" ]; then
-      # Stall watchdog fired — the provider went silent mid-stream. Don't hand
-      # a truncated partial body to the SSE parser; treat as a clean failure.
-      log_decision "rest-stall-timeout curl_exit=28"
-      REVIEW=""
-      _fail_reason="${_fail_reason:+${_fail_reason}; }REST: stall timeout (curl exit 28, no data for ${STALL_TIMEOUT}s)"
-    else
-      # Non-SSE error bypass: a non-2xx status, or a bare JSON object body (error
-      # response, not an SSE stream), must skip the SSE parser — feeding an error
-      # JSON through the "data: " cleaning pipeline silently drops it and yields an
-      # empty REVIEW with no diagnosis.
-      # SIGPIPE-safe first-char probe: `tr <big-file | head -c 1` lets head close
-      # the pipe after 1 byte while tr is still streaming the whole body, so tr
-      # dies with SIGPIPE (141). Under `set -o pipefail` the pipeline inherits 141
-      # and `set -e` then kills the hook mid-REST-fallback — before any decision
-      # JSON is emitted — on any sizable body (a normal long review response is
-      # enough). Bounding the read with a leading `head -c 100` means no stage
-      # faces an unbounded producer, so nothing gets SIGPIPE; 100 bytes is ample
-      # to find the first non-space char (leading whitespace before '{'/'data:').
-      first_char=$(head -c 100 "$ENGINE_OUT" 2>/dev/null | tr -d '[:space:]' | head -c 1)
-      case "$rest_http_status" in
-        2[0-9][0-9]) is_2xx=1 ;;
-        *) is_2xx=0 ;;
-      esac
-      if [ "$is_2xx" = "0" ] || [ "$first_char" = "{" ]; then
-        REVIEW=""
-        # Only emit rest-debug when there is a body to describe. An empty body
-        # (connection-level failure before the HTTP handshake, status 000) has
-        # nothing to diagnose — [ -s ] guards against a bare "body_prefix=" line.
-        if [ -s "$ENGINE_OUT" ]; then
-          rest_error=$(jq -r '.error.message // empty' "$ENGINE_OUT" 2>/dev/null || true)
-          if [ -n "$rest_error" ]; then
-            log_decision "rest-debug api_error=$(printf '%s' "$rest_error" | head -c 200)"
-          else
-            # tr -d '\000-\037': strip control characters to keep log single-line safe
-            log_decision "rest-debug body_prefix=$(head -c 200 "$ENGINE_OUT" | tr -d '\000-\037')"
-          fi
-        fi
-      else
-        # SSE cleaning pipeline: strip the "data: " prefix, then parse each frame
-        # in isolation and join delta.content across chunks.
-        #   -R  : read each line as a raw string (not pre-parsed JSON), so ONE
-        #         malformed frame cannot abort the whole parse.
-        #   fromjson? : parse the line to JSON, but the trailing "?" swallows a
-        #         parse error on that single line and skips it — a truncated /
-        #         garbled mid-stream frame (transient gateway hiccup) drops just
-        #         itself instead of discarding every chunk after it. The old
-        #         "-rj '.choices...'" form fed the whole stream to jq at once, so
-        #         a single bad frame aborted parsing and SILENTLY truncated the
-        #         review (2>/dev/null || true hid the exit 5) — a partial body can
-        #         carry a stale verdict and wrongly approve. fromjson? also makes
-        #         the non-JSON "[DONE]" terminator a no-op; the explicit grep -v
-        #         below is kept as belt-and-suspenders and to document intent.
-        #   -j  : join output, no per-value newline — O(1) memory, streaming.
-        #   "// empty": role-only first frame / finish_reason-only last frame /
-        #         empty-choices usage tail carry no content key — skip, don't emit "null".
-        REVIEW=$(grep '^data: ' "$ENGINE_OUT" | sed 's/^data: //' | grep -v '^\[DONE\]' | jq -j -R 'fromjson? | .choices[0].delta.content // empty' 2>/dev/null || true)
-      fi
-
-      raw_bytes=$(wc -c < "$ENGINE_OUT" | tr -d ' ')
-      review_bytes=$(printf '%s' "$REVIEW" | wc -c | tr -d ' ')
-      log_decision "rest-result http=$rest_http_status raw_bytes=$raw_bytes review_bytes=$review_bytes"
-      if [ -z "$REVIEW" ]; then
-        _fail_reason="${_fail_reason:+${_fail_reason}; }REST: http=${rest_http_status} raw_bytes=${raw_bytes}"
-      fi
-    fi
+    rest_invoke
+    rest_extract
 
     : > "$ENGINE_OUT"
     [ -z "$REVIEW" ] || echo "plan-review: REST API fallback succeeded." >&2

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -143,6 +143,10 @@ _cleanup() {
   # `declare -F` because backfill_engine_err may not be defined yet (an
   # earlier guard can exit before lib/common.sh is even sourced) — the whole
   # line must never let this trap itself fail.
+  # Reentrancy: TERM/INT/HUP fires _cleanup and then EXIT fires it again, so
+  # this runs twice. It stays idempotent because backfill_engine_err truncates
+  # $ENGINE_ERR after flushing it — the second pass sees an empty file and its
+  # own `[ -s ]` guard returns early. No double-write.
   declare -F backfill_engine_err >/dev/null 2>&1 && backfill_engine_err 143 || true
   rm -f "${PROMPT_FILE:-}" "${ENGINE_OUT:-}" "${ENGINE_ERR:-}"
   [ ${#ENGINE_TMP_FILES[@]} -eq 0 ] || rm -f "${ENGINE_TMP_FILES[@]}"

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -126,8 +126,13 @@ ENGINE_TMP_DIRS=()
 #     an empty or already-gone target is a harmless no-op. Called on EXIT
 #     (normal), INT (Ctrl-C), TERM (framework hook timeout), and HUP (terminal
 #     disconnect). Idempotent — safe to call multiple times.
+#     ENGINE_ERR is a contract channel like PROMPT_FILE/ENGINE_OUT — the
+#     orchestrator allocates it (ENGINE_ERR="${ENGINE_OUT}.err", set once
+#     below) for EVERY engine, unconditionally, so it is hardcoded here
+#     rather than routed through the generic ENGINE_TMP_FILES registry (which
+#     is for engine-PRIVATE resources only, e.g. codex's sandboxed workdir).
 _cleanup() {
-  rm -f "${PROMPT_FILE:-}" "${ENGINE_OUT:-}"
+  rm -f "${PROMPT_FILE:-}" "${ENGINE_OUT:-}" "${ENGINE_ERR:-}"
   [ ${#ENGINE_TMP_FILES[@]} -eq 0 ] || rm -f "${ENGINE_TMP_FILES[@]}"
   [ ${#ENGINE_TMP_DIRS[@]}  -eq 0 ] || rmdir "${ENGINE_TMP_DIRS[@]}" 2>/dev/null || true
   ENGINE_TMP_FILES=()
@@ -517,6 +522,15 @@ else
   # process if the hook script itself is terminated (e.g. hook timeout SIGTERM).
   ENGINE_OUT=$(mktemp)
   ENGINE_STATUS="${ENGINE_OUT}.status"
+  # Orchestrator owns the stderr CHANNEL for every engine (agy/claude/codex
+  # alike) — allocated unconditionally here, not codex-private. Each engine
+  # redirects its own invocation's stderr into it (2>"$ENGINE_ERR") and
+  # declares, via $ENGINE_ERR_POLICY (set in its engine_probe()), what the
+  # orchestrator is allowed to do with the CONTENT: "verbatim" (agy/claude)
+  # backfills it into LOG_FILE unconditionally; "filtered" (codex) only logs
+  # a privacy-filtered excerpt on failure, via the engine's own
+  # engine_err_filter() hook — see backfill_engine_err() in lib/common.sh.
+  ENGINE_ERR="${ENGINE_OUT}.err"
   REVIEW=""
   HOOK_BUDGET="${REVIEW_HOOK_BUDGET:-595}"
 
@@ -547,8 +561,6 @@ else
       fi
     fi
     engine_exit=0
-    # Snapshot log position before call — used after failure to detect capacity-specific 429
-    log_pos_before=$(wc -c < "$LOG_FILE" 2>/dev/null || echo 0)
 
     # --- Call the sourced engine's invoke hook. agy's invoke may set
     #     _ENGINE_ABORT_RETRY=1 (oversized prompt, ARG_MAX defense) to signal
@@ -562,6 +574,13 @@ else
     if [ "$_ENGINE_ABORT_RETRY" = "1" ]; then
       break
     fi
+
+    # Backfill this round's $ENGINE_ERR into LOG_FILE per the engine's own
+    # $ENGINE_ERR_POLICY (see lib/common.sh) — unconditionally for
+    # "verbatim" engines (success and failure alike), failure-only and
+    # filtered for codex. Deliberately NOT skipped on failure: the capacity
+    # detection right below reads the raw (un-truncated) $ENGINE_ERR.
+    backfill_engine_err "$engine_exit"
 
     engine_extract
     : > "$ENGINE_OUT"
@@ -577,9 +596,16 @@ else
         # Detect capacity-exhausted 429 (MODEL_CAPACITY_EXHAUSTED via cloudcode-pa.googleapis.com).
         # These outages last minutes — the default 2s retry delay is useless;
         # a longer wait gives the server time to recover.
-        # Check only log bytes written during this attempt to avoid matching old entries.
-        if tail -c "+$((log_pos_before + 1))" "$LOG_FILE" 2>/dev/null \
-             | grep -qE "RESOURCE_EXHAUSTED|MODEL_CAPACITY" 2>/dev/null; then
+        # Scan this round's raw $ENGINE_ERR directly — NOT LOG_FILE. This is
+        # the fix for the codex fast-break bug: codex's raw stderr never
+        # reaches LOG_FILE wholesale (privacy filter, see engine_err_filter
+        # in lib/engines/codex.sh), so grepping LOG_FILE only ever caught
+        # this pattern for agy/claude by coincidence — codex's fast-break
+        # depended on the capacity keyword happening to survive the 500-byte
+        # filtered codex-diag excerpt. All three engines are treated
+        # identically here because $ENGINE_ERR always holds this round's
+        # complete, unfiltered stderr regardless of engine.
+        if grep -qE "RESOURCE_EXHAUSTED|MODEL_CAPACITY" "$ENGINE_ERR" 2>/dev/null; then
           _fail_reason="${REVIEW_ENGINE}: capacity exhausted (MODEL_CAPACITY_EXHAUSTED)"
           # Drop any cached conversation_id: the session on agy's side may be
           # invalid/unrecoverable after a capacity outage — don't resume onto it.

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -132,6 +132,18 @@ ENGINE_TMP_DIRS=()
 #     rather than routed through the generic ENGINE_TMP_FILES registry (which
 #     is for engine-PRIVATE resources only, e.g. codex's sandboxed workdir).
 _cleanup() {
+  # Defensive stderr backfill BEFORE reaping temp files: if the hook is
+  # killed (SIGTERM on hook timeout) mid-invoke, $ENGINE_ERR can hold this
+  # round's stderr that never reached the normal in-loop backfill_engine_err
+  # call below (see the retry loop) — that content would otherwise be lost
+  # forever to the `rm -f` on the next line. 143 (128+SIGTERM) is a fixed
+  # literal, not a real exit code: trap context has no way to recover the
+  # actual one, and "the hook got killed mid-round" is itself failure enough
+  # to justify running codex's engine_err_filter() path. Guarded via
+  # `declare -F` because backfill_engine_err may not be defined yet (an
+  # earlier guard can exit before lib/common.sh is even sourced) — the whole
+  # line must never let this trap itself fail.
+  declare -F backfill_engine_err >/dev/null 2>&1 && backfill_engine_err 143 || true
   rm -f "${PROMPT_FILE:-}" "${ENGINE_OUT:-}" "${ENGINE_ERR:-}"
   [ ${#ENGINE_TMP_FILES[@]} -eq 0 ] || rm -f "${ENGINE_TMP_FILES[@]}"
   [ ${#ENGINE_TMP_DIRS[@]}  -eq 0 ] || rmdir "${ENGINE_TMP_DIRS[@]}" 2>/dev/null || true
@@ -575,11 +587,19 @@ else
       break
     fi
 
+    # Capacity-exhaustion detection (used further below) MUST scan the raw
+    # $ENGINE_ERR before backfill_engine_err (next) truncates it (see
+    # lib/common.sh) — capture into a flag now, consumed later instead of
+    # re-grepping a file that will already be empty by then.
+    _capacity_hit=0
+    grep -qE "RESOURCE_EXHAUSTED|MODEL_CAPACITY" "$ENGINE_ERR" 2>/dev/null && _capacity_hit=1
+
     # Backfill this round's $ENGINE_ERR into LOG_FILE per the engine's own
     # $ENGINE_ERR_POLICY (see lib/common.sh) — unconditionally for
     # "verbatim" engines (success and failure alike), failure-only and
-    # filtered for codex. Deliberately NOT skipped on failure: the capacity
-    # detection right below reads the raw (un-truncated) $ENGINE_ERR.
+    # filtered for codex. Also truncates $ENGINE_ERR once backfilled, so a
+    # later defensive re-backfill (_cleanup on hook-kill) is a harmless no-op
+    # in the normal exit path.
     backfill_engine_err "$engine_exit"
 
     engine_extract
@@ -596,16 +616,18 @@ else
         # Detect capacity-exhausted 429 (MODEL_CAPACITY_EXHAUSTED via cloudcode-pa.googleapis.com).
         # These outages last minutes — the default 2s retry delay is useless;
         # a longer wait gives the server time to recover.
-        # Scan this round's raw $ENGINE_ERR directly — NOT LOG_FILE. This is
-        # the fix for the codex fast-break bug: codex's raw stderr never
-        # reaches LOG_FILE wholesale (privacy filter, see engine_err_filter
-        # in lib/engines/codex.sh), so grepping LOG_FILE only ever caught
-        # this pattern for agy/claude by coincidence — codex's fast-break
-        # depended on the capacity keyword happening to survive the 500-byte
-        # filtered codex-diag excerpt. All three engines are treated
-        # identically here because $ENGINE_ERR always holds this round's
-        # complete, unfiltered stderr regardless of engine.
-        if grep -qE "RESOURCE_EXHAUSTED|MODEL_CAPACITY" "$ENGINE_ERR" 2>/dev/null; then
+        # $_capacity_hit was captured above (BEFORE backfill_engine_err ran)
+        # from this round's raw, un-truncated $ENGINE_ERR directly — NOT
+        # LOG_FILE. This is the fix for the codex fast-break bug: codex's raw
+        # stderr never reaches LOG_FILE wholesale (privacy filter, see
+        # engine_err_filter in lib/engines/codex.sh), so grepping LOG_FILE
+        # only ever caught this pattern for agy/claude by coincidence —
+        # codex's fast-break depended on the capacity keyword happening to
+        # survive the 500-byte filtered codex-diag excerpt. All three engines
+        # are treated identically here because $ENGINE_ERR always held this
+        # round's complete, unfiltered stderr regardless of engine (at the
+        # time it was captured, before this same round's backfill truncated it).
+        if [ "$_capacity_hit" = "1" ]; then
           _fail_reason="${REVIEW_ENGINE}: capacity exhausted (MODEL_CAPACITY_EXHAUSTED)"
           # Drop any cached conversation_id: the session on agy's side may be
           # invalid/unrecoverable after a capacity outage — don't resume onto it.

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -3348,9 +3348,80 @@ Sanitized fine."
   [[ "$HOOK_STDERR" == *"REST API fallback succeeded"* ]]
   assert_log_contains "rest-skip=capacity-fast-break engine=codex"
   # Prove the buried capacity text really did NOT survive the privacy filter:
-  # codex-diag's logged excerpt must not contain the capacity marker.
+  # codex-diag's logged excerpt must not contain the capacity marker. This
+  # assertion is only meaningful if the codex-diag line was actually written
+  # — without the `-n` check, a regressed backfill (or a broken filter that
+  # emits nothing) would leave $output empty and the `!= *"..."*` assertion
+  # would pass vacuously, "proving" nothing.
   run grep -F "codex-diag" "${REVIEW_LOG_DIR}/plan-review.log"
+  [ -n "$output" ]
   [[ "$output" != *"RESOURCE_EXHAUSTED"* ]]
+}
+
+# --- Fix (PR #146 review, Major): hook killed mid-invoke must not lose
+# this round's stderr. Pre-fix, _cleanup() only did `rm -f "$ENGINE_ERR"` on
+# every exit path (normal or signal) — a hook-timeout SIGTERM landing while
+# an engine call is in flight discarded that round's raw stderr entirely,
+# with zero trace ever reaching LOG_FILE. That is exactly the diagnostic a
+# maintainer needs most (the round that got killed, not the one that
+# finished). Runs the real hook script as a background process, waits for
+# the mock engine to actually start (ready-file handshake — no fixed sleep
+# guessing), sends SIGTERM to the hook itself (mirroring the framework's
+# 600s hook-timeout kill), and asserts _cleanup's defensive
+# `backfill_engine_err 143` call landed this round's stderr into LOG_FILE
+# before reaping the temp files.
+@test "cleanup: hook killed mid-invoke → this round's stderr still reaches LOG_FILE" {
+  local ready_file="${TEST_TEMP_DIR}/mock-agy-ready"
+  rm -f "$ready_file"
+  # Deliberately NOT the shared create_mock_engine helper: this mock must
+  # touch a ready-file and then block (sleep), which no existing generator
+  # supports. Unquoted heredoc so ${ready_file} interpolates at creation time.
+  cat > "${MOCK_BIN}/agy" << MOCK_EOF
+#!/bin/bash
+touch '${ready_file}'
+echo "MIDKILL-STDERR-MARKER: engine was killed mid-flight" >&2
+sleep 30
+MOCK_EOF
+  chmod +x "${MOCK_BIN}/agy"
+
+  INPUT=$(build_input)
+  local out_file="${TEST_TEMP_DIR}/midkill.stdout"
+  local err_file="${TEST_TEMP_DIR}/midkill.stderr"
+
+  bash "$HOOK_SCRIPT" <<< "$INPUT" > "$out_file" 2> "$err_file" &
+  local hook_pid=$!
+
+  # Handshake: block until the mock has actually started (touched
+  # ready_file) instead of guessing a fixed startup delay — avoids a flake
+  # where SIGTERM arrives before engine_invoke even begins.
+  local waited=0
+  while [ ! -f "$ready_file" ] && [ "$waited" -lt 100 ]; do
+    sleep 0.05
+    waited=$((waited + 1))
+  done
+  [ -f "$ready_file" ]
+
+  # The mock writes its stderr line immediately after touching ready_file,
+  # before its `sleep 30` — a small margin covers the write actually landing
+  # on disk (OS-buffered fd write, not an async race with the ready-file
+  # signal itself).
+  sleep 0.2
+
+  kill -TERM "$hook_pid" 2>/dev/null || true
+
+  # Wait for the hook process (and its trap-driven _cleanup) to actually
+  # exit, bounded so a stuck run fails fast instead of hanging the suite.
+  waited=0
+  while kill -0 "$hook_pid" 2>/dev/null && [ "$waited" -lt 100 ]; do
+    sleep 0.05
+    waited=$((waited + 1))
+  done
+  if kill -0 "$hook_pid" 2>/dev/null; then
+    kill -KILL "$hook_pid" 2>/dev/null || true
+  fi
+  wait "$hook_pid" 2>/dev/null || true
+
+  assert_log_contains "MIDKILL-STDERR-MARKER: engine was killed mid-flight"
 }
 
 # fixture: reset_leaky_env must clear every env var a developer shell might

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -3301,6 +3301,58 @@ Sanitized fine."
   [[ "$HOOK_STDERR" != *"not valid UTF-8"* ]]
 }
 
+# codex: 14. capacity exhausted + REST configured → fast break, same as agy/claude
+# (Issue #144 fix): codex's stderr never reached LOG_FILE wholesale (privacy
+# filter), so the old "grep LOG_FILE for RESOURCE_EXHAUSTED" capacity check only
+# caught codex by coincidence — whatever the 500-byte filtered codex-diag
+# excerpt happened to retain. Capacity detection now scans the raw $ENGINE_ERR
+# directly (see plan-review.sh), so codex behaves identically to agy/claude
+# regardless of what the privacy filter keeps or drops.
+# NOTE: this mock's capacity text is short enough to also survive inside the
+# filtered codex-diag excerpt — it exercises the "lucky" case (raw $ENGINE_ERR
+# and filtered LOG_FILE agree). See the "buried" test below for the case that
+# actually distinguishes the two.
+@test "codex: capacity exhausted + REST configured → fast break + REST used" {
+  export REVIEW_ENGINE="codex"
+  create_capacity_exhausted_codex
+  export REVIEW_API_URL="http://localhost:9999"
+  export REVIEW_API_KEY="test-key"
+  create_mock_curl_sse '<verdict>APPROVE</verdict>\nApproved via REST.'
+  INPUT=$(build_input)
+
+  run_hook
+  assert_ack_approve_json
+  [[ "$HOOK_STDERR" == *"skipping retry (REST fallback available)"* ]]
+  [[ "$HOOK_STDERR" == *"REST API fallback succeeded"* ]]
+  assert_log_contains "rest-skip=capacity-fast-break engine=codex"
+}
+
+# codex: 15. capacity exhausted (buried past the 500-byte privacy-filter
+# window) + REST configured → fast break still fires. Unlike test 14, the
+# capacity text here is truncated away by engine_err_filter()'s `head -c 500`
+# before it reaches LOG_FILE's codex-diag line — so this only passes if
+# capacity detection scans the RAW $ENGINE_ERR directly (the Issue #144 fix).
+# A pre-fix "grep LOG_FILE for RESOURCE_EXHAUSTED" check would find nothing
+# and fall through to the ordinary retry path instead of fast-breaking.
+@test "codex: capacity exhausted buried past privacy-filter window → fast break + REST used" {
+  export REVIEW_ENGINE="codex"
+  create_capacity_exhausted_codex_buried
+  export REVIEW_API_URL="http://localhost:9999"
+  export REVIEW_API_KEY="test-key"
+  create_mock_curl_sse '<verdict>APPROVE</verdict>\nApproved via REST.'
+  INPUT=$(build_input)
+
+  run_hook
+  assert_ack_approve_json
+  [[ "$HOOK_STDERR" == *"skipping retry (REST fallback available)"* ]]
+  [[ "$HOOK_STDERR" == *"REST API fallback succeeded"* ]]
+  assert_log_contains "rest-skip=capacity-fast-break engine=codex"
+  # Prove the buried capacity text really did NOT survive the privacy filter:
+  # codex-diag's logged excerpt must not contain the capacity marker.
+  run grep -F "codex-diag" "${REVIEW_LOG_DIR}/plan-review.log"
+  [[ "$output" != *"RESOURCE_EXHAUSTED"* ]]
+}
+
 # fixture: reset_leaky_env must clear every env var a developer shell might
 # export. Regression guard — the codex vars were missed when the codex engine
 # landed, and with CODEX_MODEL exported the "codex: CODEX_MODEL empty → no -m"

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -3615,3 +3615,92 @@ MOCK_EOF
   [[ "$HOOK_STDOUT" == *"[WARNING]"* ]]
   [[ "$HOOK_STDOUT" == *"prompt asset truncated"* ]]
 }
+
+# --- Engine-lib bootstrap (second bootstrap block: lib/engines/*.sh) ---
+#
+# The first bootstrap block above (lib/common.sh, lib/plan-source.sh,
+# lib/manifest.sh, lib/verdict.sh) went through the `[ -s ]` + `_source_lib`
+# hardening in PR #145. The engine libs (lib/engines/rest.sh + the
+# REVIEW_ENGINE-selected lib, e.g. agy.sh) are sourced in a SECOND, separate
+# bootstrap block further down in the script and had NOT been hardened the
+# same way — REVIEW_ENGINE is unset in these tests, which the case statement
+# resolves to the `*` fallback (agy.sh), so these tests corrupt
+# lib/engines/agy.sh to hit that path.
+#
+# Same REVIEW_DRY_RUN=1 safety-belt rationale as the first bootstrap block:
+# this guard fires and exits before the script ever reaches the
+# engine-invocation section, so dry-run cannot influence these assertions —
+# it only prevents a real engine CLI call if the guard ever regresses.
+
+# bootstrap: engine lib file exists but is empty (zero bytes) — passes the
+# old `[ -f ]` existence check clean, `source` of an empty file "succeeds"
+# (sourcing zero bytes is valid bash, exit 0), and the very next call to a
+# helper the lib was supposed to define (e.g. engine_probe) dies with
+# "command not found" (exit 127), no allow JSON ever printed — silent
+# fail-closed. This is the same gap class PR #145 closed for the first
+# bootstrap block; this test proves the second block (engine libs) is
+# hardened identically.
+@test "bootstrap: empty engine lib file → allow JSON with WARNING" {
+  export REVIEW_DRY_RUN=1
+  setup_script_copy
+  : > "${COPY_SCRIPT_DIR}/lib/engines/agy.sh"
+
+  run_hook_copy
+
+  assert_approve_json
+  [[ "$HOOK_STDOUT" == *"[WARNING]"* ]]
+  [[ "$HOOK_STDOUT" == *"lib file missing"* ]]
+}
+
+# bootstrap: engine lib file EXISTS and is non-empty (passes `[ -s ]`) but has
+# a real bash syntax error — `source` itself fails even though the
+# existence/non-emptiness check does not. Proves the engine-lib bootstrap
+# block routes through `_source_lib` (fail-open on source failure) instead of
+# a bare `source "$LIB_ENGINE_SELECTED"` that would let `set -e` kill the
+# script with no allow JSON ever emitted.
+@test "bootstrap: syntax-broken engine lib file → allow JSON with WARNING (source fails, not missing)" {
+  export REVIEW_DRY_RUN=1
+  setup_script_copy
+  # Unbalanced quote + stray paren: guaranteed bash syntax error, file still
+  # exists and is readable.
+  printf '%s\n' 'this is " not valid bash (' >> "${COPY_SCRIPT_DIR}/lib/engines/agy.sh"
+
+  run_hook_copy
+
+  assert_approve_json
+  [[ "$HOOK_STDOUT" == *"[WARNING]"* ]]
+  [[ "$HOOK_STDOUT" == *"failed to load"* ]]
+}
+
+# bootstrap: engine lib file missing entirely → allow + [WARNING]. The first
+# bootstrap block's missing-lib test (above) only exercises
+# lib/manifest.sh, which lives in the FIRST loop — it never proves the
+# SECOND loop (lib/engines/rest.sh + the selected engine lib) still guards
+# non-existence too, so this is not redundant with it.
+@test "bootstrap: missing engine lib file → allow JSON with WARNING" {
+  export REVIEW_DRY_RUN=1
+  setup_script_copy
+  rm -f "${COPY_SCRIPT_DIR}/lib/engines/agy.sh"
+
+  run_hook_copy
+
+  assert_approve_json
+  [[ "$HOOK_STDOUT" == *"[WARNING]"* ]]
+  [[ "$HOOK_STDOUT" == *"lib file missing"* ]]
+}
+
+# bootstrap: rest.sh (the OTHER lib in the engine-lib loop, sourced
+# unconditionally regardless of REVIEW_ENGINE) empty → allow + [WARNING].
+# Covers the loop iterating over $LIB_REST specifically, not just the
+# REVIEW_ENGINE-selected lib.
+@test "bootstrap: empty rest.sh lib file → allow JSON with WARNING" {
+  export REVIEW_DRY_RUN=1
+  setup_script_copy
+  : > "${COPY_SCRIPT_DIR}/lib/engines/rest.sh"
+
+  run_hook_copy
+
+  assert_approve_json
+  [[ "$HOOK_STDOUT" == *"[WARNING]"* ]]
+  [[ "$HOOK_STDOUT" == *"lib file missing"* ]]
+}

--- a/plugins/plan-review/tests/test_helper/common-setup.bash
+++ b/plugins/plan-review/tests/test_helper/common-setup.bash
@@ -374,6 +374,93 @@ MOCK_EOF
   chmod +x "${MOCK_BIN}/codex"
 }
 
+# create_capacity_exhausted_codex
+#   Same stderr shape as create_failing_codex (banner + verbatim stdin echo),
+#   but the tail carries RESOURCE_EXHAUSTED instead of a generic error —
+#   reproduces a real capacity-exhausted codex failure. Exits 1, never
+#   writes the -o file.
+#   NOTE (Issue #144 postmortem): this generator reproduces the "lucky" side
+#   of the privacy filter — the capacity text is short enough that it still
+#   survives inside the filtered codex-diag excerpt (`head -c 500`), so a
+#   test built on it cannot distinguish "scans raw $ENGINE_ERR" from "scans
+#   the filtered LOG_FILE line" (both see the text here). A counterfactual
+#   run of this exact mock against the pre-fix commit still PASSES, proving
+#   it is not a real regression guard on its own. Kept for coverage of the
+#   lucky case (real codex failures are sometimes this short); paired with
+#   create_capacity_exhausted_codex_buried below for the unlucky case that
+#   actually exercises the fix.
+create_capacity_exhausted_codex() {
+  local args_file="${MOCK_BIN}/../.agy-args-codex"
+  cat > "${MOCK_BIN}/codex" << MOCK_EOF
+#!/bin/bash
+printf '%s\n' "\$*" > '${args_file}'
+{
+  echo "codex-cli 0.0.0-mock"
+  echo "--------"
+  echo "workdir: /tmp/mock"
+  echo "model: mock-model"
+  echo "provider: mock"
+  echo "approval: never"
+  echo "sandbox: read-only"
+  echo "reasoning effort: mock"
+  echo "reasoning summaries: mock"
+  echo "session: mock-session"
+  echo "--------"
+  echo "user"
+  cat
+  echo ""
+  echo "ERROR: RESOURCE_EXHAUSTED: model capacity exceeded"
+} >&2
+exit 1
+MOCK_EOF
+  chmod +x "${MOCK_BIN}/codex"
+}
+
+# create_capacity_exhausted_codex_buried
+#   Same shape as create_capacity_exhausted_codex, but inserts ~800 bytes of
+#   diagnostic noise lines between the echoed prompt and the RESOURCE_EXHAUSTED
+#   line. engine_err_filter()'s final `head -c 500` truncates the filtered
+#   excerpt BEFORE it reaches the capacity text, so codex-diag in LOG_FILE
+#   never contains "RESOURCE_EXHAUSTED" — only the raw, unfiltered $ENGINE_ERR
+#   does. This is the "unlucky" side real codex failures can also produce
+#   (verbose diagnostic preambles before the actual error line), and it is the
+#   shape that actually falsifies "capacity detection greps LOG_FILE" (the
+#   pre-fix behavior) while passing "capacity detection greps raw $ENGINE_ERR"
+#   (the fix). The noise line's text is a synthetic placeholder that cannot
+#   collide byte-for-byte with any line of the real prompt (CODEX_PROMPT_FILE),
+#   so grep -Fvxf never strips it out before the byte-count truncation applies.
+create_capacity_exhausted_codex_buried() {
+  local args_file="${MOCK_BIN}/../.agy-args-codex"
+  cat > "${MOCK_BIN}/codex" << MOCK_EOF
+#!/bin/bash
+printf '%s\n' "\$*" > '${args_file}'
+{
+  echo "codex-cli 0.0.0-mock"
+  echo "--------"
+  echo "workdir: /tmp/mock"
+  echo "model: mock-model"
+  echo "provider: mock"
+  echo "approval: never"
+  echo "sandbox: read-only"
+  echo "reasoning effort: mock"
+  echo "reasoning summaries: mock"
+  echo "session: mock-session"
+  echo "--------"
+  echo "user"
+  cat
+  echo ""
+  i=0
+  while [ "\$i" -lt 12 ]; do
+    echo "diag-noise-placeholder-\${i}-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+    i=\$((i + 1))
+  done
+  echo "ERROR: RESOURCE_EXHAUSTED: model capacity exceeded"
+} >&2
+exit 1
+MOCK_EOF
+  chmod +x "${MOCK_BIN}/codex"
+}
+
 # create_mock_curl <response_body> [http_status]
 #   Creates an executable mock curl at MOCK_BIN/curl that:
 #   - writes <response_body> to the file specified by -o flag (curl -o behavior)


### PR DESCRIPTION
> 基于 #145（阶段一）。合并顺序：先 #145，本 PR 的 base 会自动切到 main。

## 背景

阶段一把提示词与四个 lib 抽出，主脚本降到 1007 行。但 Issue #112 真正要解决的问题还在：`REVIEW_ENGINE` 的分支判断散落在 **9 处**，加第三个引擎 codex 时改了其中 5 处。

本 PR 按**接口**切分引擎层，主脚本 **1007 → 693 行**。

## 引擎三钩子

`lib/engines/{agy,claude,codex}.sh` 各实现：

| 钩子 | 调用时机 | 职责 |
|---|---|---|
| `engine_probe` | 重试循环外，一次 | CLI 存在性 + model 解析 + 一次性临时资源准备 |
| `engine_invoke` | 每轮重试 | 调 CLI，原始输出写 `$ENGINE_OUT`，设 `engine_exit` |
| `engine_extract` | 每轮重试 | 读 `$ENGINE_OUT` 设 `REVIEW` |

新增引擎 = **加 1 个文件 + 在白名单 `case` 加 1 行**。重试循环、时间预算守卫、capacity 检测、degrade 状态机全部留编排器——引擎只管"怎么调"，不管"什么时候调、失败了怎么办"。

`REVIEW_ENGINE` 来自环境变量，所以引擎选择用白名单 `case` 而非 `source "$LIB/$REVIEW_ENGINE.sh"`——后者是路径注入面。

## REST 为什么不实现三钩子

刻意的，不是遗漏。REST 是降级通道而非第四个一等引擎：它在 CLI 重试**耗尽之后**才触发，必然与某个已 source 的引擎共存于同一进程。若它也叫 `engine_invoke`，降级时就得动态 re-source 去覆盖内存中的同名函数——覆盖时机、覆盖失败、重试回退到哪个实现全是隐式的，函数影子化是运行期最难排查的一类 bug。改用 `rest_` 前缀 + 启动时无条件 source，零名字冲突、零动态覆盖、零时序依赖。

## 顺带修掉一个跨版本地雷

agy 的 ARG_MAX 防御原先直接 `break`。搬进函数体后行为随 bash 版本分叉，实测：

```
bash 3.2: break 穿透到调用者的 for 循环 → 循环在第 1 轮就断
bash 5.3: 报 "only meaningful in a for/while/until loop" 后继续下一轮
```

照搬会在生产 bash 3.2 上"侥幸正确"、在 5.3 上静默走错。改用显式 `_ENGINE_ABORT_RETRY` 标志由编排器读取后自行 `break`。

## 行为变更：capacity fast-break（v1.4.0 → 1.4.1）

Issue #144 评审记录的缺陷：capacity fast-break 靠 grep `LOG_FILE` 增量字节找 `RESOURCE_EXHAUSTED`，但 codex 的 stderr 会回显完整 prompt（全局 + 项目 CLAUDE.md + 对话 + plan），出于隐私只有过滤后 500 字节进 `LOG_FILE`。该机制对 codex 是否生效，取决于错误文案是否恰好落在那 500 字节内——**运气，不是设计**。

修法是把信道所有权收归编排器：`ENGINE_ERR` 对所有引擎无条件分配，回填策略由引擎自陈 `ENGINE_ERR_POLICY`：

- `verbatim`（agy/claude）：**不分成败**无条件 append 进 `LOG_FILE`。现状 `2>>` 就是不分成败落盘的，只在失败时回填会静默吞掉成功路径的 CLI 警告（API 废弃、内部重试、限流临界）——那是行为倒退。
- `filtered`（codex）：隐私过滤链一字未动，仍只在失败时写 `codex-diag`，原始 stderr 绝不整体落盘。

capacity 检测改扫原始 `ENGINE_ERR`，三引擎一视同仁。

## 测试

**205 passing**（原 203 + 2），`bash 5.3` 与 `/bin/bash 3.2` 双版本全绿。

新增两条互补用例：**幸运侧**（capacity 文案够短，过滤后仍在窗口内）与**不幸侧**（被噪声挤出 `head -c 500` 窗口，过滤后不进 `LOG_FILE`）。

不幸侧那条经**反事实验证**——搬到修复前的 commit 上跑确实 FAIL。初版只有幸运侧用例，在修复前后都通过，是空门禁，已修正。

Closes #112. Refs #144.