### PR TITLE
feat(plan-review): codex 轮间记忆 + 连续 REJECT 安全阀 + 收敛性修复 (v1.5.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "plan-review",
       "description": "Adversarial plan review via cross-model consultation (agy/Claude/Codex)",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/plan-review/.claude-plugin/plugin.json
+++ b/plugins/plan-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-review",
   "description": "Adversarial plan review via cross-model consultation (agy/Claude/Codex)",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "author": {
     "name": "woodragon"
   }

--- a/plugins/plan-review/README.md
+++ b/plugins/plan-review/README.md
@@ -75,6 +75,11 @@ names.
 | `REVIEW_DRY_RUN` | `0` | Set `1` to skip engine call (synthetic APPROVE) |
 | `REVIEW_MAX_ROUNDS` | `3` | Max non-Critical consultation rounds (CONCERNS accumulation) before escalation |
 | `REVIEW_MAX_TOTAL_ROUNDS` | `20` | Absolute global ceiling (including REJECT rounds); hard-blocks once reached |
+| `REVIEW_MAX_CONSECUTIVE_REJECTS` | `0` | Opt-in third valve: K consecutive REJECT rounds → allow through for user arbitration (mirrors the non-Critical valve). `0` disables it, preserving the historical contract that REJECT rounds are unlimited up to the global hard stop. Recommended when the review engine is high-recall (e.g. codex on a large reasoning model): field data shows such engines can emit a fresh Critical every round, making the tombstone deny the only built-in exit |
+| `REVIEW_HISTORY_DISABLED` | `0` | Set `1` to disable prior-round review-thread injection for memoryless engines (currently codex; see "Round Memory" below) |
+| `REVIEW_REPO_ACCESS` | `0` | codex engine only. Set `1` to run the reviewer with `-C <project cwd>` (still `-s read-only`) instead of an empty temp dir, letting it ground findings — and verify the plan author's factual rebuttals — against real code. Trade-offs: repo content becomes readable by the engine's provider, and rounds get slower |
+| `REVIEW_GLOBAL_MD_LIMIT` | `3000` | Bytes of `~/.claude/CLAUDE.md` included in the review prompt |
+| `REVIEW_PROJECT_MD_LIMIT` | `8000` | Bytes of `$CWD/CLAUDE.md` included in the review prompt. The fixed 8KB cut has been observed to slice off load-bearing environment facts mid-file; long-context engines can afford much larger values |
 | `REVIEW_ENGINE_TIMEOUT` | `595` | Engine call timeout in seconds (requires `timeout`/`gtimeout` on `PATH`) |
 | `REVIEW_API_URL` | _(empty)_ | REST API fallback base URL (OpenAI-compatible), used when the CLI path fails |
 | `REVIEW_API_KEY` | _(empty)_ | REST API fallback bearer token |
@@ -139,7 +144,7 @@ When `REVIEW_ENGINE=claude`, the script spawns `claude -p` with triple isolation
 When `REVIEW_ENGINE=codex`, the script spawns `codex exec` with a parallel set of isolation flags:
 
 1. **`-s read-only`** — sandbox policy; the reviewer process cannot write to disk
-2. **`-C <fresh empty temp dir>`** — the working root is a throwaway empty directory, not the user's project. This relocates the working root; on its own it does not stop a tool from reaching paths outside that directory (see the tool-surface caveat below)
+2. **`-C <fresh empty temp dir>`** — the working root is a throwaway empty directory, not the user's project. This relocates the working root; on its own it does not stop a tool from reaching paths outside that directory (see the tool-surface caveat below). With `REVIEW_REPO_ACCESS=1` the working root becomes the project cwd instead (sandbox stays read-only) — an explicit opt-in trading isolation for grounded review
 3. **`--ephemeral`** — no session files persisted to disk
 4. **`--skip-git-repo-check`** — required because the isolated temp dir is not a git repo
 
@@ -160,6 +165,17 @@ This lowers 429 frequency and quota consumption on multi-round negotiations. The
 
 **agy invocation contract**: since v1.2.0 the agy CLI is always called with `--output-format json`, and the review body is text-sliced out of the (not-well-formed) JSON `response` field. This depends on agy's envelope carrying `conversation_id` and `response` keys. If a future agy build changes that envelope shape, extraction fails closed (empty review → retry / REST fallback), so a shape change degrades gracefully rather than mis-parsing — but it does mean the agy path is coupled to this envelope. The `claude` engine path and the REST fallback are unchanged. With no env config, the review decision logic behaves as before; the observable deltas are the JSON invocation, multi-round session reuse, and the shorter degrade cooldown (600s).
 
+## Round Memory (codex, v1.5.0)
+
+`codex exec --ephemeral` has no server-side conversation reuse: every consultation round is a fresh process that re-reads the whole plan from scratch. For a high-recall reviewer this breaks convergence structurally — each round it re-discovers a *new* batch of findings on text it already reviewed (and implicitly accepted) last round, so the plan author can never satisfy it. Field data from the first production run of the codex engine: 17 rounds (11 REJECT / 6 CONCERNS), zero APPROVE, exit only via the safety valve, ~2h40m wall clock.
+
+The fix mirrors agy's session reuse at the prompt layer. Engines declare `ENGINE_WANTS_HISTORY=1` at source time (currently only `codex.sh`); for those engines the orchestrator:
+
+- **Records** every CONCERNS/REJECT round's review text (capped 6KB/round) into a session-scoped thread file.
+- **Injects** the accumulated thread into the next round's prompt under `## Prior Review Thread`, with delta-review rules: re-verify prior Criticals first; a factual rebuttal the reviewer cannot verify is re-emitted as `[Major] [UNVERIFIED-REBUTTAL]` (CONCERNS — surfaces to the human) instead of staying Critical or being silently dropped; new non-Critical findings on unchanged text are waived; no new Critical + prior Criticals resolved → must not REJECT.
+
+The thread lives and dies with the review cycle (cleared on approval, escalation, plan-change-after-approve, no-plan fail-closed, and both valves). Engine failures do *not* clear it — a failed CLI call invalidates agy's resume handle, not the thread's content. `REVIEW_HISTORY_DISABLED=1` turns the whole mechanism off. agy does not participate (its `--conversation` resume already carries memory); the claude engine is deliberately left unchanged.
+
 ## Fault Tolerance
 
 - **jq missing** → allow (can't parse input)
@@ -173,9 +189,11 @@ This lowers 429 frequency and quota consumption on multi-round negotiations. The
 
 This plugin sends the following data to the configured review engine — the Gemini API, the Anthropic API, or, when `REVIEW_ENGINE=codex`, whichever provider the user's `~/.codex/config.toml` selects:
 
-- **Global CLAUDE.md** — first 3KB of `~/.claude/CLAUDE.md`
-- **Project CLAUDE.md** — first 8KB of `$CWD/CLAUDE.md`
+- **Global CLAUDE.md** — first `REVIEW_GLOBAL_MD_LIMIT` bytes (default 3KB) of `~/.claude/CLAUDE.md`
+- **Project CLAUDE.md** — first `REVIEW_PROJECT_MD_LIMIT` bytes (default 8KB) of `$CWD/CLAUDE.md`
 - **Recent conversation** — last 3 user messages from the session transcript
 - **Plan content** — the full implementation plan under review
+- **Prior review rounds** — for memoryless engines (codex), the engine's own previous review feedback for this cycle (see "Round Memory")
+- **Repository contents** — only with `REVIEW_REPO_ACCESS=1` (codex): the reviewer runs read-only inside the project working directory and may read any file in it
 
 This context is necessary for meaningful adversarial review. If your CLAUDE.md or conversations contain sensitive information (internal hostnames, credentials, business logic), be aware that this data will be sent to the external API.

--- a/plugins/plan-review/scripts/assets/review-system-prompt.md
+++ b/plugins/plan-review/scripts/assets/review-system-prompt.md
@@ -82,9 +82,13 @@ Keep your response under 3000 characters.
      - **Pure mis-tiering / fragmentation** — a sonnet-grade task already inside
        an agent, or implementation steps sharing one file set split across
        multiple agents that each reload the same context → [Minor].
-   - Manifest format: Agent steps require both agent_type + model (full name, no
-     abbreviation). Main-context steps use `-`. Missing manifest when dispatch
-     keywords are present = [Major]. Agent step missing model = [Critical].
+   - Manifest format: Agent steps require both agent_type + model. The model
+     column holds a tier name — `sonnet` / `opus` / `haiku` — and these tier
+     names ARE the complete, canonical values in the target environment (Scope
+     Boundary applies): never flag them as "abbreviations" and never demand
+     versioned model identifiers in their place. Main-context steps use `-`.
+     Missing manifest when dispatch keywords are present = [Major]. Agent step
+     missing model = [Critical].
 8. **Reuse over reinvention** — Does the plan propose building something that already exists in the project dependencies, framework, or standard library? Custom implementations require explicit justification (e.g., "framework X lacks feature Y" with concrete evidence). Without strong justification, prefer existing solutions. This is a [Major] issue.
 
 ## Review Discipline

--- a/plugins/plan-review/scripts/lib/engines/codex.sh
+++ b/plugins/plan-review/scripts/lib/engines/codex.sh
@@ -10,6 +10,20 @@
 #
 # bash 3.2 compatible: no associative arrays, no ${var^^}, no &>>.
 
+# --- Engine capability declaration (top-level, evaluated at SOURCE time —
+#     the orchestrator reads it while composing PROMPT_FILE, which happens
+#     BEFORE engine_probe() runs, so a declaration inside a hook function
+#     would come too late): codex has no server-side conversation reuse —
+#     every round is a fresh `codex exec --ephemeral` that re-reads the whole
+#     plan from scratch. Without memory, a high-recall reviewer re-discovers
+#     a new batch of findings on UNCHANGED text every round and the
+#     consultation cannot converge. Declaring this asks the orchestrator to
+#     inject the accumulated prior-round review thread into the prompt so
+#     each round becomes a delta review. agy deliberately does NOT declare it
+#     (it already resumes its own server-side conversation via
+#     --conversation); claude is left unchanged for now (no memory channel).
+ENGINE_WANTS_HISTORY=1
+
 # --- One-time setup (called once, outside the retry loop): CLI existence
 #     check + model resolution + sandboxed workdir/merged-prompt/UTF-8
 #     sanitation prep. Returns 0 if usable, 1 (with ENGINE_PROBE_REASON set)
@@ -22,13 +36,28 @@ engine_probe() {
   # Empty CODEX_MODEL means inherit codex's own ~/.codex/config.toml default.
   CODEX_MODEL="${CODEX_MODEL:-}"
 
-  # codex-only temp resources: a sandboxed workdir (-C target, deliberately NOT
-  # the project cwd — codex runs read-only but there's no reason to hand it the
-  # real tree) and a merged prompt file (system instructions + PROMPT_FILE's
-  # dynamic content — kept SEPARATE from PROMPT_FILE itself so the REST
-  # fallback's --rawfile read of PROMPT_FILE doesn't double-send the system
-  # instructions). Registered into the generic cleanup arrays so the caller's
-  # trap reaps them without knowing their codex-private names.
+  # codex-only temp resources: a sandboxed workdir (-C target — by default a
+  # fresh empty temp dir, deliberately NOT the project cwd: codex runs
+  # read-only but there's no reason to hand it the real tree) and a merged
+  # prompt file (system instructions + PROMPT_FILE's dynamic content — kept
+  # SEPARATE from PROMPT_FILE itself so the REST fallback's --rawfile read of
+  # PROMPT_FILE doesn't double-send the system instructions). The temp
+  # workdir is registered into the generic cleanup arrays so the caller's
+  # trap reaps it without knowing its codex-private name.
+  #
+  # REVIEW_REPO_ACCESS=1 (opt-in, default off) flips the workdir to the
+  # project cwd instead: the reviewer can then ground its findings — and
+  # verify the plan author's factual rebuttals — against the actual code,
+  # still under `-s read-only`. Trade-offs the user accepts by opting in:
+  # repo content becomes reachable by the engine's provider, and rounds get
+  # slower as the reviewer reads files. The real cwd must NEVER be added to
+  # ENGINE_TMP_DIRS — the cleanup trap rmdir's every entry.
+  if [ "${REVIEW_REPO_ACCESS:-0}" = "1" ] && [ -n "${CWD:-}" ] && [ -d "${CWD:-}" ]; then
+    CODEX_WORKDIR="$CWD"
+  else
+    CODEX_WORKDIR=$(mktemp -d)
+    ENGINE_TMP_DIRS+=("$CODEX_WORKDIR")
+  fi
   # NOTE: $ENGINE_ERR is NOT declared here — it is a shared orchestrator-owned
   # contract channel (plan-review.sh sets ENGINE_ERR="${ENGINE_OUT}.err" for
   # every engine, and _cleanup hardcodes it alongside PROMPT_FILE/ENGINE_OUT),
@@ -36,8 +65,6 @@ engine_probe() {
   # below (ENGINE_ERR_POLICY) because codex echoes the FULL prompt to stderr
   # before its real diagnostics — see engine_err_filter() further down,
   # which must never let that raw content reach LOG_FILE wholesale.
-  CODEX_WORKDIR=$(mktemp -d)
-  ENGINE_TMP_DIRS+=("$CODEX_WORKDIR")
   CODEX_PROMPT_FILE=$(mktemp)
   ENGINE_TMP_FILES+=("$CODEX_PROMPT_FILE" "${CODEX_PROMPT_FILE}.u8")
   ENGINE_ERR_POLICY="filtered"

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -33,6 +33,11 @@
 #   REVIEW_API_URL=<url>         — REST API fallback base URL (OpenAI-compatible, e.g. https://proxy.example.com)
 #   REVIEW_API_KEY=<key>         — REST API fallback auth key (Bearer token)
 #   REVIEW_ENGINE_DEGRADE_TTL=N  — seconds Gemini stays in degraded state after capacity exhaustion (default: 600)
+#   REVIEW_MAX_CONSECUTIVE_REJECTS=N — K consecutive REJECT rounds → allow (escalate to user); 0 = disabled (default)
+#   REVIEW_HISTORY_DISABLED=1    — disable prior-round review-thread injection for memoryless engines (codex)
+#   REVIEW_REPO_ACCESS=1         — codex engine only: run the reviewer in the project cwd (read-only) instead of an empty temp dir
+#   REVIEW_GLOBAL_MD_LIMIT=N     — bytes of global CLAUDE.md sent to the engine (default: 3000)
+#   REVIEW_PROJECT_MD_LIMIT=N    — bytes of project CLAUDE.md sent to the engine (default: 8000)
 set -euo pipefail
 
 INPUT=$(cat)
@@ -166,6 +171,13 @@ REVIEW_DRY_RUN="${REVIEW_DRY_RUN:-${GEMINI_DRY_RUN:-0}}"
 REVIEW_MAX_ROUNDS="${REVIEW_MAX_ROUNDS:-${GEMINI_MAX_REVIEWS:-3}}"
 REVIEW_MAX_TOTAL_ROUNDS="${REVIEW_MAX_TOTAL_ROUNDS:-20}"
 REVIEW_ENGINE="${REVIEW_ENGINE:-gemini}"
+# Consecutive-REJECT valve threshold: 0 (default) = disabled, preserving the
+# historical contract that REJECT rounds are unlimited up to the global valve.
+# Sanitized like the counter fields — a garbage value must disable the valve,
+# not kill the hook via a non-numeric [ -ge ] comparison under set -e.
+REVIEW_MAX_CONSECUTIVE_REJECTS="${REVIEW_MAX_CONSECUTIVE_REJECTS:-0}"
+[[ "$REVIEW_MAX_CONSECUTIVE_REJECTS" =~ ^[0-9]+$ ]] || REVIEW_MAX_CONSECUTIVE_REJECTS=0
+REVIEW_HISTORY_DISABLED="${REVIEW_HISTORY_DISABLED:-0}"
 
 # --- Engine selection: whitelist case, never string-concat into a source
 #     path (REVIEW_ENGINE is externally controlled via env var — string
@@ -254,14 +266,25 @@ DEGRADE_FILE="$COUNTER_DIR/.gemini-degraded"
 # instead of being resent every round. Lifetime = one review cycle (see cleanup
 # points at the no-plan fail-closed / ack-round-approved / non-critical-valve exits).
 CONV_FILE="$COUNTER_DIR/.conversation-${SESSION_ID}"
+# Prior-round review thread (session-scoped) — accumulated review feedback for
+# engines that declare ENGINE_WANTS_HISTORY=1 (memoryless CLIs, currently
+# codex). Injected into the prompt each round so the engine performs a delta
+# review instead of a from-scratch re-review. Same lifetime as CONV_FILE: one
+# review cycle (cleaned at every CONV_FILE cleanup point EXCEPT engine-failure
+# paths — a failed CLI call invalidates agy's resume handle but not the
+# thread's content).
+HISTORY_FILE="$COUNTER_DIR/.review-history-${SESSION_ID}"
 
-# --- Read counter (new format ATTEMPT:TOTAL, backward-compat with old single-number) ---
-IFS=: read -r ATTEMPT TOTAL_ROUNDS <<< "$(cat "$COUNTER_FILE" 2>/dev/null || echo "0:0")"
+# --- Read counter (format ATTEMPT:TOTAL:CONSEC_REJECTS, backward-compat with
+#     the older ATTEMPT:TOTAL and the original single-number formats) ---
+IFS=: read -r ATTEMPT TOTAL_ROUNDS CONSEC_REJECTS <<< "$(cat "$COUNTER_FILE" 2>/dev/null || echo "0:0:0")"
 # Three-layer defense: empty fallback → old format compat → dirty data sanitization
 ATTEMPT=${ATTEMPT:-0}
 TOTAL_ROUNDS=${TOTAL_ROUNDS:-$ATTEMPT}  # old format "3" → ATTEMPT=3, TOTAL_ROUNDS="" → 3
+CONSEC_REJECTS=${CONSEC_REJECTS:-0}     # two-field format → no reject streak recorded → 0
 [[ "$ATTEMPT" =~ ^[0-9]+$ ]] || ATTEMPT=0
 [[ "$TOTAL_ROUNDS" =~ ^[0-9]+$ ]] || TOTAL_ROUNDS=0
+[[ "$CONSEC_REJECTS" =~ ^[0-9]+$ ]] || CONSEC_REJECTS=0
 
 # --- 1. Extract plan content (must precede ack-round guard for hash comparison) ---
 PLAN=$(echo "$INPUT" | jq -r '.tool_input.plan // ""')
@@ -299,7 +322,7 @@ if [ -z "$PLAN" ] || [ "$PLAN" = "null" ]; then
   TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")
   CWD_VAL=$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null || echo "")
   log_decision "decision=deny reason=no-plan-content-fail-closed resolve=${RESOLVE_REASON:-none} resolvePath=${RESOLVE_PATH:-empty} planFilePath=${PLAN_FILE_PATH:-empty} top_keys=${TOP_KEYS} tool_input_keys=${TI_KEYS} transcript_path=${TRANSCRIPT_PATH:-empty} cwd=${CWD_VAL:-empty}"
-  rm -f "$APPROVE_MARKER" "$COUNTER_FILE" "${CONV_FILE:-}"
+  rm -f "$APPROVE_MARKER" "$COUNTER_FILE" "${CONV_FILE:-}" "${HISTORY_FILE:-}"
   # Error message routed by the resolver's RESOLVE_REASON (see
   # lib/plan-source.sh: plan_source_error_reason) — sets $REASON directly.
   plan_source_error_reason
@@ -316,15 +339,16 @@ if [ -f "$APPROVE_MARKER" ]; then
   if [ -z "$APPROVED_HASH" ] || [ "$CURRENT_HASH" = "$APPROVED_HASH" ]; then
     # True ack-round: plan unchanged (empty marker = legacy format, unconditional allow)
     log_decision "decision=allow reason=ack-round-approved"
-    rm -f "$APPROVE_MARKER" "$COUNTER_FILE" "${CONV_FILE:-}"
+    rm -f "$APPROVE_MARKER" "$COUNTER_FILE" "${CONV_FILE:-}" "${HISTORY_FILE:-}"
     allow_with_reason "Red Team 审阅已通过，plan 放行。"
   else
     # Plan was modified after approve: marker invalid, delete and fall through to re-review.
-    # Also drop the conversation handle — the session history is about the OLD
-    # plan; reusing it to review a DIFFERENT plan would resume stale context.
-    # The re-review must start a fresh first round for the new plan.
+    # Also drop the conversation handle AND the review thread — both hold
+    # history about the OLD plan; resuming either against a DIFFERENT plan
+    # would feed the engine stale context. The re-review must start a fresh
+    # first round for the new plan.
     log_decision "decision=review-again reason=plan-changed-after-approve conv-cleared"
-    rm -f "$APPROVE_MARKER" "${CONV_FILE:-}"
+    rm -f "$APPROVE_MARKER" "${CONV_FILE:-}" "${HISTORY_FILE:-}"
     # Fall through to full review pipeline
   fi
 fi
@@ -334,8 +358,9 @@ fi
 if [ "$TOTAL_ROUNDS" -ge "$REVIEW_MAX_TOTAL_ROUNDS" ]; then
   log_decision "decision=deny reason=global-safety-valve total=$TOTAL_ROUNDS"
   # Keep the COUNTER_FILE tombstone, but the review cycle is over — no further
-  # engine call will happen, so drop the session ref to avoid an orphan CONV_FILE.
-  rm -f "${CONV_FILE:-}"
+  # engine call will happen, so drop the session refs to avoid orphan
+  # CONV_FILE / HISTORY_FILE.
+  rm -f "${CONV_FILE:-}" "${HISTORY_FILE:-}"
   BLOCK_MSG="## Red Team Review — HARD STOP
 
 审阅已达全局上限（${TOTAL_ROUNDS}/${REVIEW_MAX_TOTAL_ROUNDS}），仍存在未解决的审阅意见。
@@ -350,7 +375,7 @@ fi
 # --- Non-Critical safety valve: CONCERNS rounds exhausted → allow (escalate to user) ---
 if [ "$ATTEMPT" -ge "$REVIEW_MAX_ROUNDS" ]; then
   log_decision "decision=allow reason=non-critical-safety-valve round=$ATTEMPT total=$TOTAL_ROUNDS"
-  rm -f "$COUNTER_FILE" "${CONV_FILE:-}"
+  rm -f "$COUNTER_FILE" "${CONV_FILE:-}" "${HISTORY_FILE:-}"
   VALVE_MSG="## Red Team Review — ${REVIEW_ENGINE} — ESCALATED
 
 非 Critical 磋商已达上限（${ATTEMPT}/${REVIEW_MAX_ROUNDS}），未能达成一致。Plan 直接呈现给用户做最终裁决。"
@@ -361,13 +386,35 @@ EOF
   exit 0
 fi
 
+# --- Consecutive-REJECT safety valve (opt-in, default off): K REJECT rounds
+#     in a row → allow (escalate to user), mirroring the non-Critical valve
+#     above. Rationale: REJECT rounds don't consume ATTEMPT and reset it to 0,
+#     so with a high-recall engine that surfaces a fresh Critical every round
+#     the ONLY built-in exit is the global valve's tombstone deny at
+#     REVIEW_MAX_TOTAL_ROUNDS (observed in the field: 17 rounds, 11 REJECTs).
+#     This valve provides a user-arbitration exit before that hard stop.
+#     Default 0 keeps the historical contract (unlimited REJECTs) intact.
+if [ "$REVIEW_MAX_CONSECUTIVE_REJECTS" -gt 0 ] && [ "$CONSEC_REJECTS" -ge "$REVIEW_MAX_CONSECUTIVE_REJECTS" ]; then
+  log_decision "decision=allow reason=consecutive-reject-valve consec=$CONSEC_REJECTS total=$TOTAL_ROUNDS"
+  rm -f "$COUNTER_FILE" "${CONV_FILE:-}" "${HISTORY_FILE:-}"
+  CREJ_MSG="## Red Team Review — ${REVIEW_ENGINE} — ESCALATED
+
+连续 REJECT 已达上限（${CONSEC_REJECTS}/${REVIEW_MAX_CONSECUTIVE_REJECTS}），审阅未能收敛。Plan 直接呈现给用户做最终裁决。
+向用户汇报时，必须如实同步历轮仍未解决的 Critical 意见，不得只展示 plan。"
+  CREJ_JSON=$(printf '%s' "$CREJ_MSG" | jq -Rs .)
+  cat << EOF
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":${CREJ_JSON}}}
+EOF
+  exit 0
+fi
+
 # --- Pre-flight manifest check (AFTER non-critical valve, not before) ---
 # Format correction, NOT negotiation round: increments TOTAL_ROUNDS only.
 # ATTEMPT stays frozen — pre-flight denies do not count toward MAX_ROUNDS.
 # Global safety valve (TOTAL_ROUNDS >= 20) still protects against infinite loops.
 if needs_manifest "$PLAN" && ! has_manifest "$PLAN"; then
   TOTAL_ROUNDS=$((TOTAL_ROUNDS + 1))
-  echo "${ATTEMPT:-0}:${TOTAL_ROUNDS}" > "$COUNTER_FILE"
+  echo "${ATTEMPT:-0}:${TOTAL_ROUNDS}:${CONSEC_REJECTS:-0}" > "$COUNTER_FILE"
   log_decision "decision=deny reason=missing-manifest"
   MANIFEST_MSG="## Red Team Pre-flight — MISSING DISPATCH MANIFEST
 
@@ -386,7 +433,7 @@ fi
 # Fires when manifest is present but declares zero real agent steps.
 if needs_manifest "$PLAN" && has_manifest "$PLAN" && ! manifest_has_real_agent "$PLAN"; then
   TOTAL_ROUNDS=$((TOTAL_ROUNDS + 1))
-  echo "${ATTEMPT:-0}:${TOTAL_ROUNDS}" > "$COUNTER_FILE"
+  echo "${ATTEMPT:-0}:${TOTAL_ROUNDS}:${CONSEC_REJECTS:-0}" > "$COUNTER_FILE"
   log_decision "decision=deny reason=degenerate-manifest"
   DEGEN_MSG="## Red Team Pre-flight — DEGENERATE DISPATCH MANIFEST
 
@@ -405,11 +452,23 @@ fi
 # --- 2. Collect project context ---
 CWD=$(echo "$INPUT" | jq -r '.cwd // "."')
 
+# Byte limits are env-tunable (defaults preserve historical behavior): the
+# fixed 8000-byte project cut has been observed to slice off load-bearing
+# facts mid-file (e.g. an environment constraint the reviewer needed to catch
+# a real defect). Long-context engines can afford far larger limits — raise
+# per-user via env rather than globally. Non-numeric values fall back to the
+# defaults: `head -c garbage` exits non-zero and, under set -e, would kill
+# the hook before it emits its decision JSON.
+REVIEW_GLOBAL_MD_LIMIT="${REVIEW_GLOBAL_MD_LIMIT:-3000}"
+[[ "$REVIEW_GLOBAL_MD_LIMIT" =~ ^[0-9]+$ ]] || REVIEW_GLOBAL_MD_LIMIT=3000
+REVIEW_PROJECT_MD_LIMIT="${REVIEW_PROJECT_MD_LIMIT:-8000}"
+[[ "$REVIEW_PROJECT_MD_LIMIT" =~ ^[0-9]+$ ]] || REVIEW_PROJECT_MD_LIMIT=8000
+
 GLOBAL_MD=""
-[ ! -f "$HOME/.claude/CLAUDE.md" ] || GLOBAL_MD=$(head -c 3000 "$HOME/.claude/CLAUDE.md")
+[ ! -f "$HOME/.claude/CLAUDE.md" ] || GLOBAL_MD=$(head -c "$REVIEW_GLOBAL_MD_LIMIT" "$HOME/.claude/CLAUDE.md")
 
 PROJECT_MD=""
-[ ! -f "$CWD/CLAUDE.md" ] || PROJECT_MD=$(head -c 8000 "$CWD/CLAUDE.md")
+[ ! -f "$CWD/CLAUDE.md" ] || PROJECT_MD=$(head -c "$REVIEW_PROJECT_MD_LIMIT" "$CWD/CLAUDE.md")
 
 # --- 3. Extract recent user messages from transcript ---
 TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // ""')
@@ -490,6 +549,46 @@ ${USER_REQ:-<not available>}
 ## Plan to Review
 ${PLAN}
 DYNEOF
+
+# --- Prior-round review thread (engine-scoped) ---
+# Only for engines that declare ENGINE_WANTS_HISTORY=1 at source time
+# (currently codex — no server-side conversation reuse; agy resumes its own
+# conversation via --conversation, claude is deliberately left unchanged).
+# Injecting the engine's OWN previous rounds turns each round into a delta
+# review: without it, a memoryless high-recall reviewer re-reviews the whole
+# (ever-growing) plan from scratch and surfaces a fresh batch of findings on
+# UNCHANGED text every round, so the consultation never converges to APPROVE
+# (observed in the field: 17 rounds, exit only via safety valve). The rules
+# below live HERE, not in the shared prompt asset, precisely because they
+# only make sense when a thread is attached — other engines' prompts must
+# stay byte-identical.
+if [ "${ENGINE_WANTS_HISTORY:-0}" = "1" ] && [ "$REVIEW_HISTORY_DISABLED" != "1" ] && [ -s "$HISTORY_FILE" ]; then
+  cat >> "$PROMPT_FILE" << 'HISTEOF'
+
+## Prior Review Thread
+Below are YOUR OWN previous review rounds for this same plan, oldest first.
+The "Plan to Review" above is the CURRENT revision, already amended in
+response to this thread. This round is a DELTA review — apply these rules:
+1. Re-verify every Critical from the thread against the current plan:
+   resolved → do not repeat it; convincingly rebutted → drop it. If a
+   rebuttal rests on a factual claim about the codebase that you cannot
+   verify from the plan or project context, re-emit the finding as
+   `[Major] [UNVERIFIED-REBUTTAL]` (→ CONCERNS, never REJECT) so the human
+   arbitrates it — do not keep it Critical solely to win the argument.
+2. Do NOT raise new findings on plan text that was already present in the
+   revision you previously reviewed, unless the finding is a genuine
+   Critical per the severity definitions. Non-Critical issues you did not
+   raise back then are waived — re-litigating waived text burns scarce
+   negotiation rounds without improving the plan.
+3. Focus new-finding effort on text that changed since your last round
+   (revisions, new sections, rebuttals).
+4. If every prior Critical is resolved or rebutted and no new Critical
+   exists, do NOT reject: choose CONCERNS or APPROVE per the verdict rules.
+
+### Thread
+HISTEOF
+  cat "$HISTORY_FILE" >> "$PROMPT_FILE"
+fi
 
 # Volatile tail: round context (always last, changes every round)
 if [ "$TOTAL_ROUNDS" -gt 0 ]; then
@@ -754,15 +853,32 @@ fi
 TOTAL_ROUNDS=$((TOTAL_ROUNDS + 1))
 
 if [ "$VERDICT" = "REJECT" ]; then
-  # REJECT (Critical): reset ATTEMPT so subsequent non-Critical rounds restart fresh
+  # REJECT (Critical): reset ATTEMPT so subsequent non-Critical rounds restart
+  # fresh; extend the reject streak (consumed by the consecutive-REJECT valve).
   ATTEMPT=0
+  CONSEC_REJECTS=$((CONSEC_REJECTS + 1))
 else
-  # CONCERNS: non-Critical, increment ATTEMPT
+  # CONCERNS: non-Critical, increment ATTEMPT; any non-REJECT breaks the streak
   ATTEMPT=$((ATTEMPT + 1))
+  CONSEC_REJECTS=0
 fi
 
-echo "${ATTEMPT}:${TOTAL_ROUNDS}" > "$COUNTER_FILE"
-log_decision "verdict=$VERDICT decision=deny round=$ATTEMPT/$REVIEW_MAX_ROUNDS total=$TOTAL_ROUNDS/$REVIEW_MAX_TOTAL_ROUNDS"
+echo "${ATTEMPT}:${TOTAL_ROUNDS}:${CONSEC_REJECTS}" > "$COUNTER_FILE"
+log_decision "verdict=$VERDICT decision=deny round=$ATTEMPT/$REVIEW_MAX_ROUNDS total=$TOTAL_ROUNDS/$REVIEW_MAX_TOTAL_ROUNDS consec_rejects=$CONSEC_REJECTS"
+
+# --- Append this round's review to the thread (engine-scoped, mirrors the
+#     Prior Review Thread injection above). Best-effort side channel: a write
+#     failure must never kill the hook before it emits its decision JSON
+#     (set -e), hence the trailing `|| true`. Per-round cap (6000 bytes)
+#     bounds the file even if an engine ignores the prompt's 3000-char limit;
+#     APPROVE rounds are not recorded — approval ends the cycle (ack flow),
+#     and a post-approve plan change clears the thread entirely.
+if [ "${ENGINE_WANTS_HISTORY:-0}" = "1" ] && [ "$REVIEW_HISTORY_DISABLED" != "1" ]; then
+  {
+    printf '\n### Round %s — %s\n' "$TOTAL_ROUNDS" "$VERDICT"
+    printf '%s\n' "$REVIEW" | head -c 6000
+  } >> "$HISTORY_FILE" 2>/dev/null || true
+fi
 
 # --- 8. Compose deny feedback (delegated to lib/verdict.sh, severity-differentiated) ---
 render_concerns_or_reject_feedback "$VERDICT" "$ATTEMPT" "$TOTAL_ROUNDS" "$REVIEW_ENGINE" \

--- a/plugins/plan-review/scripts/precompact-review.sh
+++ b/plugins/plan-review/scripts/precompact-review.sh
@@ -27,7 +27,10 @@ APPROVE_MARKER="$COUNTER_DIR/.review-approved-${SESSION_ID}"
 [ -f "$COUNTER_FILE" ] || [ -f "$APPROVE_MARKER" ] || exit 0
 
 # --- Determine review status ---
-IFS=: read -r ATTEMPT TOTAL_ROUNDS <<< "$(cat "$COUNTER_FILE" 2>/dev/null || echo "0:0")"
+# Counter format is ATTEMPT:TOTAL:CONSEC_REJECTS (third field unused here but
+# MUST be consumed by its own variable — a two-var read would leave ":N" glued
+# onto TOTAL_ROUNDS, fail the numeric check below, and zero the display).
+IFS=: read -r ATTEMPT TOTAL_ROUNDS _CONSEC_REJECTS <<< "$(cat "$COUNTER_FILE" 2>/dev/null || echo "0:0:0")"
 ATTEMPT=${ATTEMPT:-0}
 TOTAL_ROUNDS=${TOTAL_ROUNDS:-$ATTEMPT}
 [[ "$ATTEMPT" =~ ^[0-9]+$ ]] || ATTEMPT=0

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -3704,3 +3704,247 @@ MOCK_EOF
   [[ "$HOOK_STDOUT" == *"[WARNING]"* ]]
   [[ "$HOOK_STDOUT" == *"lib file missing"* ]]
 }
+
+# =============================================================================
+# Round memory: prior review thread (engine-scoped — codex declares
+# ENGINE_WANTS_HISTORY=1; agy/claude do not)
+# =============================================================================
+
+# history: 1. codex deny round appends a thread record
+@test "history: codex CONCERNS round writes review thread record" {
+  export REVIEW_ENGINE="codex"
+  create_mock_codex "<verdict>CONCERNS</verdict>
+[Major] finding-alpha."
+  INPUT=$(build_input)
+  run_hook
+
+  assert_deny_json
+  [ -f "$(get_history_file)" ]
+  grep -q -- "Round 1 — CONCERNS" "$(get_history_file)"
+  grep -q "finding-alpha" "$(get_history_file)"
+}
+
+# history: 2. second round's prompt carries the thread + delta-review rules;
+# first round's prompt must NOT (no thread exists yet)
+@test "history: second codex round injects Prior Review Thread into prompt" {
+  export REVIEW_ENGINE="codex"
+  create_mock_codex_capture "<verdict>REJECT</verdict>
+[Critical] finding-bravo."
+  INPUT=$(build_input)
+
+  run_hook
+  assert_deny_json
+  ! grep -q "Prior Review Thread" "${TEST_TEMP_DIR}/codex-stdin"
+
+  run_hook
+  assert_deny_json
+  grep -q "Prior Review Thread" "${TEST_TEMP_DIR}/codex-stdin"
+  grep -q -- "Round 1 — REJECT" "${TEST_TEMP_DIR}/codex-stdin"
+  grep -q "finding-bravo" "${TEST_TEMP_DIR}/codex-stdin"
+}
+
+# history: 3. memoryful engine (agy) must not write a thread file
+@test "history: gemini engine does not write review thread" {
+  create_mock_engine "agy" "<verdict>CONCERNS</verdict>
+[Major] finding-charlie."
+  INPUT=$(build_input)
+  run_hook
+
+  assert_deny_json
+  [ ! -f "$(get_history_file)" ]
+}
+
+# history: 4. kill switch suppresses both record and injection
+@test "history: REVIEW_HISTORY_DISABLED=1 → no thread file" {
+  export REVIEW_ENGINE="codex"
+  export REVIEW_HISTORY_DISABLED=1
+  create_mock_codex "<verdict>CONCERNS</verdict>
+[Major] finding-delta."
+  INPUT=$(build_input)
+  run_hook
+
+  assert_deny_json
+  [ ! -f "$(get_history_file)" ]
+}
+
+# history: 5. ack-round approval tears the thread down with the counters
+@test "history: ack-round approval clears review thread" {
+  export REVIEW_ENGINE="codex"
+  create_mock_codex "<verdict>APPROVE</verdict>
+Looks good."
+  echo "seed-thread" > "$(get_history_file)"
+  INPUT=$(build_input)
+  run_hook_to_completion
+
+  assert_approve_json
+  [ ! -f "$(get_history_file)" ]
+}
+
+# history: 6. plan modified after approve → stale thread cleared BEFORE the
+# re-review composes its prompt (fresh first round for the new plan)
+@test "history: plan changed after approve → stale thread not injected" {
+  export REVIEW_ENGINE="codex"
+  create_approve_marker "old plan content"
+  echo "stale-thread-marker" > "$(get_history_file)"
+  create_mock_codex_capture "<verdict>CONCERNS</verdict>
+[Major] finding-echo."
+  INPUT=$(build_input plan="new plan content")
+  run_hook
+
+  assert_deny_json
+  ! grep -q "stale-thread-marker" "${TEST_TEMP_DIR}/codex-stdin"
+  grep -q -- "Round 1 — CONCERNS" "$(get_history_file)"
+}
+
+# =============================================================================
+# Consecutive-REJECT safety valve (REVIEW_MAX_CONSECUTIVE_REJECTS, default off)
+# =============================================================================
+
+# consec: 1. default (0) = disabled — a long streak still reaches the engine
+@test "consec-reject valve: disabled by default → engine still called" {
+  export REVIEW_ENGINE="codex"
+  set_counter_value 0 test-session 5 4
+  create_mock_codex "<verdict>REJECT</verdict>
+[Critical] finding-foxtrot."
+  INPUT=$(build_input)
+  run_hook
+
+  assert_deny_json
+  [ "$(get_consec_rejects)" -eq 5 ]
+  [ "$(get_total_rounds)" -eq 6 ]
+}
+
+# consec: 2. threshold reached → allow (ESCALATED), session state cleaned.
+# No engine mock on purpose: the valve fires before engine_probe, and a
+# missing binary would fail-open with a [WARNING] allow — asserting the
+# ESCALATED text distinguishes the valve from that masking path.
+@test "consec-reject valve: threshold reached → allow ESCALATED + cleanup" {
+  export REVIEW_MAX_CONSECUTIVE_REJECTS=3
+  set_counter_value 0 test-session 5 3
+  echo "thread" > "$(get_history_file)"
+  INPUT=$(build_input)
+  run_hook
+
+  assert_approve_json
+  [[ "$HOOK_STDOUT" == *"连续 REJECT"* ]]
+  [ ! -f "${REVIEW_COUNTER_DIR}/.review-count-test-session" ]
+  [ ! -f "$(get_history_file)" ]
+}
+
+# consec: 3. below threshold → engine round proceeds, streak extends
+@test "consec-reject valve: below threshold → engine called, streak extends" {
+  export REVIEW_MAX_CONSECUTIVE_REJECTS=5
+  export REVIEW_ENGINE="codex"
+  set_counter_value 0 test-session 5 4
+  create_mock_codex "<verdict>REJECT</verdict>
+[Critical] finding-golf."
+  INPUT=$(build_input)
+  run_hook
+
+  assert_deny_json
+  [ "$(get_consec_rejects)" -eq 5 ]
+}
+
+# consec: 4. REJECT extends the streak, CONCERNS resets it
+@test "consec-reject: REJECT extends streak, CONCERNS resets it" {
+  export REVIEW_ENGINE="codex"
+  create_mock_codex "<verdict>REJECT</verdict>
+[Critical] finding-hotel."
+  INPUT=$(build_input)
+  run_hook
+  [ "$(get_consec_rejects)" -eq 1 ]
+
+  create_mock_codex "<verdict>CONCERNS</verdict>
+[Major] finding-india."
+  run_hook
+  [ "$(get_consec_rejects)" -eq 0 ]
+  [ "$(get_counter_value)" -eq 1 ]
+}
+
+# consec: 5. legacy two-field counter file parses as streak 0 (backward compat)
+@test "consec-reject: legacy two-field counter parses as streak 0" {
+  export REVIEW_MAX_CONSECUTIVE_REJECTS=1
+  export REVIEW_ENGINE="codex"
+  set_counter_value 0 test-session 5
+  create_mock_codex "<verdict>REJECT</verdict>
+[Critical] finding-juliett."
+  INPUT=$(build_input)
+  run_hook
+
+  assert_deny_json
+  [ "$(get_consec_rejects)" -eq 1 ]
+}
+
+# =============================================================================
+# Context byte limits (REVIEW_GLOBAL_MD_LIMIT / REVIEW_PROJECT_MD_LIMIT)
+# =============================================================================
+
+# context: 1. project CLAUDE.md is cut at the configured byte limit
+@test "context: REVIEW_PROJECT_MD_LIMIT truncates project CLAUDE.md" {
+  export REVIEW_ENGINE="codex"
+  export REVIEW_PROJECT_MD_LIMIT=14
+  local proj="${TEST_TEMP_DIR}/proj"
+  mkdir -p "$proj"
+  printf 'proj-md-head-proj-md-tail' > "${proj}/CLAUDE.md"
+  create_mock_codex_capture "<verdict>APPROVE</verdict>
+ok"
+  INPUT=$(build_input cwd="$proj")
+  run_hook
+
+  grep -q "proj-md-head-" "${TEST_TEMP_DIR}/codex-stdin"
+  ! grep -q "proj-md-tail" "${TEST_TEMP_DIR}/codex-stdin"
+}
+
+# context: 2. non-numeric limit falls back to the default instead of killing
+# the hook under set -e (head -c garbage exits non-zero)
+@test "context: invalid REVIEW_PROJECT_MD_LIMIT falls back to default" {
+  export REVIEW_ENGINE="codex"
+  export REVIEW_PROJECT_MD_LIMIT="bogus"
+  local proj="${TEST_TEMP_DIR}/proj"
+  mkdir -p "$proj"
+  printf 'PROJECT-MD-CONTENT' > "${proj}/CLAUDE.md"
+  create_mock_codex_capture "<verdict>APPROVE</verdict>
+ok"
+  INPUT=$(build_input cwd="$proj")
+  run_hook
+
+  assert_ack_approve_json
+  grep -q "PROJECT-MD-CONTENT" "${TEST_TEMP_DIR}/codex-stdin"
+}
+
+# =============================================================================
+# codex repo access (REVIEW_REPO_ACCESS, default off)
+# =============================================================================
+
+# repo-access: 1. default off → -C target is a throwaway temp dir, not cwd
+@test "repo-access: default off → codex -C is not the project cwd" {
+  export REVIEW_ENGINE="codex"
+  local proj="${TEST_TEMP_DIR}/proj"
+  mkdir -p "$proj"
+  create_mock_codex "<verdict>APPROVE</verdict>
+ok"
+  INPUT=$(build_input cwd="$proj")
+  run_hook
+
+  local args
+  args=$(agy_args codex)
+  [[ "$args" == *"-C "* ]]
+  [[ "$args" != *"-C ${proj}"* ]]
+}
+
+# repo-access: 2. opt-in → -C <cwd>, sandbox stays read-only
+@test "repo-access: REVIEW_REPO_ACCESS=1 → codex -C cwd, still read-only" {
+  export REVIEW_ENGINE="codex"
+  export REVIEW_REPO_ACCESS=1
+  local proj="${TEST_TEMP_DIR}/proj"
+  mkdir -p "$proj"
+  create_mock_codex "<verdict>APPROVE</verdict>
+ok"
+  INPUT=$(build_input cwd="$proj")
+  run_hook
+
+  local args
+  args=$(agy_args codex)
+  [[ "$args" == *"-C ${proj}"* ]]
+  [[ "$args" == *"-s read-only"* ]]
+}

--- a/plugins/plan-review/tests/test_helper/common-setup.bash
+++ b/plugins/plan-review/tests/test_helper/common-setup.bash
@@ -105,6 +105,19 @@ reset_leaky_env() {
   unset MOCK_CODEX_NO_SECOND_DASHES
   unset MOCK_CODEX_EXTRA_BLANK
   unset MOCK_CODEX_STRICT_UTF8
+
+  # Consecutive-REJECT valve (default 0 = disabled in production)
+  unset REVIEW_MAX_CONSECUTIVE_REJECTS
+
+  # Prior-round review thread (codex-scoped round memory)
+  unset REVIEW_HISTORY_DISABLED
+
+  # codex repo access (default off — reviewer runs in an empty temp dir)
+  unset REVIEW_REPO_ACCESS
+
+  # Context byte limits (defaults 3000/8000)
+  unset REVIEW_GLOBAL_MD_LIMIT
+  unset REVIEW_PROJECT_MD_LIMIT
 }
 
 common_teardown() {
@@ -325,6 +338,37 @@ fi
   echo "ERROR: mock codex failure"
 } >&2
 rm -f "\$_mock_stdin"
+if [ -n "\$out_file" ]; then
+  cat > "\$out_file" << 'OUTPUT_EOF'
+${output}
+OUTPUT_EOF
+fi
+exit 0
+MOCK_EOF
+  chmod +x "${MOCK_BIN}/codex"
+}
+
+# create_mock_codex_capture <output>
+#   Like create_mock_codex, but additionally persists the prompt received on
+#   stdin to ${TEST_TEMP_DIR}/codex-stdin (overwritten per invocation — in a
+#   multi-round test, read it after each run_hook) so tests can assert on
+#   prompt COMPOSITION: Prior Review Thread injection, CLAUDE.md byte limits.
+#   Skips the stderr banner echo — prompt-composition tests don't exercise
+#   the stderr filter, and the echo would just slow multi-round cases down.
+create_mock_codex_capture() {
+  local output="$1"
+  local args_file="${MOCK_BIN}/../.agy-args-codex"
+  local capture_file="${TEST_TEMP_DIR}/codex-stdin"
+  cat > "${MOCK_BIN}/codex" << MOCK_EOF
+#!/bin/bash
+printf '%s\n' "\$*" > '${args_file}'
+out_file=""
+prev=""
+for arg in "\$@"; do
+  if [ "\$prev" = "-o" ]; then out_file="\$arg"; fi
+  prev="\$arg"
+done
+cat > '${capture_file}'
 if [ -n "\$out_file" ]; then
   cat > "\$out_file" << 'OUTPUT_EOF'
 ${output}
@@ -697,32 +741,57 @@ create_approve_marker() {
 # --- Counter Helpers ---
 
 # get_counter_value [session_id]
-#   Reads the ATTEMPT field from counter file (new format ATTEMPT:TOTAL).
+#   Reads the ATTEMPT field from counter file (format ATTEMPT:TOTAL:CONSEC).
 #   Returns 0 if missing or unparseable.
 get_counter_value() {
   local session="${1:-test-session}"
-  local attempt total
-  IFS=: read -r attempt total <<< "$(cat "${REVIEW_COUNTER_DIR}/.review-count-${session}" 2>/dev/null || echo "0:0")"
+  local attempt total consec
+  IFS=: read -r attempt total consec <<< "$(cat "${REVIEW_COUNTER_DIR}/.review-count-${session}" 2>/dev/null || echo "0:0:0")"
   echo "${attempt:-0}"
 }
 
 # get_total_rounds [session_id]
-#   Reads the TOTAL_ROUNDS field from counter file (new format ATTEMPT:TOTAL).
-#   Falls back to ATTEMPT for old single-number format.
+#   Reads the TOTAL_ROUNDS field from counter file (format ATTEMPT:TOTAL:CONSEC).
+#   Falls back to ATTEMPT for old single-number format. The third field MUST be
+#   consumed by its own read variable — a two-var read would leave ":N" glued
+#   onto total.
 get_total_rounds() {
   local session="${1:-test-session}"
-  local attempt total
-  IFS=: read -r attempt total <<< "$(cat "${REVIEW_COUNTER_DIR}/.review-count-${session}" 2>/dev/null || echo "0:0")"
+  local attempt total consec
+  IFS=: read -r attempt total consec <<< "$(cat "${REVIEW_COUNTER_DIR}/.review-count-${session}" 2>/dev/null || echo "0:0:0")"
   echo "${total:-$attempt}"
 }
 
-# set_counter_value <attempt> [session_id] [total_rounds]
-#   Sets the counter file for the given session in ATTEMPT:TOTAL format.
+# get_consec_rejects [session_id]
+#   Reads the CONSEC_REJECTS field (third) from the counter file.
+#   Returns 0 for missing file or legacy two-field/one-field formats.
+get_consec_rejects() {
+  local session="${1:-test-session}"
+  local attempt total consec
+  IFS=: read -r attempt total consec <<< "$(cat "${REVIEW_COUNTER_DIR}/.review-count-${session}" 2>/dev/null || echo "0:0:0")"
+  echo "${consec:-0}"
+}
+
+# set_counter_value <attempt> [session_id] [total_rounds] [consec_rejects]
+#   Sets the counter file for the given session in ATTEMPT:TOTAL:CONSEC format.
+#   Omitting consec_rejects writes the two-field legacy format — deliberate:
+#   existing call sites keep exercising the backward-compat parse path.
 set_counter_value() {
   local value="$1"
   local session="${2:-test-session}"
   local total="${3:-$value}"
-  echo "${value}:${total}" > "${REVIEW_COUNTER_DIR}/.review-count-${session}"
+  if [ $# -ge 4 ]; then
+    echo "${value}:${total}:${4}" > "${REVIEW_COUNTER_DIR}/.review-count-${session}"
+  else
+    echo "${value}:${total}" > "${REVIEW_COUNTER_DIR}/.review-count-${session}"
+  fi
+}
+
+# get_history_file [session_id]
+#   Echoes the review-history file path for the session (may not exist).
+get_history_file() {
+  local session="${1:-test-session}"
+  printf '%s' "${REVIEW_COUNTER_DIR}/.review-history-${session}"
 }
 
 # --- Isolated Script Copy (bootstrap fail-open scenarios) ---


### PR DESCRIPTION
## 背景：codex 引擎首次生产使用的实测数据

`REVIEW_ENGINE=codex`（gpt-5.6 级推理模型，reasoning=high）首次跑真实 plan 的完整数据：

- **17 轮审阅**（11 REJECT / 6 CONCERNS / **0 APPROVE**），另有 1 次 manifest 预检拦截
- 耗时 **2h40m**，最终靠非 Critical 安全阀 + 用户裁决退出，**距 20 轮墓碑硬停仅差 3 轮**
- plan 从 8.1KB 单调膨胀到 31.5KB（3.9 倍）；同日另一会话 12 轮，同样只能靠阀退出
- 审阅质量本身很高（大量真实的分布式事务/状态机缺陷,其中一条事后被实现期 review 证实为最严重缺陷），问题出在**循环机制无法收敛**

四个根因及对应修复（改动面刻意收敛到 codex 路径，agy/claude 行为字节不变）：

## 1. 轮间记忆（codex 专属，核心修复）

codex `exec --ephemeral` 无会话复用，每轮从零重审整个（不断膨胀的）plan——高召回引擎每轮都会在**未变更文本**上产出全新发现，作者永远无法满足它。

仿照 agy 的 session reuse 在 prompt 层实现：引擎 source 时声明 `ENGINE_WANTS_HISTORY=1`，编排器落盘每轮 review（单轮 6KB 封顶），下一轮注入 `## Prior Review Thread` + 增量审阅规则：

- 先逐条复核历轮 Critical 的修复/辩护是否成立
- **无法核实的事实性辩护 → 降级 `[Major] [UNVERIFIED-REBUTTAL]`（CONCERNS）交人裁决**——实测中一条正确的 Critical 正是被一句错误但无法核验的辩护洗掉的，这条规则让它既不永久卡死循环、也不静默消失
- 未变更文本上的非 Critical 新发现视为已弃权
- 历轮 Critical 全部解决且无新 Critical → 禁止 REJECT

规则文本随注入块动态拼接，**共享 prompt 资产对 agy/claude 字节不变**。`REVIEW_HISTORY_DISABLED=1` 可整体关闭。生命周期与 CONV_FILE 完全对齐（approve/escalate/plan 变更/双阀清理；引擎失败不清）。

## 2. 连续 REJECT 安全阀（opt-in，默认关，零默认行为变化）

REJECT 不消耗磋商数且把 ATTEMPT 清零——遇到每轮都能给出新 Critical 的引擎，唯一内建出口是 20 轮墓碑 deny（还需人工清计数文件）。`REVIEW_MAX_CONSECUTIVE_REJECTS=K` 提供与非 Critical 阀对称的用户裁决出口。计数器扩展为 `ATTEMPT:TOTAL:CONSEC` 三字段，向后兼容旧格式（precompact-review.sh 的解析同步修复，否则三字段文件会把它的状态显示归零）。

## 3. 提示词自相矛盾修复（共享资产，唯一一处全引擎生效的改动）

criterion 7 的 "model (full name, no abbreviation)" 与 `manifest.sh` MANIFEST_EXAMPLE 的「model 用全名（sonnet / opus / haiku）」直接冲突——codex 按字面理解，连续两轮以 Critical 拒绝 manifest 里的 `sonnet`/`haiku`，要求版本化模型 ID。改为明示层级名即全名。这是 bugfix 而非策略变更，gemini/claude 只是此前没较真到触发它。

## 4. 上下文与接地（均 opt-in，默认不变）

- `REVIEW_GLOBAL_MD_LIMIT` / `REVIEW_PROJECT_MD_LIMIT`：实测 8KB 截断把项目 CLAUDE.md 第 8473 字节处的关键环境约束切掉，审阅引擎因此结构性看不见一个事后被证实的真缺陷。长上下文引擎可按需调大。
- `REVIEW_REPO_ACCESS=1`（codex）：`-C` 指向项目 cwd（仍 `-s read-only`），使引擎能对照真实代码核验事实性辩护。默认关，README 明示隐私/耗时代价。

## 测试

- 新增 15 条 bats 用例：轮间记忆 6（含二轮 prompt 注入断言、approve/plan 变更清理）/ 连续 REJECT 阀 5（含默认关闭、旧格式兼容）/ 截断限额 2（含非法值 fail-open）/ 仓库访问 2（含 read-only 不变断言）
- 存量用例零回归（本机 4 个失败在干净 origin/main 基线上同样失败，与本 PR 无关：rest-sse oversized、degrade+REST、两个 syntax-broken bootstrap 用例）
- 版本双写：plugin.json + marketplace.json → 1.5.0