### PR TITLE
feat(dispatch-contract): 补完成通知折叠机制与等待/汇报纪律

### DIFF
--- a/plugins/dispatch-contract/.claude-plugin/plugin.json
+++ b/plugins/dispatch-contract/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dispatch-contract",
   "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop)",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/subagent-dispatch"]
 }

--- a/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
@@ -9,7 +9,7 @@ description: |
   - 需要子 agent 返回强结构化产物（JSON schema 校验）时了解 Workflow agent() 用法
   - 派发 prompt 触发拒绝，排查是否遇到上游 persona 焊死问题
   时调用此 Skill。
-  Triggers: 派发 subagent, subagent 调度, dispatch subagent, spawn agent, delegate to agent, Task 派发, 并行派发, 交付物形态, 定稿标记, 输出即产物, 范围围栏, 渐进产出, 定稿纪律, offload, 卸载场景, 卸载判断, background subagent, 活性判定, TaskStop, 回传通道, workflow schema, 结构化产物, persona 拒绝, 派发契约, dispatch contract, %%DONE%%.
+  Triggers: 派发 subagent, subagent 调度, dispatch subagent, spawn agent, delegate to agent, Task 派发, 并行派发, 交付物形态, 定稿标记, 输出即产物, 范围围栏, 渐进产出, 定稿纪律, offload, 卸载场景, 卸载判断, background subagent, 活性判定, TaskStop, 回传通道, workflow schema, 结构化产物, persona 拒绝, 派发契约, dispatch contract, %%DONE%%, 通知丢失, task-notification 未送达, 完成通知没到, agent 跑完没回传, 主 session 一直等, sleep 等 subagent, 轮询等待, TaskOutput, 零产出误判.
 ---
 
 # 子 agent 派发契约
@@ -46,8 +46,11 @@ description: |
 | 纪律 | 一句话 | 展开 |
 |---|---|---|
 | 通道选择 | 不传 `name`，产物走工具返回值（可靠）；传 `name` 即提升为 teammate、产物改走 mailbox。teammate 由 team-ops 的 TeamCreate + handoff 协议起，不靠手传 `name`——故即席派发一律不传；可另配 PreToolUse hook 拦截违规通道选择 | 见 references/mailbox-liveness.md |
-| 回传通道 | background subagent 的 final text 不自动进主 mailbox，产物必须走 `SendMessage(to:"main")`；该工具在 subagent 里默认 deferred，prompt 须要求它先 `ToolSearch select:SendMessage` 加载。能同步就 `run_in_background:false` 绕开此坑 | 见 references/mailbox-liveness.md |
+| 回传通道 | background subagent 的 final text 不自动进主 mailbox，产物必须走 `SendMessage(to:"main")`；该工具在 subagent 里默认 deferred，prompt 须要求它先 `ToolSearch select:SendMessage` 加载。**能同步就 `run_in_background:false`**——产物走 tool_result，既绕开此坑，也不进那个会丢通知的队列 | 见 references/mailbox-liveness.md |
 | 活性判定 | 完成/进展是 mailbox 异步、下一 turn 才可见；文件没变 / ps 查不到进程 / sleep 期间没消息都不算 agent 死了；TaskStop 不可逆，存疑多等一 turn 不错杀 | 见 references/mailbox-liveness.md |
+| 等待方式 | 派完就结束本轮、交还主循环空闲态等唤起；**禁止 `sleep`/轮询/主动查进度**（上游官方明令，见 reference 引原文）。主循环有工具在飞时到达的通知实测 92.7% 被丢弃且不可恢复 | 见 references/mailbox-liveness.md |
+| 取产物 | 别用 `TaskOutput`（官方已标弃用，且对 local_agent 会灌入整个 transcript）；派完后台 agent 后别紧接着 `AskUserQuestion`（该期间到达的通知实测全丢） | 见 references/mailbox-liveness.md |
+| 汇报纪律 | 「没收到通知」≠「agent 零产出」——汇报前先查 transcript 末条 assistant，别把通知丢失说成子 agent 没干活 | 见 references/mailbox-liveness.md |
 
 ## 派发端补充纪律（仅上游带焊死 persona 时发作）
 

--- a/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
@@ -41,16 +41,18 @@ description: |
 
 ## 己方端补充纪律（background 派发后，与④同族）
 
-铁律①②③钉进子 agent 的 prompt（派发端），④与下列三条约束主 agent 自己（己方端）。四条同族——都拒绝凭不可靠信号抢跑不可逆动作。
+铁律①②③钉进子 agent 的 prompt（派发端），④与下列各条约束主 agent 自己（己方端）。同族——都拒绝凭不可靠信号抢跑不可逆动作。
+
+**两类别混**：前三行对**一切 background 派发**生效（通知队列投递问题）；后两行仅 **teammate/mailbox** 场景适用（传了 `name` 才会走 mailbox）。#141 那类"5 路跑完零通知"属前者，与 mailbox 无关——那 5 条通知自带完整产物正文，走的是 task-notification 队列。
 
 | 纪律 | 一句话 | 展开 |
 |---|---|---|
 | 通道选择 | 不传 `name`，产物走工具返回值（可靠）；传 `name` 即提升为 teammate、产物改走 mailbox。teammate 由 team-ops 的 TeamCreate + handoff 协议起，不靠手传 `name`——故即席派发一律不传；可另配 PreToolUse hook 拦截违规通道选择 | 见 references/mailbox-liveness.md |
-| 回传通道 | background subagent 的 final text 不自动进主 mailbox，产物必须走 `SendMessage(to:"main")`；该工具在 subagent 里默认 deferred，prompt 须要求它先 `ToolSearch select:SendMessage` 加载。**能同步就 `run_in_background:false`**——产物走 tool_result，既绕开此坑，也不进那个会丢通知的队列 | 见 references/mailbox-liveness.md |
+| 等待方式 | 需要产物才能往下走 → `run_in_background:false` 同步派发（产物走 tool_result，不进通知队列）；真要后台并行则派完就结束本轮、交还主循环空闲态。**禁止 `sleep`/轮询/主动查进度**（上游官方明令）。主循环有工具在飞时到达的通知实测 92.7% 被丢弃且无恢复通道 | 见 references/dispatch-contract.md |
+| 取产物 | 别用 `TaskOutput`（官方已标弃用，且对 local_agent 会灌入整个 transcript）；派完后台 agent 后别紧接着 `AskUserQuestion`（该期间到达的通知实测 18 例全丢） | 见 references/dispatch-contract.md |
+| 汇报纪律 | 「没收到通知」≠「agent 零产出」——汇报前先查 transcript 末条 assistant，别把通知丢失说成子 agent 没干活 | 见 references/dispatch-contract.md |
+| 回传通道 | **teammate/mailbox 专属**：background teammate 的 final text 不自动进主 mailbox，产物必须走 `SendMessage(to:"main")`；该工具在 subagent 里默认 deferred，prompt 须要求它先 `ToolSearch select:SendMessage` 加载 | 见 references/mailbox-liveness.md |
 | 活性判定 | 完成/进展是 mailbox 异步、下一 turn 才可见；文件没变 / ps 查不到进程 / sleep 期间没消息都不算 agent 死了；TaskStop 不可逆，存疑多等一 turn 不错杀 | 见 references/mailbox-liveness.md |
-| 等待方式 | 派完就结束本轮、交还主循环空闲态等唤起；**禁止 `sleep`/轮询/主动查进度**（上游官方明令，见 reference 引原文）。主循环有工具在飞时到达的通知实测 92.7% 被丢弃且不可恢复 | 见 references/mailbox-liveness.md |
-| 取产物 | 别用 `TaskOutput`（官方已标弃用，且对 local_agent 会灌入整个 transcript）；派完后台 agent 后别紧接着 `AskUserQuestion`（该期间到达的通知实测全丢） | 见 references/mailbox-liveness.md |
-| 汇报纪律 | 「没收到通知」≠「agent 零产出」——汇报前先查 transcript 末条 assistant，别把通知丢失说成子 agent 没干活 | 见 references/mailbox-liveness.md |
 
 ## 派发端补充纪律（仅上游带焊死 persona 时发作）
 
@@ -71,7 +73,8 @@ description: |
 
 - 需要每条铁律的正反例与常见踩坑时，读取：`references/dispatch-contract.md`
 - 判断某任务该不该卸载、用哪个模型档时，读取：`references/offload-scenarios.md`
-- spawn background subagent 后如何收产物 / 判活性 / 何时能 TaskStop，读取：`references/mailbox-liveness.md`
+- 派完 background agent 后怎么等、通知为什么会丢、产物怎么兜底取回，读取：`references/dispatch-contract.md` 的「己方端纪律：派完就交还主循环」章节
+- teammate（传了 `name`）的 mailbox 回传通道 / 活性判定 / 何时能 TaskStop，读取：`references/mailbox-liveness.md`
 - 需要子 agent 返回强结构化产物（JSON/schema 校验）时，读取：`references/workflow-schema.md`
 - 派发端 persona 规避的发作区/安全区展开与实测背书，读取：同一份 `references/dispatch-contract.md` 的「## 派发端补充」章节
 

--- a/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
@@ -43,13 +43,13 @@ description: |
 
 铁律①②③钉进子 agent 的 prompt（派发端），④与下列各条约束主 agent 自己（己方端）。同族——都拒绝凭不可靠信号抢跑不可逆动作。
 
-**两类别混**：前三行对**一切 background 派发**生效（通知队列投递问题）；后两行仅 **teammate/mailbox** 场景适用（传了 `name` 才会走 mailbox）。#141 那类"5 路跑完零通知"属前者，与 mailbox 无关——那 5 条通知自带完整产物正文，走的是 task-notification 队列。
+**两类别混**：前三行对**一切 background 派发**生效；后两行仅 **teammate** 场景适用（传了 `name` 才走 mailbox）。
 
 | 纪律 | 一句话 | 展开 |
 |---|---|---|
 | 通道选择 | 不传 `name`，产物走工具返回值（可靠）；传 `name` 即提升为 teammate、产物改走 mailbox。teammate 由 team-ops 的 TeamCreate + handoff 协议起，不靠手传 `name`——故即席派发一律不传；可另配 PreToolUse hook 拦截违规通道选择 | 见 references/mailbox-liveness.md |
-| 等待方式 | 需要产物才能往下走 → `run_in_background:false` 同步派发（产物走 tool_result，不进通知队列）；真要后台并行则派完就结束本轮、交还主循环空闲态。**禁止 `sleep`/轮询/主动查进度**（上游官方明令）。主循环有工具在飞时到达的通知实测 92.7% 被丢弃且无恢复通道 | 见 references/dispatch-contract.md |
-| 取产物 | 别用 `TaskOutput`（官方已标弃用，且对 local_agent 会灌入整个 transcript）；派完后台 agent 后别紧接着 `AskUserQuestion`（该期间到达的通知实测 18 例全丢） | 见 references/dispatch-contract.md |
+| 等待方式 | 需要产物才能往下走 → `run_in_background:false`（产物走 tool_result）；真要后台并行则派完就结束本轮、交还主循环空闲态。**禁止 `sleep`/轮询/主动查进度**——主循环忙时到达的通知会被丢弃且不补发 | 见 references/dispatch-contract.md |
+| 取产物 | 别用 `TaskOutput`（官方已标弃用，且对 local_agent 会灌入整个 transcript）；派完后台 agent 后别紧接着 `AskUserQuestion`（该期间到达的通知会丢） | 见 references/dispatch-contract.md |
 | 汇报纪律 | 「没收到通知」≠「agent 零产出」——汇报前先查 transcript 末条 assistant，别把通知丢失说成子 agent 没干活 | 见 references/dispatch-contract.md |
 | 回传通道 | **teammate/mailbox 专属**：background teammate 的 final text 不自动进主 mailbox，产物必须走 `SendMessage(to:"main")`；该工具在 subagent 里默认 deferred，prompt 须要求它先 `ToolSearch select:SendMessage` 加载 | 见 references/mailbox-liveness.md |
 | 活性判定 | 完成/进展是 mailbox 异步、下一 turn 才可见；文件没变 / ps 查不到进程 / sleep 期间没消息都不算 agent 死了；TaskStop 不可逆，存疑多等一 turn 不错杀 | 见 references/mailbox-liveness.md |

--- a/plugins/dispatch-contract/skills/subagent-dispatch/references/dispatch-contract.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/references/dispatch-contract.md
@@ -58,62 +58,22 @@
 
 **原则一句话**：需要产物才能往下走就同步派发；真要后台并行，派完立刻结束本轮、把主循环交还空闲态等唤起——**不 sleep、不轮询、不主动查进度**。
 
-**上游官方立场**（2.1.220 二进制内 Agent 工具描述原文，非社区转述）：
+**为什么**：后台 agent 的完成通知在「主循环正跑着工具」时到达会被丢弃，且无补发、无恢复通道。实测丢失率 92.7%（空闲时 11.7%）。`sleep` 空等最糟：既占着主循环制造丢弃窗口，又不带回任何产物。同步派发的产物走 tool_result，根本不进那个队列——没有通知，就没有丢通知。
 
-> Agents run in the background by default. When an agent runs in the background, you will be automatically notified when it completes — do NOT sleep, poll, or proactively check on its progress. Continue with other work or respond to the user instead.
+**别指望机器拦你**：上游确有 `sleep` 门禁，但默认关闭，且判据只看「首命令 + ≥25 秒 + 前台」，不看「当前有无活跃 background agent」。绕过方式很多，本纪律须自觉遵守。
 
-> **Foreground vs background**: Pass `run_in_background: false` to run an agent in the foreground when you need its results before you can proceed — e.g., research agents whose findings inform your next steps.
-
-Bash 工具描述同版原文：
-
-> Foreground `sleep` is blocked; use Monitor with an until-loop to wait on a condition.
-
-拦截文案另写明 `Do not chain shorter sleeps to work around this block.`。即"sleep 等 subagent"本就是上游明令禁止的用法。
-
-**但别指望它拦你——本纪律必须自觉遵守**。该门禁在 Bash 的 `validateInput`，三条件全真才生效：
-
-```js
-if (ese() && !DT() && !e.run_in_background) { /* eny(command) !== null → 拦 */ }
-```
-
-- `eny()`：只认**首个命令**为 `sleep <数字>` 且 **≥25 秒**（`KTo=25`）
-- `ese()`：`Ke("tengu_amber_sentinel", false)` —— 服务端特性开关，**默认关**
-- `DT()`：`CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` 环境变量
-
-本机实测开关未启用，判定被短路。且即便开启，判据也只覆盖「首命令 + ≥25 秒 + 前台」——`sleep 20` 连开五轮、`bash -c 'until ...; do sleep 2; done'` 都绕得过。更关键的是它**不看「当前有没有活跃 background agent」**，而那才是区分"无害的 sleep"与"会吃掉通知的 sleep"的判据：`sleep` 本身无罪，有罪的是有 agent 在跑时占着主循环。
-
-**为什么（机制根据）**：普通 background agent 的完成通知**自带完整产物正文**（实测 5 条通知各带 8414~14593 字符的 `<result>`），走 task-notification 队列而非 mailbox。该队列的消费分两条路：
-
-| 通知到达时主循环 | 队列动作 | 结果 |
-|---|---|---|
-| 空闲 | `dequeue` | 落成真正的 `user` 消息，模型必定看见 |
-| 正在跑工具（mid-turn） | **`remove`** | 只落一条 `attachment/queued_command`（`isMeta:true`）后从队列移除 |
-
-二进制里这是 query 主循环在每批工具结果后的 mid-turn fold：`registerFoldInFlight(dn)` → 渲染 attachment → `messageQueue.remove(Jr)`。
-
-**实测**（本地 383 个 session 全量扫描，仅统计 subagent 通知）：
-
-| 到达时主循环 | 送达 | 丢失 | 丢失率 |
-|---|---|---|---|
-| 有工具在飞 | 11 | 139 | **92.7%** |
-| 空闲 | 690 | 91 | 11.7% |
-
-按通知正文哈希精确配对 `remove` 事件（不靠代理指标）：内容出现在 `remove` 里的 430 例丢失率 **95.3%**，未出现的 1124 例 23.4%。在飞工具排名：`TaskOutput` 80、`Bash` 35（`sleep` 26）、`AskUserQuestion` 18、`Agent` 5。
-
-**无恢复通道**：`remove` 是终态。实测 28 例"丢失后用 `SendMessage` 续跑该 agent"，那条通知仍未送达——SendMessage 开的是新一轮，不补发旧通知。
-
-**正例（纪律）**：
-> 需要调研结论才能定方案 → `run_in_background: false` 同步派发，产物走 tool_result 直接返回，根本不进那个队列。没有通知，就没有丢通知。
+**正例**：
+> 需要调研结论才能定方案 → `run_in_background: false`，产物直接作为 tool result 返回。
 
 **反例**：
-> 派 5 路 background agent，然后 `Bash: sleep 110` 连等 13 轮。每轮 sleep 收尾都是一次 mid-turn fold，把期间到达的通知全部吃掉。
+> 派 5 路 background agent，然后 `Bash: sleep 110` 连等 13 轮——每轮 sleep 收尾都吃掉一批通知。
 
 **衍生三条**：
-1. **别紧接着 `AskUserQuestion`**：派完后台 agent 就抛问题给用户等答复，该期间到达的通知实测 18 例全丢。
-2. **别用 `TaskOutput` 取产物**：官方已标弃用（替代方案是 `Read` 任务输出文件路径），且上游有未修 bug——对 local_agent 调 `TaskOutput(block=true)` 会把整个 JSONL transcript 灌进调用方上下文。
-3. **「没收到通知」≠「agent 零产出」**：通知丢失时主 agent 上下文里确实没产物，容易据此向用户汇报"这几路等于零产出"。这是**基于错误前提的正向汇报**，比空等更糟——用户不追问就会接受错误结论（已踩两次）。汇报前先查 transcript 末条 assistant（`~/.claude/projects/<项目>/<session>/subagents/agent-<id>.jsonl`），只提取 text 块、不 `Read` 整个 `.output`（那是完整 JSONL，会撑爆上下文）。要求「渐进产出」的子 agent 分多段输出，末段可能只是报告尾部，需全文时拼接全部 assistant 段落。
+1. **别紧接着 `AskUserQuestion`**：派完后台 agent 就抛问题给用户等答复，该期间到达的通知实测全丢。
+2. **别用 `TaskOutput` 取产物**：官方已标弃用（替代是 `Read` 任务输出文件路径），且对 local_agent 会把整个 JSONL transcript 灌进上下文。
+3. **「没收到通知」≠「agent 零产出」**：通知丢了，主上下文里确实没产物，于是容易向用户汇报"这几路等于零产出"——基于错误前提的正向汇报，比空等更糟（已踩两次）。汇报前先查 `~/.claude/projects/<项目>/<session>/subagents/agent-<id>.jsonl` 的末条 assistant，只提取 text 块，别 `Read` 整个 `.output`（完整 JSONL，会撑爆上下文）。子 agent 分段输出时末段可能只是报告尾部，需全文则拼接各 assistant 段落。
 
-**未验证边界**：折叠出的 `isMeta:true` attachment 是完全不进 API 请求，还是进了被当背景噪声忽略——未能区分，需抓主循环真实请求体才能定。对本铁律无影响（后果一样：模型不知情），但对上游是两个不同修法。
+> 底层机制与实测数据不在本 skill 展开——本节只给行动规范。
 
 ## 铁律①的技术边界
 

--- a/plugins/dispatch-contract/skills/subagent-dispatch/references/dispatch-contract.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/references/dispatch-contract.md
@@ -68,7 +68,19 @@ Bash 工具描述同版原文：
 
 > Foreground `sleep` is blocked; use Monitor with an until-loop to wait on a condition.
 
-拦截文案另写明 `Do not chain shorter sleeps to work around this block.`。即"sleep 等 subagent"本就是上游明令禁止的用法。**注**：该拦截未必在所有环境实际生效（本地 2.1.220 实测 `sleep 3` 仍放行），拦不住你，所以本铁律须自觉遵守。
+拦截文案另写明 `Do not chain shorter sleeps to work around this block.`。即"sleep 等 subagent"本就是上游明令禁止的用法。
+
+**但别指望它拦你——本纪律必须自觉遵守**。该门禁在 Bash 的 `validateInput`，三条件全真才生效：
+
+```js
+if (ese() && !DT() && !e.run_in_background) { /* eny(command) !== null → 拦 */ }
+```
+
+- `eny()`：只认**首个命令**为 `sleep <数字>` 且 **≥25 秒**（`KTo=25`）
+- `ese()`：`Ke("tengu_amber_sentinel", false)` —— 服务端特性开关，**默认关**
+- `DT()`：`CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` 环境变量
+
+本机实测开关未启用，判定被短路。且即便开启，判据也只覆盖「首命令 + ≥25 秒 + 前台」——`sleep 20` 连开五轮、`bash -c 'until ...; do sleep 2; done'` 都绕得过。更关键的是它**不看「当前有没有活跃 background agent」**，而那才是区分"无害的 sleep"与"会吃掉通知的 sleep"的判据：`sleep` 本身无罪，有罪的是有 agent 在跑时占着主循环。
 
 **为什么（机制根据）**：普通 background agent 的完成通知**自带完整产物正文**（实测 5 条通知各带 8414~14593 字符的 `<result>`），走 task-notification 队列而非 mailbox。该队列的消费分两条路：
 

--- a/plugins/dispatch-contract/skills/subagent-dispatch/references/dispatch-contract.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/references/dispatch-contract.md
@@ -50,7 +50,58 @@
 **反例**：
 > 看到初步结论说全部确认，立即派 agent 开始修复。
 
-**同族纪律**：④管"信息完不完整就别拍板"，另有两条己方端纪律管 background 派发后的"通道"与"活性"——产物走 `SendMessage(to:"main")` 回传（该工具在 subagent 默认 deferred，须先 ToolSearch 加载）、活性判定不靠文件轮询、TaskStop 存疑多等一 turn。见 `references/mailbox-liveness.md`。
+**同族纪律**：④管"信息完不完整就别拍板"，另有两条己方端纪律管 background 派发后的"通道"与"活性"——产物走 `SendMessage(to:"main")` 回传（该工具在 subagent 默认 deferred，须先 ToolSearch 加载）、活性判定不靠文件轮询、TaskStop 存疑多等一 turn。见 `references/mailbox-liveness.md`（那份只管 teammate/mailbox 通道，普通 background agent 的通知投递见下节）。
+
+## 己方端纪律：派完就交还主循环（与铁律④同族）
+
+四铁律是**钉进子 agent prompt** 的派发端约束；本节与铁律④一样约束**主 agent 自己**，不进任何派发 prompt，故不编入铁律序号。
+
+**原则一句话**：需要产物才能往下走就同步派发；真要后台并行，派完立刻结束本轮、把主循环交还空闲态等唤起——**不 sleep、不轮询、不主动查进度**。
+
+**上游官方立场**（2.1.220 二进制内 Agent 工具描述原文，非社区转述）：
+
+> Agents run in the background by default. When an agent runs in the background, you will be automatically notified when it completes — do NOT sleep, poll, or proactively check on its progress. Continue with other work or respond to the user instead.
+
+> **Foreground vs background**: Pass `run_in_background: false` to run an agent in the foreground when you need its results before you can proceed — e.g., research agents whose findings inform your next steps.
+
+Bash 工具描述同版原文：
+
+> Foreground `sleep` is blocked; use Monitor with an until-loop to wait on a condition.
+
+拦截文案另写明 `Do not chain shorter sleeps to work around this block.`。即"sleep 等 subagent"本就是上游明令禁止的用法。**注**：该拦截未必在所有环境实际生效（本地 2.1.220 实测 `sleep 3` 仍放行），拦不住你，所以本铁律须自觉遵守。
+
+**为什么（机制根据）**：普通 background agent 的完成通知**自带完整产物正文**（实测 5 条通知各带 8414~14593 字符的 `<result>`），走 task-notification 队列而非 mailbox。该队列的消费分两条路：
+
+| 通知到达时主循环 | 队列动作 | 结果 |
+|---|---|---|
+| 空闲 | `dequeue` | 落成真正的 `user` 消息，模型必定看见 |
+| 正在跑工具（mid-turn） | **`remove`** | 只落一条 `attachment/queued_command`（`isMeta:true`）后从队列移除 |
+
+二进制里这是 query 主循环在每批工具结果后的 mid-turn fold：`registerFoldInFlight(dn)` → 渲染 attachment → `messageQueue.remove(Jr)`。
+
+**实测**（本地 383 个 session 全量扫描，仅统计 subagent 通知）：
+
+| 到达时主循环 | 送达 | 丢失 | 丢失率 |
+|---|---|---|---|
+| 有工具在飞 | 11 | 139 | **92.7%** |
+| 空闲 | 690 | 91 | 11.7% |
+
+按通知正文哈希精确配对 `remove` 事件（不靠代理指标）：内容出现在 `remove` 里的 430 例丢失率 **95.3%**，未出现的 1124 例 23.4%。在飞工具排名：`TaskOutput` 80、`Bash` 35（`sleep` 26）、`AskUserQuestion` 18、`Agent` 5。
+
+**无恢复通道**：`remove` 是终态。实测 28 例"丢失后用 `SendMessage` 续跑该 agent"，那条通知仍未送达——SendMessage 开的是新一轮，不补发旧通知。
+
+**正例（纪律）**：
+> 需要调研结论才能定方案 → `run_in_background: false` 同步派发，产物走 tool_result 直接返回，根本不进那个队列。没有通知，就没有丢通知。
+
+**反例**：
+> 派 5 路 background agent，然后 `Bash: sleep 110` 连等 13 轮。每轮 sleep 收尾都是一次 mid-turn fold，把期间到达的通知全部吃掉。
+
+**衍生三条**：
+1. **别紧接着 `AskUserQuestion`**：派完后台 agent 就抛问题给用户等答复，该期间到达的通知实测 18 例全丢。
+2. **别用 `TaskOutput` 取产物**：官方已标弃用（替代方案是 `Read` 任务输出文件路径），且上游有未修 bug——对 local_agent 调 `TaskOutput(block=true)` 会把整个 JSONL transcript 灌进调用方上下文。
+3. **「没收到通知」≠「agent 零产出」**：通知丢失时主 agent 上下文里确实没产物，容易据此向用户汇报"这几路等于零产出"。这是**基于错误前提的正向汇报**，比空等更糟——用户不追问就会接受错误结论（已踩两次）。汇报前先查 transcript 末条 assistant（`~/.claude/projects/<项目>/<session>/subagents/agent-<id>.jsonl`），只提取 text 块、不 `Read` 整个 `.output`（那是完整 JSONL，会撑爆上下文）。要求「渐进产出」的子 agent 分多段输出，末段可能只是报告尾部，需全文时拼接全部 assistant 段落。
+
+**未验证边界**：折叠出的 `isMeta:true` attachment 是完全不进 API 请求，还是进了被当背景噪声忽略——未能区分，需抓主循环真实请求体才能定。对本铁律无影响（后果一样：模型不知情），但对上游是两个不同修法。
 
 ## 铁律①的技术边界
 

--- a/plugins/dispatch-contract/skills/subagent-dispatch/references/mailbox-liveness.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/references/mailbox-liveness.md
@@ -2,7 +2,7 @@
 
 本文件管 **teammate / mailbox 通道**：产物怎么经 mailbox 收回、活性怎么判、什么时候能停。触发场景：spawn background teammate 后等待产物，或考虑 TaskStop 中止某 agent 时。
 
-**边界（先读这条，别找错文件）**：本文件的前提是"产物走 mailbox"——**只在传了 `name`（即提升为 teammate）时成立**。普通 background agent（不传 `name`）的完成通知自带完整产物正文、走 task-notification 队列，与 mailbox 无关；那条链路的投递可靠性、为什么通知会被中途折叠吃掉、以及"派完该怎么等"，见 `dispatch-contract.md` 的「己方端纪律：派完就交还主循环」章节。两者是不同机制，别混。
+**边界（先读这条，别找错文件）**：本文件的前提是"产物走 mailbox"——**只在传了 `name`（即提升为 teammate）时成立**。不传 `name` 的普通 background agent 走的是完成通知，与 mailbox 无关；那条链路的等待纪律与取产物方式见 `dispatch-contract.md` 的「己方端纪律：派完就交还主循环」。两者是不同机制，别混。
 
 来源：一次真实事故——三个 background subagent 被误判卡死并 TaskStop，事后全部复活并发来完整产物。根因是「回传通道断裂」+「等待模型错误」两个叠加，非 agent 真死。
 

--- a/plugins/dispatch-contract/skills/subagent-dispatch/references/mailbox-liveness.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/references/mailbox-liveness.md
@@ -39,10 +39,89 @@
 **正确等待手段**：
 - 需要结果才能往下走 → 用同步派发（解法优先级 #1），别 spawn 后轮询。
 - 必须异步 → 依赖完成通知 / mailbox 事件被下一 turn 唤醒，**不要中途凭文件状态抢跑 TaskStop**。
+- **派完就结束本轮**，把主循环交还空闲态等唤起。别用 `sleep` 占着主循环——除了浪费墙上时间，它还会让通知走进下节那条会被吃掉的路径。
+
+**上游官方立场（2.1.220 二进制内 Agent 工具描述原文，非社区转述）**：
+
+> Agents run in the background by default. When an agent runs in the background, you will be automatically notified when it completes — do NOT sleep, poll, or proactively check on its progress. Continue with other work or respond to the user instead.
+
+Bash 工具描述同版原文：
+
+> Foreground `sleep` is blocked; use Monitor with an until-loop to wait on a condition.
+
+拦截文案另写明 `Do not chain shorter sleeps to work around this block.`。即"sleep 等 subagent"本就是上游明令禁止的用法，本纪律与其同向，不是本地独创。
+
+注：该拦截并非在所有环境都实际生效（本地 2.1.220 实测 `sleep 3` 仍放行），所以它拦不住你，**纪律仍须自觉遵守**。
 
 **TaskStop 是不可逆动作**：套铁律④同源标准——不凭推断的卡死判断拍板。真正的死有客观兜底（框架 watchdog 对无进展达阈值判失败），不靠主 agent 用文件轮询猜。
 
 **不确定性诚实**：不能 100% 排除某次真有网络 / CLI 挂起（部分后端延迟方差大，实测 26s ~ >120s）。但存疑时**倾向再等一个完成信号 / 一个 turn**，判死门槛设高——宁可多等一 turn，不可错杀一个正在干活的 agent。本纪律的经验来源：被判死并 TaskStop 的三个 agent 事后全部复活并交出完整产物。
+
+## 完成通知会被"中途折叠"吃掉（机制级，解释为什么优先级 #1 是同步）
+
+这是"能同步就同步"的**机制层理由**，也是上节"派完就结束本轮"的根据。本地 2.1.220 实测 + 二进制代码互证。
+
+**机制**：完成通知先入命令队列，消费分两条路——
+
+| 主循环状态 | 队列动作 | 结果 |
+|---|---|---|
+| 空闲 | `dequeue` | 落成真正的 `user` 消息，模型必定看见 |
+| 正在跑工具（mid-turn） | **`remove`** | 只落一条 `attachment/queued_command`，`origin` 兜底为 `{kind:"task-notification"}` 并打 `isMeta:true`，随后从队列移除 |
+
+二进制里这段是 query 主循环在每批工具结果后做的 mid-turn fold：`registerFoldInFlight(dn)` → 渲染 attachment → `messageQueue.remove(Jr)`。
+
+**实测数据**（本地 383 个 session 全量扫描，仅统计 subagent 通知）：
+
+| 通知到达时主循环 | 送达 | 丢失 | 丢失率 |
+|---|---|---|---|
+| 有工具在飞 | 11 | 139 | **92.7%** |
+| 空闲 | 690 | 91 | 11.7% |
+
+按通知正文哈希精确配对 `remove` 事件（不靠代理指标）：内容出现在 `remove` 里的 430 例丢失率 **95.3%**，未出现的 1124 例 23.4%。
+
+**在飞工具排名**：`TaskOutput` 80、`Bash` 35（其中 `sleep` 26）、`AskUserQuestion` 18、`Agent` 5。
+
+**按后果分类**（关键区分，别一刀切）：
+- **良性**：`TaskOutput` 那 80 例中 75 例是在轮询它自己等的那个 task，其中 70 例产物经 tool_result 正常回来了——通知被吃但产物没丢。
+- **有害**：`Bash`(35，sleep 占 26)、`AskUserQuestion`(18)、`TaskOutput` 轮询别的 task(5)、`Agent`(5)、`TaskStop`(1)。这些丢了就是净丢失。
+
+**没有恢复通道**：`remove` 是终态。实测 28 例"丢失后用 `SendMessage` 续跑该 agent"，那条通知仍未送达（SendMessage 开的是新一轮，不补发旧通知）。兜底只能读 transcript（见下节）。
+
+**推论（这才是纪律的根据）**：
+1. 同步派发（`run_in_background:false`）的产物走 tool_result，**根本不进这个队列**——没有通知，就没有丢通知。这是从根上消除问题，不是打补丁。
+2. `AskUserQuestion` 期间到达的通知会丢（18 例全丢）。派完后台 agent 后**不要紧接着抛问题给用户等答复**。
+3. 别用 `TaskOutput` 取产物：官方文档已标其弃用（替代方案是 `Read` 任务输出文件路径），且上游有未修 bug——对 local_agent 调 `TaskOutput(block=true)` 会把整个 JSONL transcript 灌进上下文。
+
+**未验证边界（诚实标注）**：折叠出的 `isMeta:true` attachment 究竟是完全不进 API 请求，还是进了但被模型当背景噪声忽略——未能区分，需抓主循环真实请求体才能定。对上述纪律无影响（后果一样：模型不知情），但对上游是两个不同修法。
+
+## 别把"没收到通知"当成"agent 零产出"
+
+上一节的直接推论，独立成节因为它是**汇报正确性**问题，不只是效率问题。
+
+通知丢失时，主 agent 的上下文里确实没有产物——于是容易得出"这几路等于零产出"并据此向用户汇报。这是**基于错误前提的正向汇报**，比空等更糟：用户若不追问就会接受这个错误结论。已知踩过两次。
+
+**汇报前自查**（不读 `.output`，避免撑爆上下文）：
+
+```bash
+# 末条 assistant 文本即该 subagent 的最终产物
+python3 - <<'PY'
+import json,sys
+p="<项目>/<session-id>/subagents/agent-<agentId>.jsonl"   # ~/.claude/projects/ 下
+last=None
+for line in open(p):
+    try: d=json.loads(line)
+    except: continue
+    if d.get("type")!="assistant": continue
+    c=(d.get("message") or {}).get("content") or []
+    t="".join(b.get("text","") for b in c if isinstance(b,dict) and b.get("type")=="text")
+    if t.strip(): last=t
+print(last[:2000] if last else "(no assistant text)")
+PY
+```
+
+要求「渐进产出」的 subagent 会分多段输出，末段可能只是报告尾部——需要全文时拼接全部 assistant 段落，别只取末段。
+
+**该措施的代价**：产物未经框架侧收尾校验，且绕过了工具描述"不要读 `.output`"的契约（这里只提末条 text、不 `Read` 整个文件，属可控折中）。**不应固化为常规取产物手段**——常规路径是同步派发。
 
 ## 二进制实证（deferred 机制，标确定性）
 

--- a/plugins/dispatch-contract/skills/subagent-dispatch/references/mailbox-liveness.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/references/mailbox-liveness.md
@@ -1,6 +1,8 @@
 # 回传通道与活性判定（background subagent 派发后）
 
-本文件管"派发之后"：产物怎么收回、活性怎么判、什么时候能停。与 dispatch-contract.md（派发前怎么写 prompt）互补。触发场景：spawn background subagent / teammate 后等待产物，或考虑 TaskStop 中止某 agent 时。
+本文件管 **teammate / mailbox 通道**：产物怎么经 mailbox 收回、活性怎么判、什么时候能停。触发场景：spawn background teammate 后等待产物，或考虑 TaskStop 中止某 agent 时。
+
+**边界（先读这条，别找错文件）**：本文件的前提是"产物走 mailbox"——**只在传了 `name`（即提升为 teammate）时成立**。普通 background agent（不传 `name`）的完成通知自带完整产物正文、走 task-notification 队列，与 mailbox 无关；那条链路的投递可靠性、为什么通知会被中途折叠吃掉、以及"派完该怎么等"，见 `dispatch-contract.md` 的「己方端纪律：派完就交还主循环」章节。两者是不同机制，别混。
 
 来源：一次真实事故——三个 background subagent 被误判卡死并 TaskStop，事后全部复活并发来完整产物。根因是「回传通道断裂」+「等待模型错误」两个叠加，非 agent 真死。
 
@@ -39,89 +41,10 @@
 **正确等待手段**：
 - 需要结果才能往下走 → 用同步派发（解法优先级 #1），别 spawn 后轮询。
 - 必须异步 → 依赖完成通知 / mailbox 事件被下一 turn 唤醒，**不要中途凭文件状态抢跑 TaskStop**。
-- **派完就结束本轮**，把主循环交还空闲态等唤起。别用 `sleep` 占着主循环——除了浪费墙上时间，它还会让通知走进下节那条会被吃掉的路径。
-
-**上游官方立场（2.1.220 二进制内 Agent 工具描述原文，非社区转述）**：
-
-> Agents run in the background by default. When an agent runs in the background, you will be automatically notified when it completes — do NOT sleep, poll, or proactively check on its progress. Continue with other work or respond to the user instead.
-
-Bash 工具描述同版原文：
-
-> Foreground `sleep` is blocked; use Monitor with an until-loop to wait on a condition.
-
-拦截文案另写明 `Do not chain shorter sleeps to work around this block.`。即"sleep 等 subagent"本就是上游明令禁止的用法，本纪律与其同向，不是本地独创。
-
-注：该拦截并非在所有环境都实际生效（本地 2.1.220 实测 `sleep 3` 仍放行），所以它拦不住你，**纪律仍须自觉遵守**。
 
 **TaskStop 是不可逆动作**：套铁律④同源标准——不凭推断的卡死判断拍板。真正的死有客观兜底（框架 watchdog 对无进展达阈值判失败），不靠主 agent 用文件轮询猜。
 
 **不确定性诚实**：不能 100% 排除某次真有网络 / CLI 挂起（部分后端延迟方差大，实测 26s ~ >120s）。但存疑时**倾向再等一个完成信号 / 一个 turn**，判死门槛设高——宁可多等一 turn，不可错杀一个正在干活的 agent。本纪律的经验来源：被判死并 TaskStop 的三个 agent 事后全部复活并交出完整产物。
-
-## 完成通知会被"中途折叠"吃掉（机制级，解释为什么优先级 #1 是同步）
-
-这是"能同步就同步"的**机制层理由**，也是上节"派完就结束本轮"的根据。本地 2.1.220 实测 + 二进制代码互证。
-
-**机制**：完成通知先入命令队列，消费分两条路——
-
-| 主循环状态 | 队列动作 | 结果 |
-|---|---|---|
-| 空闲 | `dequeue` | 落成真正的 `user` 消息，模型必定看见 |
-| 正在跑工具（mid-turn） | **`remove`** | 只落一条 `attachment/queued_command`，`origin` 兜底为 `{kind:"task-notification"}` 并打 `isMeta:true`，随后从队列移除 |
-
-二进制里这段是 query 主循环在每批工具结果后做的 mid-turn fold：`registerFoldInFlight(dn)` → 渲染 attachment → `messageQueue.remove(Jr)`。
-
-**实测数据**（本地 383 个 session 全量扫描，仅统计 subagent 通知）：
-
-| 通知到达时主循环 | 送达 | 丢失 | 丢失率 |
-|---|---|---|---|
-| 有工具在飞 | 11 | 139 | **92.7%** |
-| 空闲 | 690 | 91 | 11.7% |
-
-按通知正文哈希精确配对 `remove` 事件（不靠代理指标）：内容出现在 `remove` 里的 430 例丢失率 **95.3%**，未出现的 1124 例 23.4%。
-
-**在飞工具排名**：`TaskOutput` 80、`Bash` 35（其中 `sleep` 26）、`AskUserQuestion` 18、`Agent` 5。
-
-**按后果分类**（关键区分，别一刀切）：
-- **良性**：`TaskOutput` 那 80 例中 75 例是在轮询它自己等的那个 task，其中 70 例产物经 tool_result 正常回来了——通知被吃但产物没丢。
-- **有害**：`Bash`(35，sleep 占 26)、`AskUserQuestion`(18)、`TaskOutput` 轮询别的 task(5)、`Agent`(5)、`TaskStop`(1)。这些丢了就是净丢失。
-
-**没有恢复通道**：`remove` 是终态。实测 28 例"丢失后用 `SendMessage` 续跑该 agent"，那条通知仍未送达（SendMessage 开的是新一轮，不补发旧通知）。兜底只能读 transcript（见下节）。
-
-**推论（这才是纪律的根据）**：
-1. 同步派发（`run_in_background:false`）的产物走 tool_result，**根本不进这个队列**——没有通知，就没有丢通知。这是从根上消除问题，不是打补丁。
-2. `AskUserQuestion` 期间到达的通知会丢（18 例全丢）。派完后台 agent 后**不要紧接着抛问题给用户等答复**。
-3. 别用 `TaskOutput` 取产物：官方文档已标其弃用（替代方案是 `Read` 任务输出文件路径），且上游有未修 bug——对 local_agent 调 `TaskOutput(block=true)` 会把整个 JSONL transcript 灌进上下文。
-
-**未验证边界（诚实标注）**：折叠出的 `isMeta:true` attachment 究竟是完全不进 API 请求，还是进了但被模型当背景噪声忽略——未能区分，需抓主循环真实请求体才能定。对上述纪律无影响（后果一样：模型不知情），但对上游是两个不同修法。
-
-## 别把"没收到通知"当成"agent 零产出"
-
-上一节的直接推论，独立成节因为它是**汇报正确性**问题，不只是效率问题。
-
-通知丢失时，主 agent 的上下文里确实没有产物——于是容易得出"这几路等于零产出"并据此向用户汇报。这是**基于错误前提的正向汇报**，比空等更糟：用户若不追问就会接受这个错误结论。已知踩过两次。
-
-**汇报前自查**（不读 `.output`，避免撑爆上下文）：
-
-```bash
-# 末条 assistant 文本即该 subagent 的最终产物
-python3 - <<'PY'
-import json,sys
-p="<项目>/<session-id>/subagents/agent-<agentId>.jsonl"   # ~/.claude/projects/ 下
-last=None
-for line in open(p):
-    try: d=json.loads(line)
-    except: continue
-    if d.get("type")!="assistant": continue
-    c=(d.get("message") or {}).get("content") or []
-    t="".join(b.get("text","") for b in c if isinstance(b,dict) and b.get("type")=="text")
-    if t.strip(): last=t
-print(last[:2000] if last else "(no assistant text)")
-PY
-```
-
-要求「渐进产出」的 subagent 会分多段输出，末段可能只是报告尾部——需要全文时拼接全部 assistant 段落，别只取末段。
-
-**该措施的代价**：产物未经框架侧收尾校验，且绕过了工具描述"不要读 `.output`"的契约（这里只提末条 text、不 `Read` 整个文件，属可控折中）。**不应固化为常规取产物手段**——常规路径是同步派发。
 
 ## 二进制实证（deferred 机制，标确定性）
 


### PR DESCRIPTION
## 背景

排查一起「5 路 background subagent 全部跑完、主 session 零通知、连等 13 轮 sleep」的事故，定位到根因后把纪律落进 `subagent-dispatch` skill。

原诊断记录把 `result` 事件缺失当核心证据，该判据不成立——本机 383 个 session 全量扫描确认，900+ 次**投递成功**的 subagent 同样 `result=0`（2.1.220 的 local_agent 就不写 `result`），该字段零区分度。

## 根因：完成通知被 mid-turn fold 吃掉

普通 background agent 的完成通知**自带完整产物正文**（实测 5 条各带 8414~14593 字符的 `<result>`），走 task-notification 队列。该队列消费分两条路：

| 通知到达时主循环 | 队列动作 | 结果 |
|---|---|---|
| 空闲 | `dequeue` | 落成真正的 `user` 消息，模型必定看见 |
| 正在跑工具 | **`remove`** | 只落 `attachment/queued_command`（`isMeta:true`）后从队列移除 |

二进制侧对应 query 主循环在每批工具结果后的 mid-turn fold：`registerFoldInFlight` → 渲染 attachment → `messageQueue.remove(Jr)`。

**实测**（仅统计 subagent 通知）：

- 有工具在飞时到达：丢失 **92.7%**（139/150）
- 空闲时到达：丢失 11.7%（91/781）
- 按通知正文哈希精确配对 `remove` 事件（不靠代理指标）：**95.3%** vs 23.4%

`remove` 是终态，无恢复通道——实测 28 例「丢失后 `SendMessage` 续跑」那条通知仍未送达。

## 变更内容

新增章节落在 `references/dispatch-contract.md` 的己方端纪律区，紧随铁律④（同族：都拒绝凭不可靠信号抢跑不可逆动作）：

1. **等待纪律** — 需要产物才能往下走就 `run_in_background:false`；真要后台并行则派完就结束本轮、交还主循环空闲态。附上游 2.1.220 二进制内 Agent 工具描述原文（`do NOT sleep, poll, or proactively check on its progress`）与 Bash 的 `Foreground sleep is blocked`，说明本纪律与官方同向而非本地独创；并诚实注明该拦截未必在所有环境生效（本地 `sleep 3` 实测仍放行）。
2. **衍生三条** — 别紧接着 `AskUserQuestion`（该期间到达的通知实测 18 例全丢）；别用 `TaskOutput` 取产物（官方已标弃用，替代方案是 `Read` 输出文件路径，且对 local_agent 会灌入整个 JSONL transcript）；「没收到通知」≠「agent 零产出」（附不读 `.output` 的 transcript 自查方式）。

**刻意不编为「铁律⑤」**：全局 CLAUDE.md 定义四铁律是「钉进每次派发的 prompt」的派发端约束，本节约束主 agent 自己、不进任何 prompt，编号会造成概念混淆。

## 为什么没放 mailbox-liveness.md

第一版曾放在那儿，是放错了。`mailbox-liveness.md` 的前提是「产物走 mailbox」——**只在传了 `name`（提升为 teammate）时成立**；而本 PR 处理的是普通 background agent 的通知队列，与 `SendMessage`/deferred/活性判定都是不同机制。混在一处会让读者为查 mailbox 通道进来、撞见大段无关的队列机制。

第二个 commit 已把 `mailbox-liveness.md` 回退到原状，仅在开头加了边界声明指向正确位置；`SKILL.md` 摘要表也按「一切 background 派发」与「仅 teammate/mailbox」分成两组并加了别混提示。

## 诚实标注的未验证边界

折叠出的 `isMeta:true` attachment 是完全不进 API 请求，还是进了但被模型当背景噪声忽略——未能区分，需抓主循环真实请求体才能定（本机 `logs/payloads/` 只存 exitplanmode 快照）。对本 PR 的纪律无影响（后果一样：模型不知情），但对上游是两个不同修法。已在文中标注。

## 测试

- `plugin.json` / `hooks.json` JSON 合法性通过
- `bats tests/subagent-done-gate.bats` **26 项全绿**
- 门禁脚本与 hook 行为零改动，本 PR 只动 skill 文档 + 版本号

## 版本

`dispatch-contract` 1.0.0 → 1.1.0
