### PR TITLE
feat(dispatch-contract): 后台派发门禁 + 规则注入 (#160)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -84,8 +84,8 @@
     },
     {
       "name": "dispatch-contract",
-      "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop)",
-      "version": "1.0.0",
+      "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop) + background-dispatch sync guard (PreToolUse) + dispatch-rules injection (SubagentStart)",
+      "version": "1.2.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/dispatch-contract/.claude-plugin/plugin.json
+++ b/plugins/dispatch-contract/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dispatch-contract",
-  "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop)",
-  "version": "1.0.0",
+  "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop) + background-dispatch sync guard (PreToolUse) + dispatch-rules injection (SubagentStart)",
+  "version": "1.2.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/subagent-dispatch"]
 }

--- a/plugins/dispatch-contract/README.md
+++ b/plugins/dispatch-contract/README.md
@@ -2,7 +2,7 @@
 
 Subagent dispatch contract enforcement for Claude Code — a `%%DONE%%` finalization gate plus a methodology skill for reliable subagent delegation.
 
-The plugin has two parts: a **SubagentStop hook** that enforces the `%%DONE%%` finalization marker when it is declared in the dispatch prompt, and a **`subagent-dispatch` skill** that inlines the four dispatch rules, offload-scenario guidance, and background-subagent patterns on demand.
+The plugin has four parts: a **PreToolUse hook** that blocks dispatch calls omitting `run_in_background:false`, a **SubagentStart hook** that injects the dispatch rules into every spawned subagent, a **SubagentStop hook** that enforces the `%%DONE%%` finalization marker when it is declared in the dispatch prompt, and a **`subagent-dispatch` skill** that inlines the four dispatch rules, offload-scenario guidance, and background-subagent patterns on demand.
 
 ## Installation
 
@@ -14,7 +14,29 @@ claude plugin add dispatch-contract@WooDragon-cc-plugins
 ## Architecture
 
 ```
-SubagentStop
+PreToolUse (matcher: Agent, Task)
+  │
+  └─ dispatch-sync-guard.sh (5s timeout)
+         Blocks a dispatch call that omits run_in_background:false.
+         Omission selects the background delivery channel, and that channel
+         drops completion notifications at a measured 92.7% loss rate with
+         no resend path. Passes silently (fail-open) on teammate context
+         (agent_id present), Lead-starts-a-teammate calls (tool_input.name
+         present), the CLAUDE_CODE_DISABLE_BACKGROUND_TASKS env var, and any
+         malformed or missing payload field.
+
+SubagentStart (matcher: *)
+  │
+  └─ dispatch-rules-inject.sh (5s timeout)
+         Injects the three dispatch rules — output-is-deliverable, scope
+         fence, incremental progress — into the spawned subagent's own
+         context via additionalContext, regardless of whether the dispatch
+         prompt stated them. Read-only agent types (Explore, Plan) receive
+         only the output-is-deliverable and incremental-progress rules; the
+         scope-fence rule is a no-op for agent types whose Edit/Write tools
+         are already disabled by the platform.
+
+SubagentStop (matcher: *)
   │
   └─ subagent-done-gate.sh (10s timeout)
          Checks whether the dispatch prompt contained %%DONE%%.
@@ -29,10 +51,11 @@ skills/subagent-dispatch  (no hook — loaded by description match)
          contract is reachable at dispatch time rather than only after a block.
 ```
 
-This plugin registers exactly one hook, on `SubagentStop`. There is no dispatch-side
-hook: deciding whether a given task needs a deliverable is a semantic judgment, and a
-keyword guess would misfire often enough to be ignored. The skill closes that gap
-instead.
+This plugin registers three hooks: `PreToolUse` (dispatch-sync-guard),
+`SubagentStart` (dispatch-rules-inject), and `SubagentStop` (subagent-done-gate).
+There is no dispatch-side hook that guesses whether a given task needs a
+`%%DONE%%` deliverable — that judgment is semantic, and a keyword guess would
+misfire often enough to be ignored. The skill closes that gap instead.
 
 ## The `%%DONE%%` Contract
 
@@ -81,6 +104,70 @@ Set this before starting the Claude Code session to disable the gate globally. U
 - If the dispatch prompt contains `%%DONE%%` anywhere (even in a negated or illustrative context), the gate activates. Misfire direction is one extra block, which self-heals because the retry passes unconditionally.
 - The gate blocks at most once per subagent. If the corrected output still misses the marker, it is let through — the gate does not loop.
 
+## The Background-Dispatch Sync Guard
+
+`dispatch-sync-guard.sh` runs on `PreToolUse` for `Agent` and `Task` calls. It reads
+only the fields carried by the dispatch call itself — never session state or prior
+turns — and applies this decision chain, each step fail-opening before the next runs:
+
+1. Empty stdin → pass.
+2. `jq` unavailable → pass.
+3. `jq .` fails to parse the payload → pass.
+4. `ALLOW_BACKGROUND_DISPATCH=1` → pass (escape hatch).
+5. `tool_name` is not `Agent` or `Task` → pass.
+6. `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` is set → pass.
+7. `agent_id` is present and non-blank → pass (teammate context).
+8. `tool_input.name` is present and non-blank → pass (Lead starting a teammate).
+9. `tool_input.run_in_background` is the JSON boolean `false` → pass.
+10. Otherwise → block (exit 2) with a four-line stderr correction.
+
+Step 6 checks whether `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` is set, not whether
+`run_in_background` is present, because Agent's own input schema omits the
+`run_in_background` field entirely when this variable is truthy — every dispatch is
+synchronous by construction in that mode, and judging the omission as a violation
+would misfire on every call.
+
+Step 7 distinguishes a genuinely-absent `agent_id` field from a field that is present
+but blank, using the same field-presence check pattern as `subagent-done-gate.sh`'s
+handling of `last_assistant_message`. The distinction matters because a teammate
+context is physically forbidden from requesting background dispatch by the runtime
+itself; when `agent_id` is present, background dispatch was never going to happen
+regardless of this hook, so blocking it would be a false positive.
+
+Step 8 is load-bearing for team-ops: a non-empty `tool_input.name` is the only entry
+point for starting a teammate. Removing this step would block Lead from starting any
+teammate.
+
+**Known boundary**: the Agent input schema also omits `run_in_background` when a
+server-side rollout flag (internally named `tengu_copper_fox`) is active, independent
+of `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`. This hook has no reliable way to detect that
+flag from the `PreToolUse` payload — its on-disk cache and live runtime value have
+been observed to disagree. The hook leaves this case unguarded on purpose: when the
+flag is active, the field is omitted because the background channel does not exist in
+that runtime, so the notification-loss risk this hook exists to prevent is already
+zero. A misfire in this case blocks a harmless call rather than letting a real drop
+recur, and the escape hatch (`ALLOW_BACKGROUND_DISPATCH=1` in `settings.json`'s `env`
+section) resolves it.
+
+## The SubagentStart Rules Injector
+
+`dispatch-rules-inject.sh` runs on `SubagentStart` for every spawned subagent
+(`matcher: "*"`). It writes `additionalContext` carrying the three dispatch rules
+(output-is-deliverable, scope fence, incremental progress) plus a pointer to the
+`subagent-dispatch` skill, so the rules reach the subagent even when the dispatching
+prompt omitted them.
+
+Agent types with Edit/Write disabled by the platform (`Explore`, `Plan`, matched
+case-insensitively) receive only the output-is-deliverable and incremental-progress
+rules — the scope-fence rule's file-boundary wording would be a no-op reminder for a
+type that cannot write files at all.
+
+The hook writes stdout exactly once, in a single statement at the end of the script.
+Every fail-open path (empty stdin, no `jq`, unparsable JSON,
+`ALLOW_NO_RULES_INJECT=1`) exits before that statement with no stdout output at all —
+a half-formed JSON payload on stdout would corrupt the harness's parse of the hook
+output, so an empty stdout is the safe default on any early exit.
+
 ## `subagent-dispatch` Skill
 
 The bundled skill covers:
@@ -99,12 +186,30 @@ The skill triggers on dispatch-related requests: "派发 subagent", "dispatch su
 ```bash
 # Requires bats-core
 bats plugins/dispatch-contract/tests/subagent-done-gate.bats
+bats plugins/dispatch-contract/tests/dispatch-sync-guard.bats
 ```
 
-26 test cases covering: core judgment (marker required/not required in the dispatch prompt), `fork-context-ref` transcript shape, in-band signaling defence (a subagent cannot open its own gate), whitespace and CRLF tolerance, decoration variants that must still block (bold, backticks, trailing punctuation), blank final message treated as an empty deliverable rather than fail-open, fail-open paths (missing fields, `last_assistant_message` null, invalid JSON, empty stdin, absent transcript path, `stop_hook_active`), hostile paths (`HOME` unset, FIFO must not hang), and the kill switch.
+`subagent-done-gate.bats` has 26 test cases covering: core judgment (marker
+required/not required in the dispatch prompt), `fork-context-ref` transcript shape,
+in-band signaling defence (a subagent cannot open its own gate), whitespace and CRLF
+tolerance, decoration variants that must still block (bold, backticks, trailing
+punctuation), blank final message treated as an empty deliverable rather than
+fail-open, fail-open paths (missing fields, `last_assistant_message` null, invalid
+JSON, empty stdin, absent transcript path, `stop_hook_active`), hostile paths (`HOME`
+unset, FIFO must not hang), and the kill switch.
+
+`dispatch-sync-guard.bats` covers both new hooks: the sync-guard's pass/block matrix
+(explicit `false`, omission, explicit `true`, string `"false"`, `tool_name` outside
+`{Agent, Task}`, the `agent_id` and `tool_input.name` exemptions including an
+empty-string `agent_id` that must still block, the two escape hatches, and three
+malformed-stdin shapes), plus the rules-injector's JSON-shape checks (normal
+`agent_type` gets all three rules, `Explore` omits the scope-fence rule, empty stdin
+and `ALLOW_NO_RULES_INJECT=1` both leave stdout fully empty).
 
 ## Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ALLOW_UNMARKED_FINAL` | _(unset)_ | `1` disables the gate entirely |
+| `ALLOW_UNMARKED_FINAL` | _(unset)_ | `1` disables the `%%DONE%%` finalization gate entirely |
+| `ALLOW_BACKGROUND_DISPATCH` | _(unset)_ | `1` disables the background-dispatch sync guard entirely — set in `settings.json`'s `env` section, since `export` in a Bash tool call does not reach the hook process |
+| `ALLOW_NO_RULES_INJECT` | _(unset)_ | `1` disables the SubagentStart rules injector entirely |

--- a/plugins/dispatch-contract/README.md
+++ b/plugins/dispatch-contract/README.md
@@ -206,6 +206,20 @@ malformed-stdin shapes), plus the rules-injector's JSON-shape checks (normal
 `agent_type` gets all three rules, `Explore` omits the scope-fence rule, empty stdin
 and `ALLOW_NO_RULES_INJECT=1` both leave stdout fully empty).
 
+## Block Response Shape (Deliberate Choice)
+
+Both hooks in this plugin — `dispatch-sync-guard.sh` (PreToolUse) and
+`subagent-done-gate.sh` (SubagentStop) — block via `exit 2` plus a stderr
+message. Some sibling plugins in this repo use a different shape instead:
+`plan-review`'s `dispatch-check.sh` and `doc-gate`'s `skill-gate.sh` return
+JSON `permissionDecision: deny`. This repo does not use one block-response
+shape across all plugins — `guardrails`' `git-push-guard.sh` also blocks via
+`exit 2`. Within this plugin, consistency with the sibling
+`subagent-done-gate.sh` hook takes priority over matching an unrelated
+plugin's shape. The two forms are functionally equivalent here. The runtime
+routes the `exit 2` stderr text through `blockingError` into the tool result
+the model sees. The correction message reaches model context either way.
+
 ## Environment Variables
 
 | Variable | Default | Description |

--- a/plugins/dispatch-contract/hooks/dispatch-rules-inject.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-rules-inject.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SubagentStart hook (matcher: *): inject the dispatch rules directly into
+# the subagent's OWN context, so enforcement does not depend on whether the
+# dispatching prompt happened to spell them out. This is a belt-and-suspenders
+# complement to the dispatch-side prompt convention documented in the
+# subagent-dispatch skill — the skill only helps when the dispatcher
+# remembers to write the rules; this hook makes the rules land regardless.
+#
+# Output shape (stdout, must be the only stdout write in the whole script):
+#   {"hookSpecificOutput":{"hookEventName":"SubagentStart","additionalContext":"<rules text>"}}
+#
+# Injected text is deliberately terse — SubagentStart fires once per spawned
+# subagent, and with N-way parallel dispatch the same block gets paid for N
+# times in aggregate context; full positive/negative examples belong in the
+# skill, not in every subagent's startup context.
+#
+# Tiering by agent_type: read-only agent types (Explore, Plan — case
+# insensitive) have Edit/Write physically disabled by the platform, so
+# injecting rule ②'s "only touch the files you were told to" wording would
+# be a no-op admonition about a constraint that already can't be violated.
+# Those types get rules ① and ③ plus the skill pointer only; every other
+# agent_type gets all three rules.
+#
+# stdout purity (hard constraint — this hook's payload is parsed as JSON by
+# the harness, any stray byte on stdout corrupts it):
+#   - every non-payload message in this script goes to stderr (>&2)
+#   - every intermediate command that could write to stdout is redirected to
+#     /dev/null explicitly
+#   - the JSON payload is built with `jq -n`, never hand-assembled string
+#     concatenation — the rules text below contains no user-controlled bytes
+#     today, but constructing it any other way would be one edit away from a
+#     quoting bug corrupting the emitted JSON
+#   - the ONE stdout write happens in a single statement at the very end of
+#     the script; every earlier exit path is `exit 0` with no stdout write at
+#     all — on any fail-open path this hook would rather inject nothing than
+#     emit a half-formed JSON object
+#
+# Escape hatch: ALLOW_NO_RULES_INJECT=1 -> silent exit 0, no injection.
+#
+# Fail-open conditions (exit 0, stdout empty): empty stdin, no jq, `jq .`
+# parse failure, missing/blank agent_type field is NOT fail-open by itself —
+# agent_type absent is treated as "not a known read-only type" and gets the
+# full three-rule injection, since the safer default when we can't identify
+# the type is to inject the file-scope reminder rather than omit it.
+set -u
+
+INPUT=$(cat)
+[ -z "$INPUT" ] && exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+jq . >/dev/null 2>&1 <<< "$INPUT" || exit 0
+
+[[ "${ALLOW_NO_RULES_INJECT:-}" == "1" ]] && exit 0
+
+AGENT_TYPE=$(jq -r '.agent_type // empty' <<< "$INPUT" 2>/dev/null) || exit 0
+AGENT_TYPE_LC=$(printf '%s' "$AGENT_TYPE" | tr '[:upper:]' '[:lower:]')
+
+RULE1='[dispatch-contract] 铁律①输出即产物：最终返回消息本身就是产物，禁止写完成说明或元总结。'
+RULE2='[dispatch-contract] 铁律②范围围栏：只改指定文件/只做指定事，范围外只报告不擅动。'
+RULE3='[dispatch-contract] 铁律③渐进产出：长任务分段读、尽早吐中间进展。'
+POINTER='[dispatch-contract] 详规见 Skill(subagent-dispatch)。'
+
+case "$AGENT_TYPE_LC" in
+  explore|plan)
+    CONTEXT=$(printf '%s\n%s\n%s' "$RULE1" "$RULE3" "$POINTER")
+    ;;
+  *)
+    CONTEXT=$(printf '%s\n%s\n%s\n%s' "$RULE1" "$RULE2" "$RULE3" "$POINTER")
+    ;;
+esac
+
+jq -n \
+  --arg ctx "$CONTEXT" \
+  '{hookSpecificOutput:{hookEventName:"SubagentStart",additionalContext:$ctx}}' 2>/dev/null

--- a/plugins/dispatch-contract/hooks/dispatch-rules-inject.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-rules-inject.sh
@@ -72,4 +72,4 @@ esac
 
 jq -n \
   --arg ctx "$CONTEXT" \
-  '{hookSpecificOutput:{hookEventName:"SubagentStart",additionalContext:$ctx}}' 2>/dev/null
+  '{hookSpecificOutput:{hookEventName:"SubagentStart",additionalContext:$ctx}}' 2>/dev/null || exit 0

--- a/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
@@ -124,7 +124,7 @@ NAME=$(jq -r '.tool_input.name // empty' <<< "$INPUT" 2>/dev/null) || exit 0
 
 jq -e '.tool_input.run_in_background == false' <<< "$INPUT" >/dev/null 2>&1 && exit 0
 
-printf '[dispatch-sync-guard] 省略 run_in_background 即选择后台通道：完成通知在主循环正跑工具时到达会被丢弃，实测丢失率 92.7%%，且无补发、无恢复通道（SendMessage 续跑不补发旧通知）。\n' >&2
+printf '[dispatch-sync-guard] run_in_background 被省略、显式设为 true、或传入非布尔值时都会选中后台通道：完成通知在主循环正跑工具时到达会被丢弃，实测丢失率 92.7%%，且无补发、无恢复通道（SendMessage 续跑不补发旧通知）。\n' >&2
 printf '[dispatch-sync-guard] 需要产物才能往下走 → 加 run_in_background:false 重派，产物走 tool_result，根本不进那个会被折叠吃掉的队列。真要后台并行 → 派完立刻结束本轮交还主循环，禁止 sleep/轮询/紧接 AskUserQuestion。\n' >&2
 printf '[dispatch-sync-guard] 确需后台：在 ~/.claude/settings.json 的 env 段加 "ALLOW_BACKGROUND_DISPATCH":"1"（Bash 里 export 传不进 hook 进程）。\n' >&2
 printf '[dispatch-sync-guard] 若本机所有派发都被本门禁拦下，是 fork-subagent 特性（tengu_copper_fox）已开启、run_in_background 从 schema 中移除所致。此时后台通道本不存在，拦截为误伤：按上一行加 .env 开关放行即可。\n' >&2

--- a/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
@@ -127,5 +127,5 @@ jq -e '.tool_input.run_in_background == false' <<< "$INPUT" >/dev/null 2>&1 && e
 printf '[dispatch-sync-guard] run_in_background 被省略、显式设为 true、或传入非布尔值时都会选中后台通道：完成通知在主循环正跑工具时到达会被丢弃，实测丢失率 92.7%%，且无补发、无恢复通道（SendMessage 续跑不补发旧通知）。\n' >&2
 printf '[dispatch-sync-guard] 需要产物才能往下走 → 加 run_in_background:false 重派，产物走 tool_result，根本不进那个会被折叠吃掉的队列。真要后台并行 → 派完立刻结束本轮交还主循环，禁止 sleep/轮询/紧接 AskUserQuestion。\n' >&2
 printf '[dispatch-sync-guard] 确需后台：在 ~/.claude/settings.json 的 env 段加 "ALLOW_BACKGROUND_DISPATCH":"1"（Bash 里 export 传不进 hook 进程）。\n' >&2
-printf '[dispatch-sync-guard] 若本机所有派发都被本门禁拦下，是 fork-subagent 特性（tengu_copper_fox）已开启、run_in_background 从 schema 中移除所致。此时后台通道本不存在，拦截为误伤：按上一行加 .env 开关放行即可。\n' >&2
+printf '[dispatch-sync-guard] 若本机所有派发都被本门禁拦下，是 fork-subagent 特性（tengu_copper_fox）已开启、run_in_background 从 schema 中移除所致。此时后台通道本不存在，拦截为误伤：按上一行加 env 开关放行即可。\n' >&2
 exit 2

--- a/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
@@ -108,13 +108,19 @@ esac
 # agent_id exemption: distinguish field-absent from present-but-blank.
 if jq -e 'has("agent_id") and .agent_id != null' <<< "$INPUT" >/dev/null 2>&1; then
   AGENT_ID=$(jq -r '.agent_id' <<< "$INPUT" 2>/dev/null) || exit 0
-  [[ -n "${AGENT_ID// /}" ]] && exit 0
+  # Blank test must cover tabs and newlines, not just spaces: ${var// /} only
+  # strips U+0020, so a tab-only or newline-only agent_id would read as
+  # "non-blank" and wrongly open the exemption. Same [[:space:]] shape as the
+  # sibling pre-dispatch-channel-guard.sh.
+  [[ ! "$AGENT_ID" =~ ^[[:space:]]*$ ]] && exit 0
 fi
 
 # team-ops lifeline: non-empty tool_input.name means this dispatch is
 # starting a teammate. DO NOT REMOVE.
 NAME=$(jq -r '.tool_input.name // empty' <<< "$INPUT" 2>/dev/null) || exit 0
-[[ -n "${NAME// /}" ]] && exit 0
+# Same [[:space:]] blank test as the agent_id step above — see the comment
+# there for why ${var// /} is not sufficient.
+[[ ! "$NAME" =~ ^[[:space:]]*$ ]] && exit 0
 
 jq -e '.tool_input.run_in_background == false' <<< "$INPUT" >/dev/null 2>&1 && exit 0
 

--- a/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Agent, Task): block subagent dispatch calls that
+# omit run_in_background:false, because the omission silently selects the
+# background delivery channel — and that channel drops completion
+# notifications with a measured 92.7% loss rate when the main loop is mid-tool
+# at delivery time, with no resend and no recovery path (SendMessage does not
+# replay lost notifications). See feedback-notification-lost-midturn-fold.md.
+#
+# Judgment source: fields carried by the dispatch call itself. This hook does
+# NOT read any session state, transcript, or prior turn — only tool_name and
+# tool_input from the PreToolUse payload on stdin.
+#
+# Decision chain (strict order, each step fail-opens before the next runs):
+#   1. stdin empty                                      -> exit 0
+#   2. no jq on PATH                                    -> exit 0
+#   3. `jq .` fails to parse (malformed JSON)            -> exit 0
+#   4. ALLOW_BACKGROUND_DISPATCH=1                       -> exit 0 (escape hatch)
+#   5. tool_name not in {Agent, Task}                    -> exit 0
+#   6. CLAUDE_CODE_DISABLE_BACKGROUND_TASKS is set        -> exit 0
+#   7. agent_id field present and non-blank              -> exit 0
+#   8. tool_input.name present and non-blank              -> exit 0
+#   9. tool_input.run_in_background boolean false         -> exit 0
+#  10. otherwise                                          -> exit 2 (BLOCK)
+#
+# Step 3 must run before ANY field extraction. If a malformed payload were
+# allowed past this point, every `jq -r` field pull below would fail closed
+# to empty/null, which would never satisfy step 9's "== false" pass condition
+# and would fall straight into step 10 — turning a parse failure into a false
+# BLOCK, which breaks the fail-open contract this whole chain is built on.
+# Written as `jq . >/dev/null 2>&1 || exit 0`. Every individual field
+# extraction below still carries its own `|| exit 0` (same shape as the
+# sibling subagent-done-gate.sh hook) — this is deliberate double coverage:
+# the upfront check catches wholesale malformed payloads, the per-line
+# `|| exit 0` catches a single unexpected field shape that upfront parsing
+# alone wouldn't surface (e.g. tool_input not being an object).
+#
+# Step 6 reasons about CLAUDE_CODE_DISABLE_BACKGROUND_TASKS, not step 9's
+# boolean check: when this env var is truthy, Agent's own inputSchema omits
+# the run_in_background field entirely — every dispatch is synchronous by
+# construction and the field simply does not exist on the wire. Judging
+# "omission" in that world would misfire on literally every call, so this
+# step checks "the var is set and non-blank", not "the var equals 1" — the
+# switch is Claude Code's own, and its semantics belong to Claude Code, not
+# to this hook.
+#
+# Step 7 (agent_id exemption) is intentionally strict: agent_id is an
+# OPTIONAL field. `jq -r '.agent_id // empty'` is NOT enough here — a
+# genuinely-absent field and a field present-but-blank would collapse to the
+# same empty string, and a plain root-thread dispatch (field absent) must NOT
+# be treated the same as an empty string sent by a teammate. This hook first
+# confirms the field is actually present with `jq -e 'has("agent_id") and
+# .agent_id != null'`, THEN extracts and blank-trims the value — the same
+# "distinguish field-absent from present-but-blank" shape used for
+# last_assistant_message in subagent-done-gate.sh; copied deliberately.
+# Reason this exemption exists at all: Agent.call() in the shipped runtime
+# contains `if(C && o===true) throw` where C=!!teammateContext — a teammate
+# context is PHYSICALLY forbidden from requesting background dispatch. When
+# agent_id is present (i.e. we are inside a teammate context) and
+# run_in_background is omitted, the runtime was never going to go background
+# regardless of what this hook does — notification loss risk is zero, so
+# blocking it would be a pure false positive.
+#
+# Step 8 is the team-ops lifeline. DO NOT REMOVE THIS STEP. A non-empty
+# tool_input.name is the ONLY entry point Lead has for starting a teammate —
+# empirically there is no standalone TeamCreate tool (the binary contains
+# exactly 3 occurrences of the string "TeamCreate": two are copies of the
+# `$Yr` constant-pool set literal, one is `$Yr`'s own JS definition; `$Yr` is
+# read only by UI rendering and dynamic tool-pool accounting, never touched by
+# hook dispatch). Starting a teammate goes through Agent.call()'s
+# `if(b&&i&&!L&&!s&&!a)` branch -> `cvd()` -> `Fko()` ->
+# `taskRegistry.register`, and tool_name for that call is `Agent`. Removing
+# this step would block Lead from ever starting a teammate.
+#
+# Step 9 accepts ONLY the JSON boolean `false` — the string `"false"` does
+# NOT qualify and falls through to BLOCK. Checked with
+# `jq -e '.tool_input.run_in_background == false'`.
+#
+# Known failure mode (documented, not patched): the Agent inputSchema omits
+# run_in_background whenever `DT()||TSe()` is true. Step 6 only catches the
+# DT() half (the env var). TSe() is NOT caught — it gates on a server-side
+# rollout flag (tengu_copper_fox) whose on-disk cache and live runtime value
+# have been observed to disagree, so this hook has no reliable way to judge
+# it from the PreToolUse payload alone. This is deliberately left unguarded:
+# when TSe() is true the field is omitted BECAUSE the background channel does
+# not exist in that runtime, which means the notification-loss risk this hook
+# exists to prevent is already zero — misfiring here means blocking a
+# harmless call. The failure direction is "false positive with an escape
+# hatch," never "silent miss that lets the drop recur."
+set -u
+
+INPUT=$(cat)
+[ -z "$INPUT" ] && exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+jq . >/dev/null 2>&1 <<< "$INPUT" || exit 0
+
+[[ "${ALLOW_BACKGROUND_DISPATCH:-}" == "1" ]] && exit 0
+
+TOOL_NAME=$(jq -r '.tool_name // empty' <<< "$INPUT" 2>/dev/null) || exit 0
+case "$TOOL_NAME" in
+  Agent|Task) ;;
+  *) exit 0 ;;
+esac
+
+[ -n "${CLAUDE_CODE_DISABLE_BACKGROUND_TASKS:-}" ] && exit 0
+
+# agent_id exemption: distinguish field-absent from present-but-blank.
+if jq -e 'has("agent_id") and .agent_id != null' <<< "$INPUT" >/dev/null 2>&1; then
+  AGENT_ID=$(jq -r '.agent_id' <<< "$INPUT" 2>/dev/null) || exit 0
+  [[ -n "${AGENT_ID// /}" ]] && exit 0
+fi
+
+# team-ops lifeline: non-empty tool_input.name means this dispatch is
+# starting a teammate. DO NOT REMOVE.
+NAME=$(jq -r '.tool_input.name // empty' <<< "$INPUT" 2>/dev/null) || exit 0
+[[ -n "${NAME// /}" ]] && exit 0
+
+jq -e '.tool_input.run_in_background == false' <<< "$INPUT" >/dev/null 2>&1 && exit 0
+
+printf '[dispatch-sync-guard] 省略 run_in_background 即选择后台通道：完成通知在主循环正跑工具时到达会被丢弃，实测丢失率 92.7%%，且无补发、无恢复通道（SendMessage 续跑不补发旧通知）。\n' >&2
+printf '[dispatch-sync-guard] 需要产物才能往下走 → 加 run_in_background:false 重派，产物走 tool_result，根本不进那个会被折叠吃掉的队列。真要后台并行 → 派完立刻结束本轮交还主循环，禁止 sleep/轮询/紧接 AskUserQuestion。\n' >&2
+printf '[dispatch-sync-guard] 确需后台：在 ~/.claude/settings.json 的 env 段加 "ALLOW_BACKGROUND_DISPATCH":"1"（Bash 里 export 传不进 hook 进程）。\n' >&2
+printf '[dispatch-sync-guard] 若本机所有派发都被本门禁拦下，是 fork-subagent 特性（tengu_copper_fox）已开启、run_in_background 从 schema 中移除所致。此时后台通道本不存在，拦截为误伤：按上一行加 .env 开关放行即可。\n' >&2
+exit 2

--- a/plugins/dispatch-contract/hooks/hooks.json
+++ b/plugins/dispatch-contract/hooks/hooks.json
@@ -1,6 +1,28 @@
 {
-  "description": "Dispatch contract: %%DONE%% finalization gate on SubagentStop",
+  "description": "Dispatch contract: %%DONE%% finalization gate on SubagentStop, background-dispatch sync guard on PreToolUse, dispatch-rules injection on SubagentStart",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-sync-guard.sh", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-sync-guard.sh", "timeout": 5 }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-rules-inject.sh", "timeout": 5 }
+        ]
+      }
+    ],
     "SubagentStop": [
       {
         "matcher": "*",

--- a/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
@@ -45,7 +45,7 @@ description: |
 
 | 纪律 | 一句话 | 展开 |
 |---|---|---|
-| 通道选择 | 不传 `name`，产物走工具返回值（可靠）；传 `name` 即提升为 teammate、产物改走 mailbox。teammate 由 team-ops 的 TeamCreate + handoff 协议起，不靠手传 `name`——故即席派发一律不传；可另配 PreToolUse hook 拦截违规通道选择 | 见 references/mailbox-liveness.md |
+| 通道选择 | 不传 `name`，产物走工具返回值（可靠）；传 `name` 即提升为 teammate、产物改走 mailbox。teammate 由 team-ops 的 TeamCreate + handoff 协议起，不靠手传 `name`——故即席派发一律不传。禁止 sleep/轮询/主动查进度这条现在有机器强制：本插件 `hooks/dispatch-sync-guard.sh` 在 PreToolUse 拦截省略 `run_in_background:false` 的派发；逃生舱 `ALLOW_BACKGROUND_DISPATCH=1` 需写进 `settings.json` 的 `.env` 段（Bash 里 export 传不进 hook 进程） | 见 references/mailbox-liveness.md |
 | 回传通道 | background subagent 的 final text 不自动进主 mailbox，产物必须走 `SendMessage(to:"main")`；该工具在 subagent 里默认 deferred，prompt 须要求它先 `ToolSearch select:SendMessage` 加载。能同步就 `run_in_background:false` 绕开此坑 | 见 references/mailbox-liveness.md |
 | 活性判定 | 完成/进展是 mailbox 异步、下一 turn 才可见；文件没变 / ps 查不到进程 / sleep 期间没消息都不算 agent 死了；TaskStop 不可逆，存疑多等一 turn 不错杀 | 见 references/mailbox-liveness.md |
 

--- a/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
@@ -45,7 +45,7 @@ description: |
 
 | 纪律 | 一句话 | 展开 |
 |---|---|---|
-| 通道选择 | 不传 `name`，产物走工具返回值（可靠）；传 `name` 即提升为 teammate、产物改走 mailbox。teammate 由 team-ops 的 TeamCreate + handoff 协议起，不靠手传 `name`——故即席派发一律不传。禁止 sleep/轮询/主动查进度这条现在有机器强制：本插件 `hooks/dispatch-sync-guard.sh` 在 PreToolUse 拦截省略 `run_in_background:false` 的派发；逃生舱 `ALLOW_BACKGROUND_DISPATCH=1` 需写进 `settings.json` 的 `.env` 段（Bash 里 export 传不进 hook 进程） | 见 references/mailbox-liveness.md |
+| 通道选择 | `name` 是提升为 teammate 的唯一开关：不传 `name`，产物走工具返回值（可靠）；传 `name` 即提升为 teammate、产物改走 mailbox。即席一次性派发不传 `name`；确需常驻多轮协作才传 `name`，并按 team-ops 协议管理其生命周期。禁止 sleep/轮询/主动查进度这条现在有机器强制：本插件 `hooks/dispatch-sync-guard.sh` 在 PreToolUse 拦截省略 `run_in_background:false` 的派发；逃生舱 `ALLOW_BACKGROUND_DISPATCH=1` 需写进 `settings.json` 的 `env` 段（Bash 里 export 传不进 hook 进程） | 见 references/mailbox-liveness.md |
 | 回传通道 | background subagent 的 final text 不自动进主 mailbox，产物必须走 `SendMessage(to:"main")`；该工具在 subagent 里默认 deferred，prompt 须要求它先 `ToolSearch select:SendMessage` 加载。能同步就 `run_in_background:false` 绕开此坑 | 见 references/mailbox-liveness.md |
 | 活性判定 | 完成/进展是 mailbox 异步、下一 turn 才可见；文件没变 / ps 查不到进程 / sleep 期间没消息都不算 agent 死了；TaskStop 不可逆，存疑多等一 turn 不错杀 | 见 references/mailbox-liveness.md |
 

--- a/plugins/dispatch-contract/tests/dispatch-sync-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-sync-guard.bats
@@ -101,6 +101,34 @@ teardown() {
   assert_sync_block
 }
 
+@test "sync #6c: agent_id present but tab-only + omitted RIB -> BLOCK (blank test must cover tabs, not just spaces)" {
+  local payload
+  payload=$(mk_dispatch_payload "Task" "omit" "tab")
+  # fixture self-check: field present, value is exactly one tab (not absent, not empty)
+  [[ "$(jq -e 'has("agent_id")' <<< "$payload")" == "true" ]]
+  [[ "$(jq -r '.agent_id' <<< "$payload")" == $'\t' ]]
+  run_sync_guard "$payload"
+  assert_sync_block
+}
+
+@test "sync #6d: agent_id present but newline-only + omitted RIB -> BLOCK" {
+  local payload
+  payload=$(mk_dispatch_payload "Task" "omit" "newline")
+  [[ "$(jq -e 'has("agent_id")' <<< "$payload")" == "true" ]]
+  run_sync_guard "$payload"
+  assert_sync_block
+}
+
+@test "sync #4b: tool_input.name tab-only + omitted RIB -> BLOCK (blank name must not fake the team-ops exemption)" {
+  local payload
+  payload=$(mk_dispatch_payload "Agent" "omit" "omit" "tab")
+  # fixture self-check: name key present, value is exactly one tab
+  [[ "$(jq -e '.tool_input | has("name")' <<< "$payload")" == "true" ]]
+  [[ "$(jq -r '.tool_input.name' <<< "$payload")" == $'\t' ]]
+  run_sync_guard "$payload"
+  assert_sync_block
+}
+
 # ============================================================
 # dispatch-sync-guard: env-var fail-open + escape hatch (7-8)
 # ============================================================

--- a/plugins/dispatch-contract/tests/dispatch-sync-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-sync-guard.bats
@@ -191,6 +191,9 @@ teardown() {
   # stdout must parse as JSON
   jq -e '.hookSpecificOutput.hookEventName == "SubagentStart"' <<< "$INJECT_STDOUT" >/dev/null
   jq -e '.hookSpecificOutput.additionalContext | length > 0' <<< "$INJECT_STDOUT" >/dev/null
+  local ctx
+  ctx=$(jq -r '.hookSpecificOutput.additionalContext' <<< "$INJECT_STDOUT")
+  [[ "$ctx" == *"只改指定文件"* ]]
 }
 
 # ============================================================
@@ -201,6 +204,19 @@ teardown() {
   local payload
   payload=$(mk_start_payload "Explore")
   [[ "$(jq -r '.agent_type' <<< "$payload")" == "Explore" ]]
+  run_rules_inject "$payload"
+  [ "$INJECT_EXIT" -eq 0 ]
+  local ctx
+  ctx=$(jq -r '.hookSpecificOutput.additionalContext' <<< "$INJECT_STDOUT")
+  [[ "$ctx" != *"只改指定文件"* ]]
+  [[ "$ctx" == *"输出即产物"* ]]
+  [[ "$ctx" == *"渐进产出"* ]]
+}
+
+@test "inject #13b: agent_type=Plan -> same read-only tier as Explore (omits scope-fence wording)" {
+  local payload
+  payload=$(mk_start_payload "Plan")
+  [[ "$(jq -r '.agent_type' <<< "$payload")" == "Plan" ]]
   run_rules_inject "$payload"
   [ "$INJECT_EXIT" -eq 0 ]
   local ctx

--- a/plugins/dispatch-contract/tests/dispatch-sync-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-sync-guard.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+# BDD tests for dispatch-sync-guard.sh (PreToolUse hook) and
+# dispatch-rules-inject.sh (SubagentStart hook).
+#
+# dispatch-sync-guard: BLOCK is exit 2 + "dispatch-sync-guard" in stderr.
+#                       PASS is exit 0, no "dispatch-sync-guard" in stderr.
+# dispatch-rules-inject: PASS always exits 0; assertions check stdout shape.
+#
+# Fixture self-check discipline: this suite has previously been bitten by a
+# fixture bug disguising itself as a passing fail-open gate (printf eating
+# the %%DONE%% marker's percent sign). Every payload-builder-driven test
+# below re-reads the built payload with jq before running the gate, to
+# confirm the fixture itself carries the field shape the test claims it does.
+
+setup() {
+  load 'test_helper/common-setup'
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+# ============================================================
+# dispatch-sync-guard: pass/block matrix (1-3, 11)
+# ============================================================
+
+@test "sync #1: run_in_background:false -> PASS" {
+  local payload
+  payload=$(mk_dispatch_payload "Task" "false")
+  # fixture self-check
+  [[ "$(jq -r '.tool_input.run_in_background' <<< "$payload")" == "false" ]]
+  run_sync_guard "$payload"
+  assert_sync_pass
+}
+
+@test "sync #2: run_in_background omitted -> BLOCK" {
+  local payload
+  payload=$(mk_dispatch_payload "Task" "omit")
+  # fixture self-check: field genuinely absent
+  [[ "$(jq -e 'has("tool_input") and (.tool_input | has("run_in_background") | not)' <<< "$payload")" == "true" ]]
+  run_sync_guard "$payload"
+  assert_sync_block
+}
+
+@test "sync #3: run_in_background:true (explicit) -> BLOCK" {
+  local payload
+  payload=$(mk_dispatch_payload "Task" "true")
+  [[ "$(jq -r '.tool_input.run_in_background' <<< "$payload")" == "true" ]]
+  run_sync_guard "$payload"
+  assert_sync_block
+}
+
+@test "sync #11: run_in_background:\"false\" (string) -> BLOCK" {
+  local payload
+  payload=$(mk_dispatch_payload "Task" "string_false")
+  # fixture self-check: value is a JSON string, not a boolean
+  [[ "$(jq -r '.tool_input.run_in_background | type' <<< "$payload")" == "string" ]]
+  [[ "$(jq -r '.tool_input.run_in_background' <<< "$payload")" == "false" ]]
+  run_sync_guard "$payload"
+  assert_sync_block
+}
+
+# ============================================================
+# dispatch-sync-guard: name / agent_id exemptions (4-6)
+# ============================================================
+
+@test "sync #4: tool_input.name present + omitted RIB (Lead starting a teammate) -> PASS" {
+  local payload
+  payload=$(mk_dispatch_payload "Agent" "omit" "omit" "present")
+  [[ "$(jq -r '.tool_input.name' <<< "$payload")" == "lead" ]]
+  [[ "$(jq -e '.tool_input | has("run_in_background") | not' <<< "$payload")" == "true" ]]
+  run_sync_guard "$payload"
+  assert_sync_pass
+}
+
+@test "sync #5: tool_input.name present + run_in_background:false (observed real shape) -> PASS" {
+  local payload
+  payload=$(mk_dispatch_payload "Agent" "false" "omit" "present")
+  [[ "$(jq -r '.tool_input.name' <<< "$payload")" == "lead" ]]
+  [[ "$(jq -r '.tool_input.run_in_background' <<< "$payload")" == "false" ]]
+  run_sync_guard "$payload"
+  assert_sync_pass
+}
+
+@test "sync #6: agent_id present + omitted RIB (teammate internal dispatch) -> PASS" {
+  local payload
+  payload=$(mk_dispatch_payload "Task" "omit" "present")
+  [[ "$(jq -r '.agent_id' <<< "$payload")" == "test-agent-0000" ]]
+  run_sync_guard "$payload"
+  assert_sync_pass
+}
+
+@test "sync #6b: agent_id present but empty string + omitted RIB -> BLOCK (blank must not fake the exemption)" {
+  local payload
+  payload=$(mk_dispatch_payload "Task" "omit" "empty")
+  # fixture self-check: field present, value is an empty string, not absent
+  [[ "$(jq -e 'has("agent_id")' <<< "$payload")" == "true" ]]
+  [[ "$(jq -r '.agent_id' <<< "$payload")" == "" ]]
+  run_sync_guard "$payload"
+  assert_sync_block
+}
+
+# ============================================================
+# dispatch-sync-guard: env-var fail-open + escape hatch (7-8)
+# ============================================================
+
+@test "sync #7: CLAUDE_CODE_DISABLE_BACKGROUND_TASKS set + omitted RIB -> PASS" {
+  local payload
+  payload=$(mk_dispatch_payload "Task" "omit")
+  run_sync_guard "$payload" "CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1"
+  assert_sync_pass
+}
+
+@test "sync #8: ALLOW_BACKGROUND_DISPATCH=1 + omitted RIB -> PASS" {
+  local payload
+  payload=$(mk_dispatch_payload "Task" "omit")
+  run_sync_guard "$payload" "ALLOW_BACKGROUND_DISPATCH=1"
+  assert_sync_pass
+}
+
+# ============================================================
+# dispatch-sync-guard: tool_name outside {Agent, Task} (9)
+# ============================================================
+
+@test "sync #9: tool_name=Bash -> PASS (not a dispatch call)" {
+  local payload
+  payload=$(mk_dispatch_payload "Bash" "omit")
+  [[ "$(jq -r '.tool_name' <<< "$payload")" == "Bash" ]]
+  run_sync_guard "$payload"
+  assert_sync_pass
+}
+
+# ============================================================
+# dispatch-sync-guard: malformed stdin fail-open (10)
+# ============================================================
+
+@test "sync #10a: empty stdin -> PASS" {
+  run_sync_guard ""
+  assert_sync_pass
+}
+
+@test "sync #10b: truncated JSON '{' -> PASS" {
+  run_sync_guard "{"
+  assert_sync_pass
+}
+
+@test "sync #10c: whitespace-only stdin -> PASS" {
+  run_sync_guard $'   \n  \n'
+  assert_sync_pass
+}
+
+# ============================================================
+# dispatch-rules-inject: normal injection shape (12)
+# ============================================================
+
+@test "inject #12: normal agent_type -> stdout is valid JSON with additionalContext" {
+  local payload
+  payload=$(mk_start_payload "worker")
+  [[ "$(jq -r '.agent_type' <<< "$payload")" == "worker" ]]
+  run_rules_inject "$payload"
+  [ "$INJECT_EXIT" -eq 0 ]
+  # stdout must parse as JSON
+  jq -e '.hookSpecificOutput.hookEventName == "SubagentStart"' <<< "$INJECT_STDOUT" >/dev/null
+  jq -e '.hookSpecificOutput.additionalContext | length > 0' <<< "$INJECT_STDOUT" >/dev/null
+}
+
+# ============================================================
+# dispatch-rules-inject: read-only agent_type tiering (13)
+# ============================================================
+
+@test "inject #13: agent_type=Explore -> omits scope-fence wording" {
+  local payload
+  payload=$(mk_start_payload "Explore")
+  [[ "$(jq -r '.agent_type' <<< "$payload")" == "Explore" ]]
+  run_rules_inject "$payload"
+  [ "$INJECT_EXIT" -eq 0 ]
+  local ctx
+  ctx=$(jq -r '.hookSpecificOutput.additionalContext' <<< "$INJECT_STDOUT")
+  [[ "$ctx" != *"只改指定文件"* ]]
+  [[ "$ctx" == *"输出即产物"* ]]
+  [[ "$ctx" == *"渐进产出"* ]]
+}
+
+# ============================================================
+# dispatch-rules-inject: fail-open with empty stdout (14-15)
+# ============================================================
+
+@test "inject #14: empty stdin -> stdout completely empty, exit 0" {
+  run_rules_inject ""
+  assert_inject_empty_stdout
+}
+
+@test "inject #15: ALLOW_NO_RULES_INJECT=1 -> stdout empty, exit 0" {
+  local payload
+  payload=$(mk_start_payload "worker")
+  run_rules_inject "$payload" "ALLOW_NO_RULES_INJECT=1"
+  assert_inject_empty_stdout
+}

--- a/plugins/dispatch-contract/tests/test_helper/common-setup.bash
+++ b/plugins/dispatch-contract/tests/test_helper/common-setup.bash
@@ -152,12 +152,19 @@ mk_dispatch_payload() {
   esac
   if [[ "$name_mode" == "present" ]]; then
     tool_input=$(jq -cn --argjson base "$tool_input" '$base + {name:"lead"}')
+  elif [[ "$name_mode" == "tab" ]]; then
+    # Tab-only name: must read as blank. Guards against ${var// /}, which
+    # strips only U+0020 and would let this fake the team-ops exemption.
+    tool_input=$(jq -cn --argjson base "$tool_input" '$base + {name:"\t"}')
   fi
   local payload
   payload=$(jq -cn --arg tool "$tool" --argjson ti "$tool_input" '{tool_name:$tool, tool_input:$ti}')
   case "$agent_id_mode" in
     present) payload=$(jq -cn --argjson base "$payload" '$base + {agent_id:"test-agent-0000"}') ;;
     empty)   payload=$(jq -cn --argjson base "$payload" '$base + {agent_id:""}') ;;
+    # Tab-only / newline-only agent_id: same blank-detection trap as name above.
+    tab)     payload=$(jq -cn --argjson base "$payload" '$base + {agent_id:"\t"}') ;;
+    newline) payload=$(jq -cn --argjson base "$payload" '$base + {agent_id:"\n"}') ;;
     omit)    ;;
   esac
   echo "$payload"

--- a/plugins/dispatch-contract/tests/test_helper/common-setup.bash
+++ b/plugins/dispatch-contract/tests/test_helper/common-setup.bash
@@ -123,7 +123,145 @@ run_gate() {
   rm -f "$stderr_file"
 }
 
-# --- Assertion Helpers ---
+# ============================================================
+# Additions below support dispatch-sync-guard.bats
+# (PreToolUse sync guard + SubagentStart rules injector).
+# Existing functions above are untouched — subagent-done-gate.bats
+# depends on them as-is.
+# ============================================================
+
+SYNC_GUARD_SCRIPT="${BATS_TEST_DIRNAME}/../hooks/dispatch-sync-guard.sh"
+INJECT_SCRIPT="${BATS_TEST_DIRNAME}/../hooks/dispatch-rules-inject.sh"
+
+# --- Payload Builders (dispatch-sync-guard) ---
+
+# mk_dispatch_payload TOOL_NAME RIB_MODE [AGENT_ID_MODE] [NAME_MODE]
+# TOOL_NAME: any string (e.g. Agent, Task, Bash)
+# RIB_MODE: false | true | string_false | omit  (tool_input.run_in_background)
+# AGENT_ID_MODE (optional, default omit): omit | present | empty
+# NAME_MODE (optional, default omit): omit | present  (tool_input.name)
+mk_dispatch_payload() {
+  local tool="$1" rib_mode="$2" agent_id_mode="${3:-omit}" name_mode="${4:-omit}"
+  local tool_input
+  case "$rib_mode" in
+    false)        tool_input=$(jq -cn '{run_in_background:false}') ;;
+    true)         tool_input=$(jq -cn '{run_in_background:true}') ;;
+    string_false) tool_input=$(jq -cn '{run_in_background:"false"}') ;;
+    omit)         tool_input='{}' ;;
+    *)            tool_input='{}' ;;
+  esac
+  if [[ "$name_mode" == "present" ]]; then
+    tool_input=$(jq -cn --argjson base "$tool_input" '$base + {name:"lead"}')
+  fi
+  local payload
+  payload=$(jq -cn --arg tool "$tool" --argjson ti "$tool_input" '{tool_name:$tool, tool_input:$ti}')
+  case "$agent_id_mode" in
+    present) payload=$(jq -cn --argjson base "$payload" '$base + {agent_id:"test-agent-0000"}') ;;
+    empty)   payload=$(jq -cn --argjson base "$payload" '$base + {agent_id:""}') ;;
+    omit)    ;;
+  esac
+  echo "$payload"
+}
+
+# --- Payload Builders (dispatch-rules-inject) ---
+
+# mk_start_payload [AGENT_TYPE]
+# AGENT_TYPE omitted entirely from payload when not passed.
+mk_start_payload() {
+  local agent_type="${1:-}"
+  if [[ -z "$agent_type" ]]; then
+    jq -cn '{}'
+  else
+    jq -cn --arg t "$agent_type" '{agent_type:$t}'
+  fi
+}
+
+# --- Run Helpers ---
+
+# run_sync_guard PAYLOAD [env_overrides...]
+# Sets: SYNC_STDOUT, SYNC_STDERR, SYNC_EXIT
+run_sync_guard() {
+  local payload="$1"
+  SYNC_STDOUT=""
+  SYNC_STDERR=""
+  SYNC_EXIT=0
+
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  if [[ "${2:-}" != "" ]]; then
+    SYNC_STDOUT=$(printf '%s' "$payload" | env "${@:2}" bash "$SYNC_GUARD_SCRIPT" 2>"$stderr_file") || SYNC_EXIT=$?
+  else
+    SYNC_STDOUT=$(printf '%s' "$payload" | bash "$SYNC_GUARD_SCRIPT" 2>"$stderr_file") || SYNC_EXIT=$?
+  fi
+  SYNC_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+# run_rules_inject PAYLOAD [env_overrides...]
+# Sets: INJECT_STDOUT, INJECT_STDERR, INJECT_EXIT
+run_rules_inject() {
+  local payload="$1"
+  INJECT_STDOUT=""
+  INJECT_STDERR=""
+  INJECT_EXIT=0
+
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  if [[ "${2:-}" != "" ]]; then
+    INJECT_STDOUT=$(printf '%s' "$payload" | env "${@:2}" bash "$INJECT_SCRIPT" 2>"$stderr_file") || INJECT_EXIT=$?
+  else
+    INJECT_STDOUT=$(printf '%s' "$payload" | bash "$INJECT_SCRIPT" 2>"$stderr_file") || INJECT_EXIT=$?
+  fi
+  INJECT_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+# --- Assertion Helpers (dispatch-sync-guard) ---
+
+# assert_sync_pass — exit 0 and no "dispatch-sync-guard" in stderr
+assert_sync_pass() {
+  [ "$SYNC_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $SYNC_EXIT"
+    echo "stderr: $SYNC_STDERR"
+    return 1
+  }
+  [[ "$SYNC_STDERR" != *"dispatch-sync-guard"* ]] || {
+    echo "Expected no 'dispatch-sync-guard' in stderr, got: $SYNC_STDERR"
+    return 1
+  }
+}
+
+# assert_sync_block — exit 2 and "dispatch-sync-guard" in stderr
+assert_sync_block() {
+  [ "$SYNC_EXIT" -eq 2 ] || {
+    echo "Expected exit 2, got $SYNC_EXIT"
+    echo "stderr: $SYNC_STDERR"
+    return 1
+  }
+  [[ "$SYNC_STDERR" == *"dispatch-sync-guard"* ]] || {
+    echo "Expected 'dispatch-sync-guard' in stderr, got: $SYNC_STDERR"
+    return 1
+  }
+}
+
+# --- Assertion Helpers (dispatch-rules-inject) ---
+
+# assert_inject_empty_stdout — exit 0 and completely empty stdout
+assert_inject_empty_stdout() {
+  [ "$INJECT_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $INJECT_EXIT"
+    echo "stderr: $INJECT_STDERR"
+    return 1
+  }
+  [ -z "$INJECT_STDOUT" ] || {
+    echo "Expected empty stdout, got: $INJECT_STDOUT"
+    return 1
+  }
+}
+
+# --- Assertion Helpers (existing — subagent-done-gate.bats) ---
 
 # assert_pass — exit 0 and no "subagent-done-gate" in stderr
 assert_pass() {


### PR DESCRIPTION
## Summary

- 新增 `hooks/dispatch-sync-guard.sh`（PreToolUse，matcher: Agent / Task）：拦截省略 `run_in_background:false` 的派发调用。省略即选择后台通道，完成通知在主循环正跑工具时到达会被折叠丢弃（实测丢失率 92.7%），且无补发、无恢复通道。判据链严格按 10 步顺序 fail-open，对 teammate 内部再派发（`agent_id` 非空）、Lead 起 teammate（`tool_input.name` 非空）、`CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` 环境变量放行，均放行不拦。
- 新增 `hooks/dispatch-rules-inject.sh`（SubagentStart，matcher: `*`）：把四铁律中的①③（只读 agent_type）或①②③（其余 agent_type）直接注入子 agent 自身上下文，不再依赖派发方 prompt 是否写全。stdout 单点写入、jq -n 构造 JSON，任何 fail-open 路径 stdout 保持完全为空。
- `hooks.json` 追加两条注册（PreToolUse 拆成 Agent / Task 两个独立条目，照抄本仓 plan-review 插件已验证的写法）；`plugin.json` version 1.0.0 → 1.2.0
- `SKILL.md`「等待方式」行补一句机器强制说明；`README.md` 补两个新 hook 的判定链、逃生舱与已知边界

## 已知边界

`dispatch-sync-guard.sh` 的判据链只能挡住 `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`（`DT()`）导致的字段省略。Agent inputSchema 实际在 `DT()||TSe()` 为真时省略 `run_in_background`，`TSe()` 是服务端 rollout 开关（`tengu_copper_fox`），其落盘缓存与运行时取值实测不一致，hook 侧无法可靠判定。刻意不兜底：`TSe()` 为真时字段被省略 ⇒ 后台通道本不存在 ⇒ 通知丢失风险为零，此时误拦的是无害调用（有逃生舱 `ALLOW_BACKGROUND_DISPATCH=1`），失效方向是「误伤」而非「漏拦事故复发」。

## Test plan

- [x] `bats plugins/dispatch-contract/tests/dispatch-sync-guard.bats` — 22/22 通过
- [x] `bats plugins/dispatch-contract/tests/subagent-done-gate.bats` — 26/26 回归通过，未破坏既有门禁
- [x] `jq . plugins/dispatch-contract/hooks/hooks.json` — 合法 JSON
- [x] `bash -n` 两个新脚本 — 语法检查通过
- [x] 手工验证两脚本的 stdout 纯净度（空 stdin / 畸形 JSON / 逃生舱三路径 stdout 字节数为 0）
