### PR TITLE
fix(dispatch-contract): 纠正 fork 世界判据语义,给出可执行解法 (v1.2.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -85,7 +85,7 @@
     {
       "name": "dispatch-contract",
       "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop) + background-dispatch sync guard (PreToolUse) + dispatch-rules injection (SubagentStart)",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/dispatch-contract/.claude-plugin/plugin.json
+++ b/plugins/dispatch-contract/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dispatch-contract",
   "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop) + background-dispatch sync guard (PreToolUse) + dispatch-rules injection (SubagentStart)",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/subagent-dispatch"]
 }

--- a/plugins/dispatch-contract/README.md
+++ b/plugins/dispatch-contract/README.md
@@ -119,7 +119,9 @@ turns — and applies this decision chain, each step fail-opening before the nex
 7. `agent_id` is present and non-blank → pass (teammate context).
 8. `tool_input.name` is present and non-blank → pass (Lead starting a teammate).
 9. `tool_input.run_in_background` is the JSON boolean `false` → pass.
-10. Otherwise → block (exit 2) with a four-line stderr correction.
+9b. `run_in_background` field absent → block (exit 2), fork-aware stderr (4 lines).
+10. Otherwise (field present but not `false`, e.g. `true` or a non-boolean) →
+    block (exit 2), generic stderr (3 lines).
 
 Step 6 checks whether `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` is set, not whether
 `run_in_background` is present, because Agent's own input schema omits the
@@ -144,7 +146,9 @@ entirely when the `fork-subagent` feature (server-side rollout flag, internally 
 In that mode the runtime forces every dispatch onto the background channel — it does
 not remove the channel, it removes the ability to opt out of it. The hook detects this
 state structurally, from field absence combined with step 6's env var being unset, and
-blocks (exit 2) with a fork-specific stderr message rather than passing. The fix is
+blocks (exit 2) with a fork-aware stderr message rather than passing — the message
+leads with the generic "you probably just forgot the field" advice first, then covers
+the fork-world case as the second, less common possibility. The fix is
 `CLAUDE_CODE_FORK_SUBAGENT=0` in `settings.json`'s `env` section, which restarts Claude
 Code with the fork feature off, restores `run_in_background` to the schema, and makes
 synchronous dispatch requestable again. `ALLOW_BACKGROUND_DISPATCH=1` does not fix this

--- a/plugins/dispatch-contract/README.md
+++ b/plugins/dispatch-contract/README.md
@@ -138,16 +138,18 @@ Step 8 is load-bearing for team-ops: a non-empty `tool_input.name` is the only e
 point for starting a teammate. Removing this step would block Lead from starting any
 teammate.
 
-**Known boundary**: the Agent input schema also omits `run_in_background` when a
-server-side rollout flag (internally named `tengu_copper_fox`) is active, independent
-of `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`. This hook has no reliable way to detect that
-flag from the `PreToolUse` payload — its on-disk cache and live runtime value have
-been observed to disagree. The hook leaves this case unguarded on purpose: when the
-flag is active, the field is omitted because the background channel does not exist in
-that runtime, so the notification-loss risk this hook exists to prevent is already
-zero. A misfire in this case blocks a harmless call rather than letting a real drop
-recur, and the escape hatch (`ALLOW_BACKGROUND_DISPATCH=1` in `settings.json`'s `env`
-section) resolves it.
+**Fork world (step 9b)**: the Agent input schema also drops `run_in_background`
+entirely when the `fork-subagent` feature (server-side rollout flag, internally named
+`tengu_copper_fox`) is active, independent of `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`.
+In that mode the runtime forces every dispatch onto the background channel — it does
+not remove the channel, it removes the ability to opt out of it. The hook detects this
+state structurally, from field absence combined with step 6's env var being unset, and
+blocks (exit 2) with a fork-specific stderr message rather than passing. The fix is
+`CLAUDE_CODE_FORK_SUBAGENT=0` in `settings.json`'s `env` section, which restarts Claude
+Code with the fork feature off, restores `run_in_background` to the schema, and makes
+synchronous dispatch requestable again. `ALLOW_BACKGROUND_DISPATCH=1` does not fix this
+case — it silences the guard everywhere, including runtimes where the background
+channel is real and the guard is protecting against an actual notification-loss risk.
 
 ## The SubagentStart Rules Injector
 
@@ -227,3 +229,4 @@ the model sees. The correction message reaches model context either way.
 | `ALLOW_UNMARKED_FINAL` | _(unset)_ | `1` disables the `%%DONE%%` finalization gate entirely |
 | `ALLOW_BACKGROUND_DISPATCH` | _(unset)_ | `1` disables the background-dispatch sync guard entirely — set in `settings.json`'s `env` section, since `export` in a Bash tool call does not reach the hook process |
 | `ALLOW_NO_RULES_INJECT` | _(unset)_ | `1` disables the SubagentStart rules injector entirely |
+| `CLAUDE_CODE_FORK_SUBAGENT` | _(unset)_ | `0` disables the fork-subagent feature — restores `run_in_background` to the Agent input schema, the correct fix for step 9b's fork-world block |

--- a/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
@@ -164,11 +164,17 @@ NAME=$(jq -r '.tool_input.name // empty' <<< "$INPUT" 2>/dev/null) || exit 0
 
 jq -e '.tool_input.run_in_background == false' <<< "$INPUT" >/dev/null 2>&1 && exit 0
 
-# No type-check on tool_input is needed before this `has()`: a non-object
-# tool_input (string/number/array) makes jq error out (exit 5) at step 8's
+# No type-check on tool_input is needed before this `has()`, but the reason is
+# narrower than "non-object payloads never get here". A string/number/array/
+# boolean tool_input makes jq error out (exit 5) at step 8's
 # `jq -r '.tool_input.name // empty'`, which already carries `|| exit 0` and
-# fail-opens there — such a payload can never reach this branch. A guard here
-# would be dead code, and a test for it would pass vacuously.
+# fail-opens there — those genuinely cannot reach this branch. A null
+# tool_input is the exception: `null | has(...)` is a clean exit 1, so step 8
+# does not fail-open and the payload DOES land here and gets the fork-aware
+# message. That is accepted rather than guarded: Agent/Task always send an
+# object tool_input in practice, so a type-check here would be dead code and
+# any test for it would pass vacuously (verified — commenting the guard out
+# left its test green).
 
 # Fork world (field absent + step 6's env var unset) gets its own message:
 # the generic "add run_in_background:false" advice is unfollowable there,

--- a/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
@@ -20,6 +20,7 @@
 #   7. agent_id field present and non-blank              -> exit 0
 #   8. tool_input.name present and non-blank              -> exit 0
 #   9. tool_input.run_in_background boolean false         -> exit 0
+#  9b. field absent (fork world)                        -> exit 2 (BLOCK, fork-specific message)
 #  10. otherwise                                          -> exit 2 (BLOCK)
 #
 # Step 3 must run before ANY field extraction. If a malformed payload were
@@ -75,17 +76,56 @@
 # NOT qualify and falls through to BLOCK. Checked with
 # `jq -e '.tool_input.run_in_background == false'`.
 #
-# Known failure mode (documented, not patched): the Agent inputSchema omits
-# run_in_background whenever `DT()||TSe()` is true. Step 6 only catches the
-# DT() half (the env var). TSe() is NOT caught — it gates on a server-side
-# rollout flag (tengu_copper_fox) whose on-disk cache and live runtime value
-# have been observed to disagree, so this hook has no reliable way to judge
-# it from the PreToolUse payload alone. This is deliberately left unguarded:
-# when TSe() is true the field is omitted BECAUSE the background channel does
-# not exist in that runtime, which means the notification-loss risk this hook
-# exists to prevent is already zero — misfiring here means blocking a
-# harmless call. The failure direction is "false positive with an escape
-# hatch," never "silent miss that lets the drop recur."
+# Step 9b (fork world) exists because the Agent inputSchema DROPS
+# run_in_background whenever `Lv() || bEe()` is true — Lv() is the env var
+# from step 6, bEe() is the fork-subagent feature. Step 6 already exempts the
+# Lv() half. The bEe() half is the dangerous one, and an earlier revision of
+# this header had its semantics exactly backwards, claiming the field is
+# omitted BECAUSE the background channel does not exist and that blocking
+# here is therefore a harmless false positive. Reading the shipped runtime
+# (2.1.222) shows the opposite. The expression deciding async is:
+#
+#   let K=Wb(), q=bEe(), U=Lv();
+#   Z = z || (o===!0 || V.background===!0 || K || q || !w && o!==!1) && !U;
+#
+# `q` (i.e. bEe()) is an independent disjunct, so when fork is on, Z is
+# unconditionally true and EVERY dispatch takes the async_launched /
+# isBackgroundAgent:true branch. Meanwhile zod's `.object()` strips keys not
+# in the schema, so passing run_in_background:false does not even reach `o` —
+# and even if it did, `q` would still force Z true. Fork world is therefore
+# not "no background channel, zero risk"; it is "background forced, sync
+# unrequestable" — the worst form of the very thing this hook guards.
+#
+# That is why step 9b still BLOCKS. What it changes is the WAY OUT. The old
+# text pointed at ALLOW_BACKGROUND_DISPATCH=1, which silences this hook in
+# every world including the ones where the channel is real and the guard is
+# earning its keep. The actionable fix is CLAUDE_CODE_FORK_SUBAGENT=0,
+# because the fork gate resolves as:
+#
+#   function Ax_(){
+#     if(Ple())return"disabled";
+#     if(tr(env.CLAUDE_CODE_FORK_SUBAGENT))return"env";
+#     if($u(env.CLAUDE_CODE_FORK_SUBAGENT))return"disabled";  // <- before rollout
+#     if(Sn())return"disabled";
+#     if(Qe(wx_,!1))return"gb_rollout";
+#     return"disabled" }
+#
+# The falsy-env branch sits BEFORE the `tengu_copper_fox` rollout check, so
+# it overrides the server-side flag. Setting it makes bEe() false, which
+# restores the field to the schema and clears `q` from Z — the third state
+# (channel present but sync unexpressable) stops existing, and this hook's
+# judgment source is never an empty set again. Removing the hazard beats
+# muting the alarm, so no fourth env switch is added here: a guard that needs
+# another guard to stay honest is a design smell.
+#
+# Detection is deliberately indirect. The rollout flag's on-disk cache and
+# live runtime value have been observed to disagree, so this hook never tries
+# to read it. It infers fork world structurally instead: the field is absent
+# AND step 6's env var is unset, which leaves bEe() as the only remaining
+# explanation for the omission. A dispatcher that simply forgot the field in
+# a normal (non-fork) runtime lands here too, and blocking that is correct
+# anyway — the failure direction stays "false positive with a way out," never
+# "silent miss that lets the drop recur."
 set -u
 
 INPUT=$(cat)
@@ -124,8 +164,18 @@ NAME=$(jq -r '.tool_input.name // empty' <<< "$INPUT" 2>/dev/null) || exit 0
 
 jq -e '.tool_input.run_in_background == false' <<< "$INPUT" >/dev/null 2>&1 && exit 0
 
+# Fork world (field absent + step 6's env var unset) gets its own message:
+# the generic "add run_in_background:false" advice is unfollowable there,
+# because the field is not in the schema to begin with.
+if ! jq -e '.tool_input | has("run_in_background")' <<< "$INPUT" >/dev/null 2>&1; then
+  printf '[dispatch-sync-guard] run_in_background 不在 Agent 的 inputSchema 里,说明 fork-subagent 特性已开启(tengu_copper_fox)。此时后台不是"不存在"而是被强制:运行时里 bEe() 是决定异步的独立析取项,Z 恒真,所有派发都走 async_launched;zod 会剥掉 schema 外的键,硬传 run_in_background:false 也进不去。\n' >&2
+  printf '[dispatch-sync-guard] 完成通知在主循环正跑工具时到达会被丢弃,实测丢失率 92.7%%,无补发、无恢复通道 —— 所以这里不放行。\n' >&2
+  printf '[dispatch-sync-guard] 解法:在 ~/.claude/settings.json 的 env 段加 "CLAUDE_CODE_FORK_SUBAGENT":"0"(需重启 CC 生效)。该假值分支在运行时里排在 rollout 检查之前,能压过服务端 flag,字段随即回到 schema、同步派发重新可表达。代价仅是放弃 fork 的上下文继承。\n' >&2
+  printf '[dispatch-sync-guard] 不要改用 ALLOW_BACKGROUND_DISPATCH=1 绕过 —— 那会让本门禁在所有环境一起失效,包括后台通道真实存在、真正需要它的场景。\n' >&2
+  exit 2
+fi
+
 printf '[dispatch-sync-guard] run_in_background 被省略、显式设为 true、或传入非布尔值时都会选中后台通道：完成通知在主循环正跑工具时到达会被丢弃，实测丢失率 92.7%%，且无补发、无恢复通道（SendMessage 续跑不补发旧通知）。\n' >&2
 printf '[dispatch-sync-guard] 需要产物才能往下走 → 加 run_in_background:false 重派，产物走 tool_result，根本不进那个会被折叠吃掉的队列。真要后台并行 → 派完立刻结束本轮交还主循环，禁止 sleep/轮询/紧接 AskUserQuestion。\n' >&2
 printf '[dispatch-sync-guard] 确需后台：在 ~/.claude/settings.json 的 env 段加 "ALLOW_BACKGROUND_DISPATCH":"1"（Bash 里 export 传不进 hook 进程）。\n' >&2
-printf '[dispatch-sync-guard] 若本机所有派发都被本门禁拦下，是 fork-subagent 特性（tengu_copper_fox）已开启、run_in_background 从 schema 中移除所致。此时后台通道本不存在，拦截为误伤：按上一行加 env 开关放行即可。\n' >&2
 exit 2

--- a/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-sync-guard.sh
@@ -20,7 +20,7 @@
 #   7. agent_id field present and non-blank              -> exit 0
 #   8. tool_input.name present and non-blank              -> exit 0
 #   9. tool_input.run_in_background boolean false         -> exit 0
-#  9b. field absent (fork world)                        -> exit 2 (BLOCK, fork-specific message)
+#  9b. field absent (fork world)                        -> exit 2 (BLOCK, fork-aware message)
 #  10. otherwise                                          -> exit 2 (BLOCK)
 #
 # Step 3 must run before ANY field extraction. If a malformed payload were
@@ -164,18 +164,27 @@ NAME=$(jq -r '.tool_input.name // empty' <<< "$INPUT" 2>/dev/null) || exit 0
 
 jq -e '.tool_input.run_in_background == false' <<< "$INPUT" >/dev/null 2>&1 && exit 0
 
+# No type-check on tool_input is needed before this `has()`: a non-object
+# tool_input (string/number/array) makes jq error out (exit 5) at step 8's
+# `jq -r '.tool_input.name // empty'`, which already carries `|| exit 0` and
+# fail-opens there — such a payload can never reach this branch. A guard here
+# would be dead code, and a test for it would pass vacuously.
+
 # Fork world (field absent + step 6's env var unset) gets its own message:
 # the generic "add run_in_background:false" advice is unfollowable there,
 # because the field is not in the schema to begin with.
 if ! jq -e '.tool_input | has("run_in_background")' <<< "$INPUT" >/dev/null 2>&1; then
-  printf '[dispatch-sync-guard] run_in_background 不在 Agent 的 inputSchema 里,说明 fork-subagent 特性已开启(tengu_copper_fox)。此时后台不是"不存在"而是被强制:运行时里 bEe() 是决定异步的独立析取项,Z 恒真,所有派发都走 async_launched;zod 会剥掉 schema 外的键,硬传 run_in_background:false 也进不去。\n' >&2
-  printf '[dispatch-sync-guard] 完成通知在主循环正跑工具时到达会被丢弃,实测丢失率 92.7%%,无补发、无恢复通道 —— 所以这里不放行。\n' >&2
-  printf '[dispatch-sync-guard] 解法:在 ~/.claude/settings.json 的 env 段加 "CLAUDE_CODE_FORK_SUBAGENT":"0"(需重启 CC 生效)。该假值分支在运行时里排在 rollout 检查之前,能压过服务端 flag,字段随即回到 schema、同步派发重新可表达。代价仅是放弃 fork 的上下文继承。\n' >&2
-  printf '[dispatch-sync-guard] 不要改用 ALLOW_BACKGROUND_DISPATCH=1 绕过 —— 那会让本门禁在所有环境一起失效,包括后台通道真实存在、真正需要它的场景。\n' >&2
+  printf '[dispatch-sync-guard] tool_input 里没有 run_in_background。若你只是漏传了 → 补 run_in_background:false 重派即可,产物走 tool_result,不进那个会被折叠吃掉的队列(丢失率实测 92.7%%,无补发、无恢复通道)。\n' >&2
+  printf '[dispatch-sync-guard] 若重派时发现该字段根本不在 Agent 的 inputSchema 里(传了也被剥掉),说明 fork-subagent 特性已开启(tengu_copper_fox)。此时后台不是"不存在"而是被强制:运行时里 bEe() 是决定异步的独立析取项,Z 恒真,所有派发都走 async_launched;zod 会剥掉 schema 外的键,硬传 run_in_background:false 也进不去 —— 所以这里同样不放行。\n' >&2
+  printf '[dispatch-sync-guard] fork 世界的解法:在 ~/.claude/settings.json 的 env 段加 "CLAUDE_CODE_FORK_SUBAGENT":"0"(需重启 CC 生效)。该假值分支在运行时里排在 rollout 检查之前,能压过服务端 flag,字段随即回到 schema、同步派发重新可表达。代价仅是放弃 fork 的上下文继承。\n' >&2
+  printf '[dispatch-sync-guard] 两种情形都不要改用 ALLOW_BACKGROUND_DISPATCH=1 绕过 —— 那会让本门禁在所有环境一起失效,包括后台通道真实存在、真正需要它的场景。\n' >&2
   exit 2
 fi
 
-printf '[dispatch-sync-guard] run_in_background 被省略、显式设为 true、或传入非布尔值时都会选中后台通道：完成通知在主循环正跑工具时到达会被丢弃，实测丢失率 92.7%%，且无补发、无恢复通道（SendMessage 续跑不补发旧通知）。\n' >&2
+# 省略的情形已被上面的 field-absent 分支截走,这里只可能是"字段在场但值非法"
+# (显式 true,或字符串 "false" 之类非布尔值)。文案必须与控制流一致,否则等于
+# 对模型撒谎。
+printf '[dispatch-sync-guard] run_in_background 显式设为 true、或传入非布尔值(如字符串 "false")时都会选中后台通道：完成通知在主循环正跑工具时到达会被丢弃，实测丢失率 92.7%%，且无补发、无恢复通道（SendMessage 续跑不补发旧通知）。\n' >&2
 printf '[dispatch-sync-guard] 需要产物才能往下走 → 加 run_in_background:false 重派，产物走 tool_result，根本不进那个会被折叠吃掉的队列。真要后台并行 → 派完立刻结束本轮交还主循环，禁止 sleep/轮询/紧接 AskUserQuestion。\n' >&2
 printf '[dispatch-sync-guard] 确需后台：在 ~/.claude/settings.json 的 env 段加 "ALLOW_BACKGROUND_DISPATCH":"1"（Bash 里 export 传不进 hook 进程）。\n' >&2
 exit 2

--- a/plugins/dispatch-contract/tests/dispatch-sync-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-sync-guard.bats
@@ -241,3 +241,59 @@ teardown() {
   run_rules_inject "$payload" "ALLOW_NO_RULES_INJECT=1"
   assert_inject_empty_stdout
 }
+
+# --- fork world (schema dropped run_in_background) ---
+
+@test "sync #16: RIB field absent + no DISABLE env -> BLOCK with fork-specific message" {
+  local payload
+  payload=$(mk_dispatch_payload "Agent" "omit")
+  # 夹具自检：确认 tool_input 里真的没有该键(防夹具错导致假绿)
+  run jq -e '.tool_input | has("run_in_background") | not' <<< "$payload"
+  [ "$status" -eq 0 ]
+
+  run_sync_guard "$payload"
+  assert_sync_block
+  [[ "$SYNC_STDERR" == *"CLAUDE_CODE_FORK_SUBAGENT"* ]] || {
+    echo "Expected fork-specific advice in stderr, got: $SYNC_STDERR"
+    return 1
+  }
+  # fork 世界必须给出可执行解法。判据锚定"有没有指向 FORK_SUBAGENT 这个正解",
+  # 而不是"有没有出现 ALLOW_BACKGROUND_DISPATCH 这个词"——消息里本就有一句
+  # "不要改用 ALLOW_BACKGROUND_DISPATCH=1 绕过"的劝阻,按词判会与自家措辞撞车。
+  # 因此这里断言:该词若出现,必须是以劝阻形态出现(带"不要")。
+  [[ "$SYNC_STDERR" == *"需重启"* ]] || {
+    echo "Fork-world message must state the fix requires a CC restart, got: $SYNC_STDERR"
+    return 1
+  }
+  if [[ "$SYNC_STDERR" == *"ALLOW_BACKGROUND_DISPATCH"* ]]; then
+    [[ "$SYNC_STDERR" == *"不要改用 ALLOW_BACKGROUND_DISPATCH"* ]] || {
+      echo "If ALLOW_BACKGROUND_DISPATCH appears in fork-world message it must be as a warning, got: $SYNC_STDERR"
+      return 1
+    }
+  fi
+}
+
+@test "sync #17: RIB explicitly true -> generic message, NOT the fork one" {
+  local payload
+  payload=$(mk_dispatch_payload "Agent" "true")
+  run jq -e '.tool_input | has("run_in_background")' <<< "$payload"
+  [ "$status" -eq 0 ]
+
+  run_sync_guard "$payload"
+  assert_sync_block
+  [[ "$SYNC_STDERR" != *"CLAUDE_CODE_FORK_SUBAGENT"* ]] || {
+    echo "Field-present block must not use the fork message, got: $SYNC_STDERR"
+    return 1
+  }
+}
+
+@test "sync #18: RIB string \"false\" -> generic message, NOT the fork one" {
+  local payload
+  payload=$(mk_dispatch_payload "Agent" "string_false")
+  run_sync_guard "$payload"
+  assert_sync_block
+  [[ "$SYNC_STDERR" != *"CLAUDE_CODE_FORK_SUBAGENT"* ]] || {
+    echo "Field-present block must not use the fork message, got: $SYNC_STDERR"
+    return 1
+  }
+}

--- a/plugins/dispatch-contract/tests/dispatch-sync-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-sync-guard.bats
@@ -39,6 +39,7 @@ teardown() {
   payload=$(mk_dispatch_payload "Task" "omit")
   # fixture self-check: field genuinely absent
   [[ "$(jq -e 'has("tool_input") and (.tool_input | has("run_in_background") | not)' <<< "$payload")" == "true" ]]
+  # 省略路径的 stderr 形态断言见 sync #16（field-absent 分支）——本用例只钉 BLOCK。
   run_sync_guard "$payload"
   assert_sync_block
 }

--- a/plugins/dispatch-contract/tests/test_helper/common-setup.bash
+++ b/plugins/dispatch-contract/tests/test_helper/common-setup.bash
@@ -114,10 +114,13 @@ run_gate() {
   local stderr_file
   stderr_file=$(mktemp)
 
+  # 夹具必须隔离调用者环境：若跑测试的 shell 里设了 ALLOW_UNMARKED_FINAL=1
+  # (subagent-done-gate 的逃生舱),门禁会全局失效,导致每个 BLOCK 用例假通过。
+  # -u 排在显式 override 之前,用例仍能主动传该变量做正向测试。
   if [[ "${2:-}" != "" ]]; then
-    HOOK_STDOUT=$(printf '%s' "$payload" | env "${@:2}" bash "$GATE_SCRIPT" 2>"$stderr_file") || HOOK_EXIT=$?
+    HOOK_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_UNMARKED_FINAL "${@:2}" bash "$GATE_SCRIPT" 2>"$stderr_file") || HOOK_EXIT=$?
   else
-    HOOK_STDOUT=$(printf '%s' "$payload" | bash "$GATE_SCRIPT" 2>"$stderr_file") || HOOK_EXIT=$?
+    HOOK_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_UNMARKED_FINAL bash "$GATE_SCRIPT" 2>"$stderr_file") || HOOK_EXIT=$?
   fi
   HOOK_STDERR=$(cat "$stderr_file")
   rm -f "$stderr_file"
@@ -196,10 +199,14 @@ run_sync_guard() {
   local stderr_file
   stderr_file=$(mktemp)
 
+  # 夹具必须隔离调用者环境：若跑测试的 shell 里设了 ALLOW_BACKGROUND_DISPATCH=1
+  # 或 CLAUDE_CODE_DISABLE_BACKGROUND_TASKS,门禁会全部 fail-open,导致每个
+  # BLOCK 用例假通过。测试结果不该取决于谁在什么 shell 里跑。
+  # 注意 -u 必须排在显式 override 之前,这样用例仍能主动传这两个变量做正向测试。
   if [[ "${2:-}" != "" ]]; then
-    SYNC_STDOUT=$(printf '%s' "$payload" | env "${@:2}" bash "$SYNC_GUARD_SCRIPT" 2>"$stderr_file") || SYNC_EXIT=$?
+    SYNC_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_BACKGROUND_DISPATCH -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS "${@:2}" bash "$SYNC_GUARD_SCRIPT" 2>"$stderr_file") || SYNC_EXIT=$?
   else
-    SYNC_STDOUT=$(printf '%s' "$payload" | bash "$SYNC_GUARD_SCRIPT" 2>"$stderr_file") || SYNC_EXIT=$?
+    SYNC_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_BACKGROUND_DISPATCH -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS bash "$SYNC_GUARD_SCRIPT" 2>"$stderr_file") || SYNC_EXIT=$?
   fi
   SYNC_STDERR=$(cat "$stderr_file")
   rm -f "$stderr_file"
@@ -216,10 +223,13 @@ run_rules_inject() {
   local stderr_file
   stderr_file=$(mktemp)
 
+  # 夹具必须隔离调用者环境：若跑测试的 shell 里设了 ALLOW_NO_RULES_INJECT=1
+  # (dispatch-rules-inject 的逃生舱),门禁会静默 exit 0 不注入,导致用例假通过。
+  # -u 排在显式 override 之前,用例仍能主动传该变量做正向测试。
   if [[ "${2:-}" != "" ]]; then
-    INJECT_STDOUT=$(printf '%s' "$payload" | env "${@:2}" bash "$INJECT_SCRIPT" 2>"$stderr_file") || INJECT_EXIT=$?
+    INJECT_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_NO_RULES_INJECT "${@:2}" bash "$INJECT_SCRIPT" 2>"$stderr_file") || INJECT_EXIT=$?
   else
-    INJECT_STDOUT=$(printf '%s' "$payload" | bash "$INJECT_SCRIPT" 2>"$stderr_file") || INJECT_EXIT=$?
+    INJECT_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_NO_RULES_INJECT bash "$INJECT_SCRIPT" 2>"$stderr_file") || INJECT_EXIT=$?
   fi
   INJECT_STDERR=$(cat "$stderr_file")
   rm -f "$stderr_file"


### PR DESCRIPTION
## 问题

`dispatch-sync-guard.sh` 在 fork-subagent 运行时拦下**全部**根线程 Agent 派发,而它唯一给出的出路 `ALLOW_BACKGROUND_DISPATCH=1` 会让门禁在**所有**环境一起失效。叠加 solo 编辑门禁后形成死锁:既不能自己改文件,也不能派人改。

## 根因(原注释说反了)

原 header 的 `Known failure mode` 段断言 fork 世界「后台通道不存在、风险为零、拦截是误伤」。读 2.1.222 运行时后确认相反。决定异步的表达式:

```js
let K=Wb(), q=bEe(), U=Lv();
Z = z || (o===!0 || V.background===!0 || K || q || !w && o!==!1) && !U;
```

`q` 即 `bEe()`(fork 特性)是**独立析取项**,fork 开启时 `Z` 恒真,全部派发走 `async_launched` / `isBackgroundAgent:true`。同时 `dia()` 把字段从 schema 摘掉,zod `.object()` 剥掉 schema 外的键,硬传 `run_in_background:false` 也进不了 `o`;即便进了,`q` 照样让 `Z` 为真。

所以 fork 世界不是「后台不存在」,而是**「后台被强制、同步不可表达」**——正是本门禁存在理由的最坏形态。门禁要求的证据,在它最该生效的世界里被物理删除了。

## 方案

判据**不放松一寸**:字段缺失仍 BLOCK(新增 step 9b),只把出路换成可执行的 `CLAUDE_CODE_FORK_SUBAGENT=0`。依据是 fork gate 的判定顺序:

```js
function Ax_(){
  if(Ple())return"disabled";
  if(tr(env.CLAUDE_CODE_FORK_SUBAGENT))return"env";
  if($u(env.CLAUDE_CODE_FORK_SUBAGENT))return"disabled";  // <- 在 rollout 检查之前
  if(Sn())return"disabled";
  if(Qe(wx_,!1))return"gb_rollout";
  return"disabled" }
```

假值分支排在 `tengu_copper_fox` rollout 检查**之前**,能压过服务端 flag。设它之后 `bEe()` 恒假,字段回到 schema,`q` 从 `Z` 里消失——第三态(通道存在但同步不可表达)停止存在,门禁判据不再面对空集。

**不新增第四个开关**:需要另一个门禁来保证诚实的门禁是设计坏味。移除危险优于把警报器蒙上。

检测刻意间接:rollout flag 的 on-disk cache 与 live 值曾观察到不一致,故不去读它,改用结构判据(字段缺失 + step 6 env 未设 ⟹ 只剩 bEe() 能解释)。普通运行时里忘传字段的派发也落到这里,而拦它本来就是对的。

## 顺带修的两个测试缺陷

1. **sync #16 断言与自家措辞撞车**:原断言要求 fork 消息不含 `ALLOW_BACKGROUND_DISPATCH`,但消息里本就有一句「不要改用 `ALLOW_BACKGROUND_DISPATCH=1` 绕过」的劝阻。改为锚定语义(是否给出可执行解法 + 该词若出现须为劝阻形态)。
2. **夹具不隔离调用者环境**:三个 fixture runner 未清逃生舱变量,跑测试的 shell 里若有 `ALLOW_BACKGROUND_DISPATCH=1`,门禁全部 fail-open,**每个 BLOCK 用例假通过**。已加 `env -u`(排在显式 override 之前,正向用例 sync #7/#8 不受影响)。这个缺陷是本轮实测撞上的。

## 验证

- 51 个用例全绿:`dispatch-sync-guard` 25(原 22 + 新增 3) + `subagent-done-gate` 26
- **变异验证**:fork 分支 `exit 2` 改 `exit 0` 时 sync #16 确实失败(`Expected exit 2, got 0`),证明非恒真假绿
- **污染验证**:带 `ALLOW_BACKGROUND_DISPATCH=1` 跑也全绿,证明夹具隔离生效
- 版本双写:`plugin.json` 与 `marketplace.json` 均 `1.2.1`

## 行为不变项

step 7(teammate `agent_id` 豁免)、step 8(team-ops `name` 生命线)、step 9 对显式 `true` 与字符串 `"false"` 的拦截,全部保持原语义(sync #17/#18 专门钉住"字段在场时不得走 fork 消息")。