### PR TITLE
feat(plan-review): 通用第二意见入口 second-opinion.sh (v1.6.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "plan-review",
       "description": "Adversarial plan review via cross-model consultation (agy/Claude/Codex)",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "author": {
         "name": "WooDragon"
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ WooDragon 的 Claude Code 插件 + 技能包 marketplace。
 
 | 类型 | 名称 | 说明 |
 |------|------|------|
-| Plugin | plan-review | 对抗性审阅（Gemini/Claude/Codex） |
+| Plugin | plan-review | 对抗性审阅（Gemini/Claude/Codex）+ `second-opinion.sh` 通用第二意见驱动（插件外可调用） |
 | Plugin | ppt-press（4 skills） | PPT 全生命周期（init/create/deploy/manage） |
 | Plugin | doc-gate（1 skill + 3 hooks + 2 tools） | 文档编辑门禁 + 词法召回 |
 | Plugin | code-search（1 skill） | 代码搜索与符号导航方法论（纯 skill，零 hook） |
@@ -33,9 +33,11 @@ plugins/
     .claude-plugin/plugin.json    # 插件元数据
     hooks/hooks.json              # PreToolUse + PreCompact hook 声明
     scripts/
-      plan-review.sh             # 编排器：守卫→计数→双安全阀→预检→prompt 组装→重试驱动→verdict 分支
+      plan-review.sh             # 编排器（hook）：守卫→计数→双安全阀→预检→prompt 组装→重试驱动→verdict 分支
+      second-opinion.sh          # 通用第二意见驱动：插件外调用方直接拿评审正文，fail loud，不做 verdict 解析
       lib/
         common.sh                # 日志三件套 + backfill_engine_err + allow_with_reason + plan_hash + DELTA_REVIEW_RULES（delta 审阅规则单一来源）+ clamp_head_bytes / clamp_tail_bytes（UTF-8 安全字节截断）
+        consult.sh                # 引擎调用状态机 run_consultation()：超时解析/降级检查/重试循环/REST fallback，hook 与驱动共用
         plan-source.sh           # transcript 反查三重安全门 + 提取链 + RESOLVE_REASON 三态文案
         verdict.sh               # verdict 提取 + APPROVE/CONCERNS/REJECT 三种反馈渲染
         manifest.sh              # Manifest 检测三函数 + MANIFEST_EXAMPLE + JSON 序列化
@@ -45,12 +47,14 @@ plugins/
           codex.sh               # REVIEW_ENGINE=codex（含 engine_err_filter 隐私过滤钩子）
           rest.sh                # REST SSE 降级通道（rest_ 前缀独立函数，不实现三钩子）
       assets/
-        review-system-prompt.md  # SYSTEM_INSTRUCTIONS 提示词正文（纯数据）
+        review-common.md         # 通用评审规范层（ground truth / Review Discipline / Finding Quality Gate / Severity / Verdict Rules / Output Format），供 hook 与驱动共用
+        review-plan.md           # plan 专有层（框架语 / Scope Boundary / 9 条 Review Criteria / 输出长度上限），hook 拼接在 review-common.md 之前
       dispatch-check.sh          # Layer 2 hook（Agent/Task 调度参数强制）
       precompact-review.sh       # PreCompact hook（compaction 恢复）
     tests/                        # BDD 测试套件（bats-core；用例计数属动态指标，权威版本见 MEMORY.md 层）
       plan-review.bats            # 主测试套件（含 Dispatch Manifest、codex 引擎、轮间记忆）
       dispatch-check.bats         # Layer 2 hook 测试
+      second-opinion.bats         # second-opinion.sh 驱动测试
       test_helper/
         common-setup.bash         # 测试基础设施（mock、断言）
   doc-gate/                       # 文档编辑门禁 + 词法召回插件

--- a/plugins/plan-review/.claude-plugin/plugin.json
+++ b/plugins/plan-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-review",
   "description": "Adversarial plan review via cross-model consultation (agy/Claude/Codex)",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": {
     "name": "woodragon"
   }

--- a/plugins/plan-review/README.md
+++ b/plugins/plan-review/README.md
@@ -18,11 +18,23 @@ claude --plugin-dir ~/.claude/dev-plugins/plan-review
 
 ```
 scripts/
-  plan-review.sh              Orchestrator: guards → counters → dual safety valves →
-                               pre-check → prompt assembly → retry driver → verdict branching
+  plan-review.sh              Orchestrator (PreToolUse hook): guards → counters → dual safety
+                               valves → pre-check → prompt assembly → retry driver → verdict
+                               branching. Plan-specific policy only (plan extraction, ack-round
+                               counters, verdict routing, manifest parsing).
+  second-opinion.sh           Generic second-opinion driver — a plain CLI any caller invokes
+                               directly to get a second opinion on any artifact, built on the
+                               same engine state machine. Does no verdict parsing; stdout is the
+                               engine's raw review text, verbatim. See "Second Opinion Entry
+                               Point" below.
   lib/
     common.sh                 Logging helpers, backfill_engine_err, allow_with_reason, plan_hash,
                                clamp_head_bytes/clamp_tail_bytes (UTF-8-safe byte-budget truncation)
+    consult.sh                Engine consultation state machine (run_consultation()): timeout
+                               resolution, degrade checks, the retry loop (capacity/timeout/empty-
+                               response handling), and the REST fallback. Shared by both
+                               plan-review.sh (hook) and second-opinion.sh (driver) — extracted so
+                               the engine infrastructure is callable outside the hook context.
     plan-source.sh            Transcript triple-gated lookup + extraction chain +
                                RESOLVE_REASON tri-state messaging
     verdict.sh                Verdict extraction + APPROVE/CONCERNS/REJECT feedback rendering
@@ -34,7 +46,14 @@ scripts/
                                 engine_err_filter privacy-redaction hook
       rest.sh                  REST SSE fallback (see "Engine interface" below)
   assets/
-    review-system-prompt.md   SYSTEM_INSTRUCTIONS prompt text (pure data, no shell logic)
+    review-common.md          Generic review-engine instructions shared by every caller (ground
+                               truth on version identifiers, Review Discipline, Finding Quality
+                               Gate, Severity Definitions, Verdict Rules, Output Format). Does not
+                               assume the artifact under review is a plan.
+    review-plan.md            Plan-specific layer (framing, Scope Boundary, the 9 Review
+                               Criteria, output length cap). Concatenated ahead of
+                               review-common.md when plan-review.sh assembles the hook's system
+                               prompt — this is the only consumer that concatenates the two.
   dispatch-check.sh           Layer 2 hook — Agent/Task dispatch-parameter enforcement
   precompact-review.sh        PreCompact hook — plan recovery across compaction
 ```
@@ -87,6 +106,19 @@ names.
 
 Legacy variables (`GEMINI_REVIEW_OFF`, `GEMINI_DRY_RUN`, `GEMINI_MAX_REVIEWS`) are supported via fallback mapping.
 
+### `second-opinion.sh` (generic second-opinion driver)
+
+The driver reuses the same engine variables above (`REVIEW_ENGINE`, `AGY_MODEL`, `CLAUDE_MODEL`,
+`CODEX_BIN`, `CODEX_MODEL`, `GEMINI_MODEL`, `REVIEW_API_URL`, `REVIEW_API_KEY`,
+`REVIEW_REST_TIMEOUT`, `REVIEW_REST_STALL_TIMEOUT`, `REVIEW_HOOK_BUDGET`,
+`REVIEW_CAPACITY_DELAY`, `REVIEW_ENGINE_DEGRADE_TTL`) and shares `REVIEW_COUNTER_DIR` (and
+therefore `DEGRADE_FILE`) with `plan-review.sh` — a Gemini capacity degrade tripped by one is
+honored by the other. It does **not** provide its own `--timeout` flag; time budget is inherited
+purely from env (`REVIEW_ENGINE_TIMEOUT` / `REVIEW_HOOK_BUDGET`). It also does **not** read
+`REVIEW_DISABLED` or `REVIEW_DRY_RUN` — see [Second Opinion Entry Point](#second-opinion-entry-point-second-opinionsh)
+for why. `REVIEW_LOG_DIR` (default `~/.claude/logs`) controls where its own `second-opinion.log`
+is written, separate from `plan-review.log`.
+
 ### `dispatch-check.sh` (Layer 2 — Agent/Task dispatch enforcement)
 
 | Variable | Default | Description |
@@ -109,7 +141,15 @@ on that second call permits execution.
 
 ## Review Criteria
 
-Nine criteria — authoritative text lives in `scripts/assets/review-system-prompt.md`.
+Nine criteria — authoritative text is split across two files (see [Architecture](#architecture)):
+
+- `scripts/assets/review-common.md` — the generic layer: version-identifier ground truth, Review
+  Discipline, Finding Quality Gate, Severity Definitions, Verdict Rules, Output Format. Shared by
+  every caller of the engine infrastructure, including `second-opinion.sh`; it never assumes the
+  reviewed artifact is a plan.
+- `scripts/assets/review-plan.md` — the plan-specific layer: framing, Scope Boundary, the 9
+  criteria below, and the output length cap. Only `plan-review.sh` uses this file, concatenating
+  it ahead of `review-common.md` when assembling the hook's system prompt.
 
 | # | Criterion | Focus |
 |---|-----------|-------|
@@ -171,7 +211,125 @@ The `## Consultation Context` block (present whenever a plan is past its first r
 
 The thread's lifetime mirrors the review cycle: cleared whenever a cycle ends — approval, either safety valve, no-plan fail-closed, or an orphan exit (engine not found / not attempted — dropped to avoid leaking one plan's findings into an unrelated later plan under the same session id). The one exception is a plan revised after approval (plan hash no longer matches the approved marker): that is not a cycle end — the counter keeps counting — so the thread survives with an appended revision marker instead of being cleared, since prior findings on this same plan are exactly the highest-value context to carry into the re-review. Only the `--conversation` handle is dropped there, since it embeds the full old plan text server-side.
 
-No new environment variables — the byte budgets are fixed defaults in `lib/common.sh` (`HISTORY_ROUND_BYTES=9000` per recorded round, `HISTORY_INJECT_BYTES=48000` on injection), sized so a full-length CJK review (`review-system-prompt.md` caps output at 3000 characters, ~9KB in Chinese) survives a single round uncut and roughly 5 rounds of thread history survive injection. Once a plan's accumulated thread exceeds the injection budget, `clamp_tail_bytes` keeps the most recent rounds and silently drops the oldest ones first. These match the raised `CLAUDE.md` ingestion limits below (`GLOBAL_MD_BYTES=8000`, `PROJECT_MD_BYTES=24000`).
+No new environment variables — the byte budgets are fixed defaults in `lib/common.sh` (`HISTORY_ROUND_BYTES=9000` per recorded round, `HISTORY_INJECT_BYTES=48000` on injection), sized so a full-length CJK review (`review-plan.md` caps output at 3000 characters, ~9KB in Chinese) survives a single round uncut and roughly 5 rounds of thread history survive injection. Once a plan's accumulated thread exceeds the injection budget, `clamp_tail_bytes` keeps the most recent rounds and silently drops the oldest ones first. These match the raised `CLAUDE.md` ingestion limits below (`GLOBAL_MD_BYTES=8000`, `PROJECT_MD_BYTES=24000`).
+
+## Second Opinion Entry Point (second-opinion.sh)
+
+`second-opinion.sh` is a generic, out-of-hook driver built on the same engine infrastructure
+(agy + Gemini 3.1 Pro + REST fallback + session reuse) that `plan-review.sh` uses. Unlike the
+hook, it is a plain CLI: any caller invokes it directly to get a second opinion on any artifact —
+not just an implementation plan — and gets back raw review text, not a verdict decision.
+
+### Interface
+
+```
+second-opinion.sh --system-prompt-file <path> [--system-prompt-file <path2> ...]
+                  [--prompt-file <path>] [--session <label>]
+```
+
+- `--system-prompt-file` — **required, repeatable**. Concatenated in command-line order to form
+  the system instructions sent to the engine. Missing entirely, pointing at a nonexistent path, or
+  an empty file is **fail loud**: nonzero exit, empty stdout. There is no fallback rubric — unlike
+  the hook, this driver never silently substitutes the plan-review criteria for a caller that
+  forgot to pass one.
+- Artifact body — `--prompt-file <path>` or stdin. **stdin is the only path available to callers
+  that are forbidden from writing files** (e.g. redteam-style callers operating under a
+  read-only mandate). If both are given, `--prompt-file` wins; stdin is a fallback for
+  file-write-averse callers, not a second source merged with an explicit file.
+- stdout carries **only** the review body — no JSON wrapper, no log lines. stderr carries all
+  diagnostics. Exit 0 means a result was obtained; nonzero means every engine was exhausted, or a
+  fail-loud precondition was violated.
+
+**Fail loud, not fail open.** `plan-review.sh` fails open (allows the tool call through) on every
+engine failure, because the cost of a false block is high and the hook has a native human
+approval step downstream regardless. This driver has no such downstream backstop — a caller
+treats whatever comes out of stdout as the review. A synthesized "looks like a review" response
+here would be actively misleading, so every failure path is fail-closed: nonzero exit, empty
+stdout, diagnostic on stderr.
+
+**Does not read `REVIEW_DISABLED` / `REVIEW_DRY_RUN`.** Those two variables encode "turn off the
+ExitPlanMode gate" semantics for the hook. An explicit, direct invocation of this driver is not
+that gate — it must not be silently reshaped by env state that was set for a different call site.
+
+**Shares `DEGRADE_FILE`** with `plan-review.sh` (same `REVIEW_COUNTER_DIR`) so a Gemini
+capacity-exhaustion degrade tripped by one caller is honored by the other. **Does no verdict
+parsing** — the driver is a transport layer only; `<verdict>` tags, if present in the engine's
+response, are returned as-is inside the raw text.
+
+### Session continuation (`--session <label>`)
+
+`--session <label>` takes an opaque label, not a file path. The actual session-file path is
+derived by the driver:
+
+```
+${REVIEW_COUNTER_DIR:-/tmp/claude-reviews}/.so-<hash(label + assembled system-prompt bytes)[:16]>
+```
+
+The hash folds in the **assembled system-prompt bytes**, not just the label, via `plan_hash()`
+(`lib/common.sh`, reused verbatim — sha256sum → shasum -a 256 → cksum fallback, so this stays
+portable across Linux and macOS). This is deliberate: it means a rubric edit invalidates the old
+session automatically. A caller does not need to remember "I changed the prompt, so I must also
+throw away the old `--session` value" — that is a rule a path-based scheme would require the
+caller to enforce themselves, and forgetting it means resuming a stale session under a changed
+rubric, silently mixing old and new review criteria.
+
+Real evidence from testing: with the same `--session` label, changing one byte of the system
+prompt changed the derived key from `9f2d2375...` to `bf96267a...`, and the engine returned to a
+genuinely fresh first round (no reference to "the previous round") instead of resuming the old
+one.
+
+Omitting `--session` gives a single-round, stateless call backed by a throwaway temp file — no
+session persists past that one invocation.
+
+### Path discovery
+
+The officially recommended path is:
+
+```
+~/.claude/plugins/marketplaces/cc-plugins/plugins/plan-review/scripts/second-opinion.sh
+```
+
+This is the version-less, CC-maintained git checkout — the one under `marketplaces/`, not
+`cache/`. **This has a real cost, and it is intentional to state it plainly rather than let
+callers discover it by surprise**: `marketplaces/` tracks the marketplace `HEAD`, but the hook
+actually loads assets from `plugins/cache/<version>/`. The two drift apart across a push — a
+caller invoking the `marketplaces/` path picks up a change immediately on push; the hook only
+picks it up after the next plugin reinstall. The same asset can therefore be two different
+versions depending on which of the two consumers is looking at it.
+
+**Do not glob `find ~/.claude/plugins -path '.../second-opinion.sh'` and take the first hit.**
+Tested against the structurally identical `pr-review` plugin, that glob returned three hits
+(`marketplaces/` + two different `cache/<version>/` directories); `head -1` picking the "right"
+one is an accident of filesystem traversal order, not a guarantee. `plan-review`'s own `cache/`
+directory currently has four different versions sitting side by side.
+
+### Time budget
+
+The driver does **not** provide its own `--timeout` flag — time budget is purely inherited from
+env (`REVIEW_ENGINE_TIMEOUT` / `REVIEW_HOOK_BUDGET`). To override, set those env vars inline on
+the invocation. Worst-case measured latency was ~415s (agy self-terminates at its own
+`--print-timeout` 5-minute mark, the retry guard breaks out because the remaining time budget is
+insufficient for another attempt, and REST fallback then gets its own 115s). Callers wrapping the
+driver in a `timeout` command should budget **at least 480s**.
+
+### Known limitation: no usage/log traceability
+
+The driver does not set `SESSION_ID`, so its calls produce **no** `agy-conversation` /
+`agy-usage` log lines — the driver's diagnostics go to stderr only (`second-opinion.log`), by
+design, but the practical effect is that a driver invocation **cannot be traced from
+`plan-review.log`**. If you need to quantify the driver's own token consumption, that requires
+adding a separate extraction mechanism — not currently in scope.
+
+### Example
+
+```bash
+SO=~/.claude/plugins/marketplaces/cc-plugins/plugins/plan-review/scripts/second-opinion.sh
+"$SO" --system-prompt-file <plugin>/scripts/assets/review-common.md \
+      --system-prompt-file <your-own-rubric>.md \
+      --session my-review-t7 <<'EOF'
+<artifact under review>
+EOF
+```
 
 ## Fault Tolerance
 

--- a/plugins/plan-review/README.md
+++ b/plugins/plan-review/README.md
@@ -324,12 +324,18 @@ adding a separate extraction mechanism — not currently in scope.
 
 ```bash
 SO=~/.claude/plugins/marketplaces/cc-plugins/plugins/plan-review/scripts/second-opinion.sh
-"$SO" --system-prompt-file <plugin>/scripts/assets/review-common.md \
-      --system-prompt-file <your-own-rubric>.md \
+"$SO" --system-prompt-file <your-own-rubric>.md \
+      --system-prompt-file <plugin>/scripts/assets/review-common.md \
       --session my-review-t7 <<'EOF'
 <artifact under review>
 EOF
 ```
+
+Order matters: your own rubric goes first, `review-common.md` goes last. The plugin's own
+`review-plan.md` follows the same rule (see [Review Criteria](#review-criteria) above) because it
+opens with framing language ("You are a senior software architect performing...") that must lead
+the assembled prompt; `review-common.md` is the shared review discipline and output-format layer,
+so it belongs at the end regardless of what precedes it.
 
 ## Fault Tolerance
 

--- a/plugins/plan-review/README.md
+++ b/plugins/plan-review/README.md
@@ -281,6 +281,16 @@ one.
 Omitting `--session` gives a single-round, stateless call backed by a throwaway temp file — no
 session persists past that one invocation.
 
+Multi-round memory under `--session` is **not unconditional**. It lives entirely in agy's
+server-side `--conversation` session, which only accumulates while the agy CLI path keeps
+succeeding. If the agy CLI fails on a given round and the REST fallback produces the review
+instead, that round's output never reaches agy's session history — the driver detects this and
+deletes the session file (`CONV_FILE`) rather than leave a conversation handle with a silent gap
+in it. The **next** round under the same `--session` label therefore starts over as a fresh first
+round, with no memory of anything before the REST fallback fired. Callers relying on continuity
+across rounds should treat "agy CLI succeeded every round so far" as the precondition for that
+continuity, not the `--session` flag alone.
+
 ### Path discovery
 
 The officially recommended path is:

--- a/plugins/plan-review/scripts/assets/review-common.md
+++ b/plugins/plan-review/scripts/assets/review-common.md
@@ -13,7 +13,7 @@ emit it as `[UNVERIFIED]` (never Critical), never as a confident correction.
 - Every issue MUST cite specific evidence from the artifact or its project context.
 
 ## Finding Quality Gate (pre-report self-check)
-False positives burn scarce negotiation rounds. Gate EVERY finding:
+False positives waste review budget. Gate EVERY finding:
 
 1. **Confidence** — Low confidence + Minor/Major → DROP silently. Low confidence +
    suspected Critical → keep as `[UNVERIFIED]`, downgrade to Major (→ CONCERNS, not REJECT).

--- a/plugins/plan-review/scripts/assets/review-common.md
+++ b/plugins/plan-review/scripts/assets/review-common.md
@@ -1,0 +1,57 @@
+## Version Identifiers Are Ground Truth
+Your training knowledge has a cutoff; the artifact may reference things newer than it.
+Treat version identifiers in the artifact — model names (e.g. `sonnet-5`, `opus-4.8`),
+library/dependency versions, API signatures — as GROUND TRUTH, not as claims to
+verify against your memory. Whether such an identifier "exists" or "is correct" is
+NOT common knowledge you may assert unprompted: it requires evidence from the
+artifact or its project context. Absent that evidence, you have no grounds to flag
+it — do not raise it. If you genuinely suspect a concrete, evidence-backed problem,
+emit it as `[UNVERIFIED]` (never Critical), never as a confident correction.
+
+## Review Discipline
+- Focus on gaps the author **missed**, not on restating what they already considered.
+- Every issue MUST cite specific evidence from the artifact or its project context.
+
+## Finding Quality Gate (pre-report self-check)
+False positives burn scarce negotiation rounds. Gate EVERY finding:
+
+1. **Confidence** — Low confidence + Minor/Major → DROP silently. Low confidence +
+   suspected Critical → keep as `[UNVERIFIED]`, downgrade to Major (→ CONCERNS, not REJECT).
+2. **False-positive registry** — Never raise: naming/style preferences, justified design
+   choices (attack the justification instead), tool/agent-type/parameter names, or version
+   identifiers whose existence or correctness you cannot verify from the artifact or its
+   project context — model names, library/dependency versions, API signatures (see
+   "Version Identifiers Are Ground Truth" above).
+3. **Severity calibration** — Style is never Major/Critical. Critical requires a concrete,
+   named blocker (specific vuln, data-loss path, wrong-result logic).
+4. **Verdict↔severity** — Confirm verdict matches highest surviving finding:
+   confirmed Critical → REJECT; Major or UNVERIFIED → CONCERNS; Minor-only → APPROVE.
+
+## Severity Definitions
+- **[Critical]** — Blocker: security vulnerabilities, data loss, logic errors producing wrong results, breaking changes to existing behavior, fundamental approach flaws
+- **[Major]** — Significant gap: missing error handling on critical paths, poor architecture decisions, performance issues under normal load, incomplete implementation
+- **[Minor]** — Polish: naming, style, documentation gaps, minor optimization opportunities
+
+## Verdict Rules
+- **APPROVE**: No issues, or only Minor items remaining
+- **CONCERNS**: Major items present (including any `[UNVERIFIED]` suspicion) but no confirmed Critical
+- **REJECT**: confirmed Critical items present
+
+Verdict is the structured severity signal — the automation routes on verdict tags only,
+no body scanning. Strictly follow verdict-severity correspondence (see Finding Quality
+Gate check 4 — the verdict must match your highest surviving finding).
+
+## Output Format
+- FIRST line must be a verdict tag: <verdict>APPROVE</verdict> or <verdict>CONCERNS</verdict> or <verdict>REJECT</verdict>
+- List issues, each prefixed with severity tag: `[Critical]`, `[Major]`, or `[Minor]`
+- Each issue format: `[Severity] description → impact → suggested fix`
+- A low-confidence but high-severity suspicion (Quality Gate check 1) is emitted as
+  `[Major] [UNVERIFIED] description → ...` — surfaced for the human, never as REJECT
+- If a severity level has no issues, omit it entirely
+- End with brief strengths of the artifact (if any)
+
+IMPORTANT: The verdict MUST be wrapped in <verdict></verdict> XML tags on the
+very first line. This is machine-parsed. Do NOT place verdict keywords anywhere
+else in your response without the tags.
+
+Use Chinese for the review output.

--- a/plugins/plan-review/scripts/assets/review-plan.md
+++ b/plugins/plan-review/scripts/assets/review-plan.md
@@ -11,15 +11,6 @@ calls, or parameter names that do not exist in YOUR environment — this is norm
 and correct. DO NOT judge whether tool names or agent type identifiers match your
 own system. Focus exclusively on logic, architecture, and engineering quality.
 
-Your training knowledge has a cutoff; the plan may reference things newer than it.
-Treat version identifiers in the plan — model names (e.g. `sonnet-5`, `opus-4.8`),
-library/dependency versions, API signatures — as GROUND TRUTH, not as claims to
-verify against your memory. Whether such an identifier "exists" or "is correct" is
-NOT common knowledge you may assert unprompted: it requires evidence from the plan
-or project context. Absent that evidence, you have no grounds to flag it — do not
-raise it. If you genuinely suspect a concrete, evidence-backed problem, emit it as
-`[UNVERIFIED]` (never Critical), never as a confident correction.
-
 Keep your response under 3000 characters.
 
 ## Review Criteria
@@ -90,50 +81,3 @@ Keep your response under 3000 characters.
      [Major]. Agent step missing model = [Critical]. This tier list matches
      the target environment's own manifest generator; do not diverge from it.
 8. **Reuse over reinvention** — Does the plan propose building something that already exists in the project dependencies, framework, or standard library? Custom implementations require explicit justification (e.g., "framework X lacks feature Y" with concrete evidence). Without strong justification, prefer existing solutions. This is a [Major] issue.
-
-## Review Discipline
-- Focus on gaps the plan author **missed**, not on restating what they already considered.
-- Every issue MUST cite specific evidence from the plan or project context.
-
-## Finding Quality Gate (pre-report self-check)
-False positives burn scarce negotiation rounds. Gate EVERY finding:
-
-1. **Confidence** — Low confidence + Minor/Major → DROP silently. Low confidence +
-   suspected Critical → keep as `[UNVERIFIED]`, downgrade to Major (→ CONCERNS, not REJECT).
-2. **False-positive registry** — Never raise: naming/style preferences, justified design
-   choices (attack the justification instead), tool/agent-type/parameter names, or version
-   identifiers whose existence or correctness you cannot verify from the plan or project
-   context — model names, library/dependency versions, API signatures (Scope Boundary).
-3. **Severity calibration** — Style is never Major/Critical. Critical requires a concrete,
-   named blocker (specific vuln, data-loss path, wrong-result logic).
-4. **Verdict↔severity** — Confirm verdict matches highest surviving finding:
-   confirmed Critical → REJECT; Major or UNVERIFIED → CONCERNS; Minor-only → APPROVE.
-
-## Severity Definitions
-- **[Critical]** — Blocker: security vulnerabilities, data loss, logic errors producing wrong results, breaking changes to existing behavior, fundamental approach flaws
-- **[Major]** — Significant gap: missing error handling on critical paths, poor architecture decisions, performance issues under normal load, incomplete implementation, reinventing functionality available in existing dependencies without justification
-- **[Minor]** — Polish: naming, style, documentation gaps, minor optimization opportunities
-
-## Verdict Rules
-- **APPROVE**: No issues, or only Minor items remaining
-- **CONCERNS**: Major items present (including any `[UNVERIFIED]` suspicion) but no confirmed Critical
-- **REJECT**: confirmed Critical items present
-
-Verdict is the structured severity signal — the automation routes on verdict tags only,
-no body scanning. Strictly follow verdict-severity correspondence (see Finding Quality
-Gate check 4 — the verdict must match your highest surviving finding).
-
-## Output Format
-- FIRST line must be a verdict tag: <verdict>APPROVE</verdict> or <verdict>CONCERNS</verdict> or <verdict>REJECT</verdict>
-- List issues, each prefixed with severity tag: `[Critical]`, `[Major]`, or `[Minor]`
-- Each issue format: `[Severity] description → impact → suggested fix`
-- A low-confidence but high-severity suspicion (Quality Gate check 1) is emitted as
-  `[Major] [UNVERIFIED] description → ...` — surfaced for the human, never as REJECT
-- If a severity level has no issues, omit it entirely
-- End with brief strengths of the plan (if any)
-
-IMPORTANT: The verdict MUST be wrapped in <verdict></verdict> XML tags on the
-very first line. This is machine-parsed. Do NOT place verdict keywords anywhere
-else in your response without the tags.
-
-Use Chinese for the review output.

--- a/plugins/plan-review/scripts/lib/common.sh
+++ b/plugins/plan-review/scripts/lib/common.sh
@@ -32,11 +32,11 @@
 #   - agy.sh assigns AGY_PROMPT as a double-quoted string, which also
 #     performs parameter expansion — ${DELTA_REVIEW_RULES} expands in place.
 DELTA_REVIEW_RULES=$(cat <<'DELTA_RULES_EOF'
-1. Re-check every prior Critical against the CURRENT plan: if resolved, drop
-   it; if effectively rebutted, withdraw it.
+1. Re-check every prior Critical against the CURRENT artifact: if resolved,
+   drop it; if effectively rebutted, withdraw it.
 2. A new non-Critical finding on text that is UNCHANGED since the last round
-   is a forfeited relitigation — it burns a round without improving the plan.
-   Do not raise it.
+   is a forfeited relitigation — it burns a round without improving the
+   artifact. Do not raise it.
 3. Focus new-finding attention on text that has changed since the last round.
 4. Evidence burden is symmetric. A rebuttal resting on an unverifiable
    factual claim about the codebase does NOT clear a finding — keep the

--- a/plugins/plan-review/scripts/lib/consult.sh
+++ b/plugins/plan-review/scripts/lib/consult.sh
@@ -1,0 +1,294 @@
+# lib/consult.sh — engine consultation state machine (CLI retry loop + REST
+# fallback), extracted from plan-review.sh's inline "Call review engine"
+# section so it can be shared by the hook AND a future out-of-plugin driver
+# (second-opinion.sh, PR2) without either one re-implementing the retry /
+# degrade / REST-downgrade logic. Sourced (not executed) by plan-review.sh.
+#
+# Entry point: run_consultation(). Return codes:
+#   0 — engine_probe succeeded; $REVIEW holds the result (possibly still
+#       empty if every attempt — CLI retries + REST fallback — failed; the
+#       caller distinguishes "tried and failed" from "never attempted" via
+#       $_fail_reason being non-empty/empty, exactly as before extraction).
+#   1 — engine_probe failed (CLI not found). $ENGINE_PROBE_REASON is set by
+#       engine_probe() itself. The caller owns the reaction to this (log +
+#       HISTORY_FILE cleanup + allow_with_reason) — that is hook policy, not
+#       state-machine plumbing, so it deliberately stays out of this file.
+#
+# Orchestrator globals this file reads (already in scope, same process):
+# REVIEW_DISABLED is NOT read here (handled by the caller before invoking
+# run_consultation). Reads: REVIEW_ENGINE, REVIEW_ENGINE_TIMEOUT,
+# REVIEW_ENGINE_DEGRADE_TTL, REVIEW_API_URL, REVIEW_API_KEY,
+# REVIEW_RETRY_DELAY, REVIEW_CAPACITY_DELAY, REVIEW_HOOK_BUDGET, DEGRADE_FILE,
+# CONV_FILE, LOG_FILE, ENGINE_CMD, ARTIFACT, ROUND_INDEX. The sourced engine
+# (agy/claude/codex) and rest.sh provide engine_probe/engine_invoke/
+# engine_extract/rest_invoke/rest_extract.
+#
+# Weak hooks (declare -F pattern, same spirit as engine_err_filter in
+# lib/common.sh's backfill_engine_err — no-op when the caller does not
+# define them):
+#   consult_on_round_end    — after engine_extract() inside the retry loop,
+#                             once this round's native-memory handle state is
+#                             final. plan-review.sh defines this to call its
+#                             own inject_review_thread(); a driver with no
+#                             HISTORY_FILE/round-memory concept leaves it
+#                             undefined.
+#   consult_on_rest_prepare — immediately before the REST fallback call.
+#                             plan-review.sh defines this to call
+#                             inject_review_thread force.
+#   consult_on_rest_success — after REST produces a non-empty REVIEW.
+#                             plan-review.sh defines this to drop CONV_FILE
+#                             (see the original call site's rationale — REST
+#                             just produced this round's authoritative result,
+#                             so agy's own session, if still "live", is now
+#                             one round behind).
+#
+# bash 3.2 compatible: no associative arrays, no ${var^^}, no &>>.
+
+run_consultation() {
+  # Portable timeout: timeout (GNU/Homebrew) > gtimeout (coreutils) > none
+  TIMEOUT_CMD=""
+  if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_CMD="timeout"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_CMD="gtimeout"
+  fi
+  # Engine-specific timeout defaults:
+  # - agy/Claude: 595s = hook timeout budget, one CLI attempt then REST fallback.
+  #   Time-budget guard blocks retry (remaining < ENGINE_TIMEOUT), preserving REST budget.
+  ENGINE_TIMEOUT="${REVIEW_ENGINE_TIMEOUT:-595}"
+
+  # --- Gemini degraded-state check ---
+  # If Gemini was capacity-exhausted recently and REST is configured,
+  # skip CLI entirely — gives REST the full ~115s budget.
+  REVIEW_ENGINE_DEGRADE_TTL="${REVIEW_ENGINE_DEGRADE_TTL:-600}"
+  _gemini_skip_cli=0
+  _fail_reason=""
+  if [ "$REVIEW_ENGINE" = "gemini" ] && [ -n "${REVIEW_API_URL:-}" ] && [ -n "${REVIEW_API_KEY:-}" ]; then
+    if [ -f "$DEGRADE_FILE" ]; then
+      degrade_ts=$(cat "$DEGRADE_FILE" 2>/dev/null)
+      [[ "$degrade_ts" =~ ^[0-9]+$ ]] || degrade_ts=0
+      now_ts=$(date +%s)
+      degrade_age=$(( now_ts - degrade_ts ))
+      if (( degrade_age < REVIEW_ENGINE_DEGRADE_TTL )); then
+        remaining_degrade=$(( REVIEW_ENGINE_DEGRADE_TTL - degrade_age ))
+        echo "plan-review: gemini degraded state active (${degrade_age}s ago, TTL=${REVIEW_ENGINE_DEGRADE_TTL}s, ${remaining_degrade}s remaining), skipping CLI → REST fallback" >&2
+        log_decision "gemini-degraded skip-cli remaining_degrade=${remaining_degrade}s"
+        _gemini_skip_cli=1
+        _fail_reason="Gemini: degraded state (${degrade_age}s ago, expires in ${remaining_degrade}s)"
+      fi
+    fi
+  fi
+
+  # --- Engine invocation with retry (2 attempts: 1 initial + 1 retry) ---
+  # Background + wait pattern: tracks ENGINE_PID so _cleanup can kill the engine
+  # process if the hook script itself is terminated (e.g. hook timeout SIGTERM).
+  ENGINE_OUT=$(mktemp)
+  ENGINE_STATUS="${ENGINE_OUT}.status"
+  # Orchestrator owns the stderr CHANNEL for every engine (agy/claude/codex
+  # alike) — allocated unconditionally here, not codex-private. Each engine
+  # redirects its own invocation's stderr into it (2>"$ENGINE_ERR") and
+  # declares, via $ENGINE_ERR_POLICY (set in its engine_probe()), what the
+  # orchestrator is allowed to do with the CONTENT: "verbatim" (agy/claude)
+  # backfills it into LOG_FILE unconditionally; "filtered" (codex) only logs
+  # a privacy-filtered excerpt on failure, via the engine's own
+  # engine_err_filter() hook — see backfill_engine_err() in lib/common.sh.
+  ENGINE_ERR="${ENGINE_OUT}.err"
+  REVIEW=""
+  HOOK_BUDGET="${REVIEW_HOOK_BUDGET:-595}"
+
+  # --- Pre-flight: CLI existence check (permanent failure, no retry) + one-
+  #     time per-engine setup (model resolution, temp resource prep) —
+  #     delegated to the sourced engine's engine_probe(), called once outside
+  #     the retry loop below. ---
+  if ! engine_probe; then
+    return 1
+  fi
+
+  for (( engine_attempt=1; engine_attempt<=2; engine_attempt++ )); do
+    # Degraded-state skip: jump out of CLI retry immediately on first iteration.
+    if (( engine_attempt == 1 )) && [ "$_gemini_skip_cli" = "1" ]; then
+      break
+    fi
+
+    # Time-budget guard: on retry, check remaining wall-clock time can fit
+    # a full ENGINE_TIMEOUT. Prevents hook timeout SIGTERM from killing
+    # the script mid-retry, making REST fallback unreachable.
+    if (( engine_attempt > 1 )); then
+      remaining=$(( HOOK_BUDGET - SECONDS ))
+      if (( remaining < ENGINE_TIMEOUT )); then
+        echo "plan-review: time budget exhausted for retry (${remaining}s remaining < ${ENGINE_TIMEOUT}s needed), breaking to fallback..." >&2
+        log_decision "skip-retry reason=time-budget remaining=${remaining}s timeout=${ENGINE_TIMEOUT}s budget=${HOOK_BUDGET}s"
+        break
+      fi
+    fi
+    engine_exit=0
+
+    # --- Call the sourced engine's invoke hook. agy's invoke may set
+    #     _ENGINE_ABORT_RETRY=1 (oversized prompt, ARG_MAX defense) to signal
+    #     an immediate break BEFORE extraction/exit-code handling — mirroring
+    #     the pre-refactor inline `break`. A literal `break` inside the
+    #     function itself would be bash-version-dependent (verified: bash 3.2
+    #     propagates it to this loop, bash 5.x does not), so an explicit flag
+    #     is the only portable signal.
+    _ENGINE_ABORT_RETRY=0
+    engine_invoke
+    if [ "$_ENGINE_ABORT_RETRY" = "1" ]; then
+      break
+    fi
+
+    # Capacity-exhaustion detection (used further below) MUST scan the raw
+    # $ENGINE_ERR before backfill_engine_err (next) truncates it (see
+    # lib/common.sh) — capture into a flag now, consumed later instead of
+    # re-grepping a file that will already be empty by then.
+    _capacity_hit=0
+    grep -qE "RESOURCE_EXHAUSTED|MODEL_CAPACITY" "$ENGINE_ERR" 2>/dev/null && _capacity_hit=1
+
+    # Backfill this round's $ENGINE_ERR into LOG_FILE per the engine's own
+    # $ENGINE_ERR_POLICY (see lib/common.sh) — unconditionally for
+    # "verbatim" engines (success and failure alike), failure-only and
+    # filtered for codex. Also truncates $ENGINE_ERR once backfilled, so a
+    # later defensive re-backfill (_cleanup on hook-kill) is a harmless no-op
+    # in the normal exit path.
+    backfill_engine_err "$engine_exit"
+
+    engine_extract
+
+    # Orchestrator-level CONV_FILE invalidation: a non-zero CLI exit (timeout
+    # 124, resume-rejected, network, plain 1) means engine_extract()'s own
+    # outer guard (`[ "$engine_exit" = "0" ] && [ -s "$ENGINE_OUT" ]`) never
+    # ran, so agy's internal persist/rm logic never touched CONV_FILE this
+    # round — the orchestrator is the ONLY thing that can invalidate it here.
+    # Drop it so the next round starts a fresh full first round instead of
+    # re-sending a --conversation onto a session that just failed. (A 0-exit-
+    # but-malformed-envelope round is the other invalidation path, handled
+    # entirely inside engine_extract() itself — see lib/engines/agy.sh.)
+    if [ "$engine_exit" != "0" ]; then
+      rm -f "${CONV_FILE:-}"
+    fi
+
+    # Call site 2: by this point this round's native-handle state is FINAL,
+    # whichever of the paths above (or agy's own internal rm inside
+    # engine_extract) got it there — see inject_review_thread's own comment
+    # for why this single point replaces per-rm-site patches.
+    declare -F consult_on_round_end >/dev/null 2>&1 && consult_on_round_end || true
+
+    : > "$ENGINE_OUT"
+    if [ "$engine_exit" != "0" ]; then
+      REVIEW=""
+      _fail_reason="${REVIEW_ENGINE}: exit ${engine_exit}"
+      if [ "$engine_attempt" -lt 2 ]; then
+        # Detect capacity-exhausted 429 (MODEL_CAPACITY_EXHAUSTED via cloudcode-pa.googleapis.com).
+        # These outages last minutes — the default 2s retry delay is useless;
+        # a longer wait gives the server time to recover.
+        # $_capacity_hit was captured above (BEFORE backfill_engine_err ran)
+        # from this round's raw, un-truncated $ENGINE_ERR directly — NOT
+        # LOG_FILE. This is the fix for the codex fast-break bug: codex's raw
+        # stderr never reaches LOG_FILE wholesale (privacy filter, see
+        # engine_err_filter in lib/engines/codex.sh), so grepping LOG_FILE
+        # only ever caught this pattern for agy/claude by coincidence —
+        # codex's fast-break depended on the capacity keyword happening to
+        # survive the 500-byte filtered codex-diag excerpt. All three engines
+        # are treated identically here because $ENGINE_ERR always held this
+        # round's complete, unfiltered stderr regardless of engine (at the
+        # time it was captured, before this same round's backfill truncated it).
+        if [ "$_capacity_hit" = "1" ]; then
+          _fail_reason="${REVIEW_ENGINE}: capacity exhausted (MODEL_CAPACITY_EXHAUSTED)"
+          # CONV_FILE was already dropped and re-injected (if needed) by call
+          # site 2 above, right after engine_extract() — a capacity-flavored
+          # non-zero exit is still a non-zero exit, no separate handling
+          # needed here (the old duplicate rm+inject pinned to this branch
+          # specifically was provably a no-op: this code only runs inside the
+          # `engine_exit != 0` branch, whose invalidation already ran).
+          # If REST fallback is configured, skip retry immediately — retrying a
+          # capacity-exhausted endpoint wastes the time budget REST needs.
+          if [ -n "${REVIEW_API_URL:-}" ] && [ -n "${REVIEW_API_KEY:-}" ]; then
+            # Persist degraded state: subsequent hooks skip CLI for TTL seconds.
+            if [ "$REVIEW_ENGINE" = "gemini" ]; then
+              printf '%s' "$(date +%s)" > "$DEGRADE_FILE" 2>/dev/null || true
+              log_decision "gemini-degrade-write ts=$(date +%s)"
+            fi
+            echo "plan-review: $REVIEW_ENGINE capacity exhausted, skipping retry (REST fallback available)" >&2
+            log_decision "rest-skip=capacity-fast-break engine=$REVIEW_ENGINE attempt=$engine_attempt"
+            break
+          fi
+          retry_delay="${REVIEW_CAPACITY_DELAY:-25}"
+          echo "plan-review: $REVIEW_ENGINE capacity exhausted, waiting ${retry_delay}s for recovery..." >&2
+        else
+          retry_delay="${REVIEW_RETRY_DELAY:-2}"
+          echo "plan-review: $REVIEW_ENGINE failed (attempt $engine_attempt/2, exit $engine_exit), retrying in ${retry_delay}s..." >&2
+        fi
+        sleep "$retry_delay"
+      fi
+      continue
+    fi
+
+    # Engine succeeded (exit 0) but returned empty → retry
+    if [ -z "$REVIEW" ]; then
+      if [ "$engine_attempt" -lt 2 ]; then
+        echo "plan-review: engine returned empty response (attempt $engine_attempt/2), retrying..." >&2
+        sleep "${REVIEW_RETRY_DELAY:-2}"
+      fi
+      continue
+    fi
+
+    # Non-empty response obtained — exit retry loop
+    break
+  done
+
+  # --- REST API fallback: CLI exhausted, try OpenAI-compatible endpoint ---
+  # Zero-intrusion: only fires when CLI produced no result AND env vars are set.
+  # REVIEW_API_URL/REVIEW_API_KEY empty → skip (preserves original fail-open).
+  if [ -z "$REVIEW" ] && [ -n "${REVIEW_API_URL:-}" ] && [ -n "${REVIEW_API_KEY:-}" ]; then
+    # Persist (or refresh) Gemini degraded state for any failure mode.
+    # Covers timeout (exit 124), network errors (ECONNRESET), empty responses, etc.
+    # Always refreshes the timestamp — even if the file already exists but has expired.
+    # Without refresh, an expired degrade file blocks TTL renewal: the check above lets
+    # Gemini run again (_gemini_skip_cli=0), it fails again, but the stale file prevents
+    # writing a new timestamp, creating an infinite retry-with-40s-REST-budget loop.
+    if [ "$REVIEW_ENGINE" = "gemini" ] && [ "$_gemini_skip_cli" = "0" ]; then
+      printf '%s' "$(date +%s)" > "$DEGRADE_FILE" 2>/dev/null || true
+      log_decision "gemini-degrade-write ts=$(date +%s) reason=rest-fallback-triggered"
+    fi
+    echo "plan-review: CLI exhausted, trying REST API fallback..." >&2
+    log_decision "rest-start url=${REVIEW_API_URL:+(set)} key=${REVIEW_API_KEY:+(set)}"
+
+    # Call site 3 (force): REST is a DIFFERENT engine, not "agy with a maybe-
+    # cleared CONV_FILE" — it never has session memory of its own, so gating
+    # its injection on agy's CONV_FILE state is a category error. `force`
+    # skips that condition entirely; this is what closes the gap where a
+    # round aborts BEFORE ever reaching engine_extract() (agy's own ARG_MAX
+    # guard, ${TIMEOUT_CMD:+...} never invoked, ${_ENGINE_ABORT_RETRY}=1) —
+    # CONV_FILE is untouched in that path and can still look perfectly live,
+    # even though REST, about to receive this exact prompt, has no way to
+    # consume that liveness. HISTORY_INJECTED still guards this from
+    # double-injecting on top of call site 1 or 2 if either already injected
+    # this round.
+    declare -F consult_on_rest_prepare >/dev/null 2>&1 && consult_on_rest_prepare || true
+    rest_invoke
+    rest_extract
+
+    # Cross-ROUND fix (different dimension from the three same-round
+    # injection call sites above — do not fold this into any of them). This
+    # round's CONV_FILE can still be live even after REST — not agy — just
+    # produced the authoritative REVIEW for it (e.g. the ARG_MAX-abort path:
+    # agy's own CLI never ran, so nothing ever touched CONV_FILE). If left
+    # alone, agy's server-side session history silently stops one round
+    # short of current: the NEXT round's composition-time check
+    # (call site 1) sees a non-empty CONV_FILE, concludes agy has native
+    # memory, and skips thread injection — but agy's actual session never
+    # saw this round's REST-produced finding, so the next round gets NEITHER
+    # the injected thread NOR a native memory of what REST just found.
+    # Dropping CONV_FILE here forces the next round onto the thread path
+    # instead, which DOES have this round's finding (written into
+    # HISTORY_FILE via A3 further below). Gated on REVIEW being non-empty:
+    # if REST also failed, this round produced no authoritative result at
+    # all, so agy's (possibly still-valid) session must not be invalidated
+    # for nothing.
+    [ -z "$REVIEW" ] || { declare -F consult_on_rest_success >/dev/null 2>&1 && consult_on_rest_success || true; }
+
+    : > "$ENGINE_OUT"
+    [ -z "$REVIEW" ] || echo "plan-review: REST API fallback succeeded." >&2
+  fi
+
+  return 0
+}

--- a/plugins/plan-review/scripts/lib/engines/agy.sh
+++ b/plugins/plan-review/scripts/lib/engines/agy.sh
@@ -5,7 +5,7 @@
 # why unrecognized values fall through here (current-behavior preservation).
 #
 # Orchestrator pre-sets before calling these hooks: PROMPT_FILE,
-# SYSTEM_INSTRUCTIONS, PLAN, TOTAL_ROUNDS, ENGINE_OUT, ENGINE_TIMEOUT,
+# SYSTEM_INSTRUCTIONS, ARTIFACT, ROUND_INDEX, ENGINE_OUT, ENGINE_TIMEOUT,
 # TIMEOUT_CMD, CONV_FILE, LOG_FILE, ENGINE_CMD.
 #
 # engine_invoke may set _ENGINE_ABORT_RETRY=1 to signal the caller's retry
@@ -97,7 +97,7 @@ engine_invoke() {
     # an injected "## Prior Review Thread" section to point at (PROMPT_FILE
     # is bypassed), so it must not claim one may exist above.
     AGY_PROMPT="## Consultation Context
-This is round $((TOTAL_ROUNDS + 1)) of adversarial review.
+This is round $((ROUND_INDEX + 1)) of adversarial review.
 The plan author may have revised or added rebuttals since the previous round.
 Evaluate the CURRENT plan on its merits — if prior concerns have been addressed, APPROVE.
 
@@ -106,7 +106,7 @@ memory):
 ${DELTA_REVIEW_RULES}
 
 ## Plan to Review
-${PLAN}"
+${ARTIFACT}"
   fi
 
   # ARG_MAX defense: agy only accepts the prompt as a command-line argument,

--- a/plugins/plan-review/scripts/lib/engines/agy.sh
+++ b/plugins/plan-review/scripts/lib/engines/agy.sh
@@ -98,14 +98,14 @@ engine_invoke() {
     # is bypassed), so it must not claim one may exist above.
     AGY_PROMPT="## Consultation Context
 This is round $((ROUND_INDEX + 1)) of adversarial review.
-The plan author may have revised or added rebuttals since the previous round.
-Evaluate the CURRENT plan on its merits — if prior concerns have been addressed, APPROVE.
+The author may have revised the artifact or added rebuttals since the previous round.
+Evaluate the CURRENT artifact on its merits — if prior concerns have been addressed, APPROVE.
 
 Delta review rules (this round builds on prior rounds — see your own session
 memory):
 ${DELTA_REVIEW_RULES}
 
-## Plan to Review
+## Artifact to Review
 ${ARTIFACT}"
   fi
 

--- a/plugins/plan-review/scripts/lib/engines/claude.sh
+++ b/plugins/plan-review/scripts/lib/engines/claude.sh
@@ -3,7 +3,7 @@
 # executed) by plan-review.sh when REVIEW_ENGINE=claude.
 #
 # Orchestrator pre-sets before calling these hooks: PROMPT_FILE,
-# SYSTEM_INSTRUCTIONS, PLAN, TOTAL_ROUNDS, ENGINE_OUT, ENGINE_TIMEOUT,
+# SYSTEM_INSTRUCTIONS, ARTIFACT, ROUND_INDEX, ENGINE_OUT, ENGINE_TIMEOUT,
 # TIMEOUT_CMD, CONV_FILE, LOG_FILE, ENGINE_CMD.
 #
 # bash 3.2 compatible: no associative arrays, no ${var^^}, no &>>.

--- a/plugins/plan-review/scripts/lib/engines/codex.sh
+++ b/plugins/plan-review/scripts/lib/engines/codex.sh
@@ -3,7 +3,7 @@
 # executed) by plan-review.sh when REVIEW_ENGINE=codex.
 #
 # Orchestrator pre-sets before calling these hooks: PROMPT_FILE,
-# SYSTEM_INSTRUCTIONS, PLAN, TOTAL_ROUNDS, ENGINE_OUT, ENGINE_TIMEOUT,
+# SYSTEM_INSTRUCTIONS, ARTIFACT, ROUND_INDEX, ENGINE_OUT, ENGINE_TIMEOUT,
 # TIMEOUT_CMD, CONV_FILE, LOG_FILE, ENGINE_CMD. ENGINE_TMP_FILES/
 # ENGINE_TMP_DIRS arrays are declared (and cleared) by the caller before
 # trap registration — this file only appends its own private temp paths.

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -57,7 +57,9 @@ LIB_COMMON="$SCRIPT_DIR/lib/common.sh"
 LIB_PLAN_SOURCE="$SCRIPT_DIR/lib/plan-source.sh"
 LIB_MANIFEST="$SCRIPT_DIR/lib/manifest.sh"
 LIB_VERDICT="$SCRIPT_DIR/lib/verdict.sh"
-PROMPT_ASSET="$SCRIPT_DIR/assets/review-system-prompt.md"
+LIB_CONSULT="$SCRIPT_DIR/lib/consult.sh"
+PROMPT_ASSET_PLAN="$SCRIPT_DIR/assets/review-plan.md"
+PROMPT_ASSET_COMMON="$SCRIPT_DIR/assets/review-common.md"
 
 for _lib in "$LIB_COMMON" "$LIB_PLAN_SOURCE" "$LIB_MANIFEST" "$LIB_VERDICT"; do
   # `-s` (exists AND non-empty) catches both gaps in one test: a missing
@@ -188,7 +190,7 @@ LIB_ENGINES_DIR="$SCRIPT_DIR/lib/engines"
 LIB_REST="$LIB_ENGINES_DIR/rest.sh"
 LIB_ENGINE_SELECTED="$LIB_ENGINES_DIR/$ENGINE_LIB"
 
-for _lib in "$LIB_REST" "$LIB_ENGINE_SELECTED"; do
+for _lib in "$LIB_REST" "$LIB_ENGINE_SELECTED" "$LIB_CONSULT"; do
   # Same `-s` rationale as the first bootstrap block above: an empty file
   # passes `-f` clean, `source` "succeeds" on zero bytes, and the first call
   # into a helper this lib was supposed to define (e.g. engine_probe) then
@@ -206,6 +208,8 @@ unset _lib
 _source_lib "$LIB_REST"
 # shellcheck disable=SC1090  # dynamic path — engine chosen by the whitelisted case above
 _source_lib "$LIB_ENGINE_SELECTED"
+# shellcheck source=lib/consult.sh
+_source_lib "$LIB_CONSULT"
 unset -f _source_lib
 
 # --- Unified field extraction (single jq fork, reused by guards + logging) ---
@@ -456,8 +460,12 @@ fi
 # Static instructions: single canonical source, injected per-channel (see
 # variant A below): claude → --system-prompt; agy → inline concat; REST →
 # messages[0]. PROMPT_FILE itself carries dynamic content only.
-# SYSTEM_INSTRUCTIONS content lives in $PROMPT_ASSET (scripts/assets/
-# review-system-prompt.md), not inline — keeps the review rubric editable
+# SYSTEM_INSTRUCTIONS content lives in two assets under scripts/assets/ —
+# review-plan.md (plan-specific framing/criteria) and review-common.md
+# (engine-agnostic rubric, also consumable by an out-of-plugin caller via
+# --system-prompt-file) — concatenated in that order (review-plan.md's
+# framing language must come first; review-common.md was originally the
+# TAIL of the single asset), not inline, so the review rubric stays editable
 # without touching bash. Missing/empty asset fails open (same allow +
 # [WARNING] shape as the jq-missing guard above). A plain $(...) would
 # silently strip the file's trailing newline; the original `read -r -d ''`
@@ -465,29 +473,41 @@ fi
 # with \n, and `read -d ''` never finds its NUL delimiter so nothing gets
 # stripped), so we append a sentinel byte before capture and strip only the
 # sentinel back off — this reproduces the exact prior byte sequence.
-if [ ! -f "$PROMPT_ASSET" ] || [ ! -s "$PROMPT_ASSET" ]; then
-  echo "plan-review: missing/empty prompt asset $PROMPT_ASSET, allowing." >&2
-  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"[WARNING] prompt asset missing/empty, plan-review skipped"}}'
-  exit 0
-fi
-# Anchor check: `-s` only proves the file has SOME bytes — a truncated asset
+for PROMPT_ASSET in "$PROMPT_ASSET_PLAN" "$PROMPT_ASSET_COMMON"; do
+  if [ ! -f "$PROMPT_ASSET" ] || [ ! -s "$PROMPT_ASSET" ]; then
+    echo "plan-review: missing/empty prompt asset $PROMPT_ASSET, allowing." >&2
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"[WARNING] prompt asset missing/empty, plan-review skipped"}}'
+    exit 0
+  fi
+done
+unset PROMPT_ASSET
+# The `printf '\n'` between the two tr streams is load-bearing, not
+# decorative: review-plan.md ends mid-paragraph (criterion 8's prose) and
+# review-common.md opens with a `## ` heading (Version Identifiers Are Ground
+# Truth) — markdown requires a blank line before a heading or it gets glued
+# to the preceding paragraph on render. Before the split, this exact boundary
+# sat inside one file with a blank line separating the sections; splitting
+# into two files and concatenating them back-to-back silently dropped that
+# blank line, so it has to be reinserted here to reproduce the original byte
+# layout at the seam.
+SYSTEM_INSTRUCTIONS=$( { tr -d '\r' < "$PROMPT_ASSET_PLAN"; printf '\n'; tr -d '\r' < "$PROMPT_ASSET_COMMON"; }; printf 'x')
+SYSTEM_INSTRUCTIONS="${SYSTEM_INSTRUCTIONS%x}"
+# Anchor check: `-s` only proves each file has SOME bytes — a truncated asset
 # (e.g. left as a single space or a lone newline by a bad edit) still passes
 # `-s` but carries no real reviewing instructions. `<verdict>` is the one
-# string this file MUST contain: it is the literal tag extract_verdict()
-# (lib/verdict.sh) greps the engine's response for — if the prompt asset
-# doesn't instruct the engine to emit that tag, no review response will ever
-# parse, silently degrading every verdict to the CONCERNS fallback instead of
-# failing open visibly. Reusing that same load-bearing string as the anchor
-# (rather than an arbitrary section heading that could be renamed with zero
-# functional impact) means this check can only pass if the asset still does
-# the one thing the rest of the pipeline actually depends on.
-if ! grep -qF '<verdict>' "$PROMPT_ASSET"; then
-  echo "plan-review: prompt asset $PROMPT_ASSET missing <verdict> anchor (truncated?), allowing." >&2
+# string the CONCATENATED result MUST contain: it is the literal tag
+# extract_verdict() (lib/verdict.sh) greps the engine's response for — if the
+# assembled prompt doesn't instruct the engine to emit that tag, no review
+# response will ever parse, silently degrading every verdict to the CONCERNS
+# fallback instead of failing open visibly. The tag lives in review-common.md
+# post-split, but the check validates the assembled SYSTEM_INSTRUCTIONS
+# (rather than either single file) because that is what the engine actually
+# receives — the one thing the rest of the pipeline depends on.
+if ! grep -qF '<verdict>' <<< "$SYSTEM_INSTRUCTIONS"; then
+  echo "plan-review: prompt assets ($PROMPT_ASSET_PLAN + $PROMPT_ASSET_COMMON) missing <verdict> anchor (truncated?), allowing." >&2
   echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"[WARNING] prompt asset truncated, plan-review skipped"}}'
   exit 0
 fi
-SYSTEM_INSTRUCTIONS=$(tr -d '\r' < "$PROMPT_ASSET"; printf 'x')
-SYSTEM_INSTRUCTIONS="${SYSTEM_INSTRUCTIONS%x}"
 
 ENGINE_OUT=""
 ENGINE_STATUS=""
@@ -622,62 +642,22 @@ if [ "$REVIEW_DRY_RUN" = "1" ]; then
   REVIEW="<verdict>APPROVE</verdict>
 [DRY-RUN] 审阅调用已跳过。"
 else
-  # Portable timeout: timeout (GNU/Homebrew) > gtimeout (coreutils) > none
-  TIMEOUT_CMD=""
-  if command -v timeout >/dev/null 2>&1; then
-    TIMEOUT_CMD="timeout"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    TIMEOUT_CMD="gtimeout"
-  fi
-  # Engine-specific timeout defaults:
-  # - agy/Claude: 595s = hook timeout budget, one CLI attempt then REST fallback.
-  #   Time-budget guard blocks retry (remaining < ENGINE_TIMEOUT), preserving REST budget.
-  ENGINE_TIMEOUT="${REVIEW_ENGINE_TIMEOUT:-595}"
+  # consult.sh's run_consultation() is engine-neutral, so it reads ARTIFACT/
+  # ROUND_INDEX instead of this hook's own PLAN/TOTAL_ROUNDS — see agy.sh's
+  # resume branch (Section B rename) for why: a future out-of-plugin driver
+  # (second-opinion.sh) has no "plan" concept, only "an artifact under review".
+  ARTIFACT="$PLAN"
+  ROUND_INDEX="$TOTAL_ROUNDS"
 
-  # --- Gemini degraded-state check ---
-  # If Gemini was capacity-exhausted recently and REST is configured,
-  # skip CLI entirely — gives REST the full ~115s budget.
-  REVIEW_ENGINE_DEGRADE_TTL="${REVIEW_ENGINE_DEGRADE_TTL:-600}"
-  _gemini_skip_cli=0
-  _fail_reason=""
-  if [ "$REVIEW_ENGINE" = "gemini" ] && [ -n "${REVIEW_API_URL:-}" ] && [ -n "${REVIEW_API_KEY:-}" ]; then
-    if [ -f "$DEGRADE_FILE" ]; then
-      degrade_ts=$(cat "$DEGRADE_FILE" 2>/dev/null)
-      [[ "$degrade_ts" =~ ^[0-9]+$ ]] || degrade_ts=0
-      now_ts=$(date +%s)
-      degrade_age=$(( now_ts - degrade_ts ))
-      if (( degrade_age < REVIEW_ENGINE_DEGRADE_TTL )); then
-        remaining_degrade=$(( REVIEW_ENGINE_DEGRADE_TTL - degrade_age ))
-        echo "plan-review: gemini degraded state active (${degrade_age}s ago, TTL=${REVIEW_ENGINE_DEGRADE_TTL}s, ${remaining_degrade}s remaining), skipping CLI → REST fallback" >&2
-        log_decision "gemini-degraded skip-cli remaining_degrade=${remaining_degrade}s"
-        _gemini_skip_cli=1
-        _fail_reason="Gemini: degraded state (${degrade_age}s ago, expires in ${remaining_degrade}s)"
-      fi
-    fi
-  fi
+  # Weak hooks consumed by run_consultation() (see lib/consult.sh's own
+  # header comment) — this hook is the "plan-review" caller, so all three
+  # simply forward to inject_review_thread(), exactly as the pre-extraction
+  # inline call sites did.
+  consult_on_round_end() { inject_review_thread; }
+  consult_on_rest_prepare() { inject_review_thread force; }
+  consult_on_rest_success() { rm -f "${CONV_FILE:-}"; }
 
-  # --- Engine invocation with retry (2 attempts: 1 initial + 1 retry) ---
-  # Background + wait pattern: tracks ENGINE_PID so _cleanup can kill the engine
-  # process if the hook script itself is terminated (e.g. hook timeout SIGTERM).
-  ENGINE_OUT=$(mktemp)
-  ENGINE_STATUS="${ENGINE_OUT}.status"
-  # Orchestrator owns the stderr CHANNEL for every engine (agy/claude/codex
-  # alike) — allocated unconditionally here, not codex-private. Each engine
-  # redirects its own invocation's stderr into it (2>"$ENGINE_ERR") and
-  # declares, via $ENGINE_ERR_POLICY (set in its engine_probe()), what the
-  # orchestrator is allowed to do with the CONTENT: "verbatim" (agy/claude)
-  # backfills it into LOG_FILE unconditionally; "filtered" (codex) only logs
-  # a privacy-filtered excerpt on failure, via the engine's own
-  # engine_err_filter() hook — see backfill_engine_err() in lib/common.sh.
-  ENGINE_ERR="${ENGINE_OUT}.err"
-  REVIEW=""
-  HOOK_BUDGET="${REVIEW_HOOK_BUDGET:-595}"
-
-  # --- Pre-flight: CLI existence check (permanent failure, no retry) + one-
-  #     time per-engine setup (model resolution, temp resource prep) —
-  #     delegated to the sourced engine's engine_probe(), called once outside
-  #     the retry loop below. ---
-  if ! engine_probe; then
+  if ! run_consultation; then
     log_decision "decision=allow reason=engine-not-found engine=$REVIEW_ENGINE"
     # Orphan-out cleanup: no engine call will ever happen this cycle, but the
     # cycle itself is NOT over (COUNTER_FILE/CONV_FILE deliberately survive —
@@ -688,192 +668,6 @@ else
     # COUNTER_FILE (a stale count is merely inaccurate, not cross-plan noise).
     rm -f "${HISTORY_FILE:-}"
     allow_with_reason "[WARNING] REVIEW_ENGINE=$REVIEW_ENGINE but '$ENGINE_PROBE_REASON' not found"
-  fi
-
-  for (( engine_attempt=1; engine_attempt<=2; engine_attempt++ )); do
-    # Degraded-state skip: jump out of CLI retry immediately on first iteration.
-    if (( engine_attempt == 1 )) && [ "$_gemini_skip_cli" = "1" ]; then
-      break
-    fi
-
-    # Time-budget guard: on retry, check remaining wall-clock time can fit
-    # a full ENGINE_TIMEOUT. Prevents hook timeout SIGTERM from killing
-    # the script mid-retry, making REST fallback unreachable.
-    if (( engine_attempt > 1 )); then
-      remaining=$(( HOOK_BUDGET - SECONDS ))
-      if (( remaining < ENGINE_TIMEOUT )); then
-        echo "plan-review: time budget exhausted for retry (${remaining}s remaining < ${ENGINE_TIMEOUT}s needed), breaking to fallback..." >&2
-        log_decision "skip-retry reason=time-budget remaining=${remaining}s timeout=${ENGINE_TIMEOUT}s budget=${HOOK_BUDGET}s"
-        break
-      fi
-    fi
-    engine_exit=0
-
-    # --- Call the sourced engine's invoke hook. agy's invoke may set
-    #     _ENGINE_ABORT_RETRY=1 (oversized prompt, ARG_MAX defense) to signal
-    #     an immediate break BEFORE extraction/exit-code handling — mirroring
-    #     the pre-refactor inline `break`. A literal `break` inside the
-    #     function itself would be bash-version-dependent (verified: bash 3.2
-    #     propagates it to this loop, bash 5.x does not), so an explicit flag
-    #     is the only portable signal.
-    _ENGINE_ABORT_RETRY=0
-    engine_invoke
-    if [ "$_ENGINE_ABORT_RETRY" = "1" ]; then
-      break
-    fi
-
-    # Capacity-exhaustion detection (used further below) MUST scan the raw
-    # $ENGINE_ERR before backfill_engine_err (next) truncates it (see
-    # lib/common.sh) — capture into a flag now, consumed later instead of
-    # re-grepping a file that will already be empty by then.
-    _capacity_hit=0
-    grep -qE "RESOURCE_EXHAUSTED|MODEL_CAPACITY" "$ENGINE_ERR" 2>/dev/null && _capacity_hit=1
-
-    # Backfill this round's $ENGINE_ERR into LOG_FILE per the engine's own
-    # $ENGINE_ERR_POLICY (see lib/common.sh) — unconditionally for
-    # "verbatim" engines (success and failure alike), failure-only and
-    # filtered for codex. Also truncates $ENGINE_ERR once backfilled, so a
-    # later defensive re-backfill (_cleanup on hook-kill) is a harmless no-op
-    # in the normal exit path.
-    backfill_engine_err "$engine_exit"
-
-    engine_extract
-
-    # Orchestrator-level CONV_FILE invalidation: a non-zero CLI exit (timeout
-    # 124, resume-rejected, network, plain 1) means engine_extract()'s own
-    # outer guard (`[ "$engine_exit" = "0" ] && [ -s "$ENGINE_OUT" ]`) never
-    # ran, so agy's internal persist/rm logic never touched CONV_FILE this
-    # round — the orchestrator is the ONLY thing that can invalidate it here.
-    # Drop it so the next round starts a fresh full first round instead of
-    # re-sending a --conversation onto a session that just failed. (A 0-exit-
-    # but-malformed-envelope round is the other invalidation path, handled
-    # entirely inside engine_extract() itself — see lib/engines/agy.sh.)
-    if [ "$engine_exit" != "0" ]; then
-      rm -f "${CONV_FILE:-}"
-    fi
-
-    # Call site 2: by this point this round's native-handle state is FINAL,
-    # whichever of the paths above (or agy's own internal rm inside
-    # engine_extract) got it there — see inject_review_thread's own comment
-    # for why this single point replaces per-rm-site patches.
-    inject_review_thread
-
-    : > "$ENGINE_OUT"
-    if [ "$engine_exit" != "0" ]; then
-      REVIEW=""
-      _fail_reason="${REVIEW_ENGINE}: exit ${engine_exit}"
-      if [ "$engine_attempt" -lt 2 ]; then
-        # Detect capacity-exhausted 429 (MODEL_CAPACITY_EXHAUSTED via cloudcode-pa.googleapis.com).
-        # These outages last minutes — the default 2s retry delay is useless;
-        # a longer wait gives the server time to recover.
-        # $_capacity_hit was captured above (BEFORE backfill_engine_err ran)
-        # from this round's raw, un-truncated $ENGINE_ERR directly — NOT
-        # LOG_FILE. This is the fix for the codex fast-break bug: codex's raw
-        # stderr never reaches LOG_FILE wholesale (privacy filter, see
-        # engine_err_filter in lib/engines/codex.sh), so grepping LOG_FILE
-        # only ever caught this pattern for agy/claude by coincidence —
-        # codex's fast-break depended on the capacity keyword happening to
-        # survive the 500-byte filtered codex-diag excerpt. All three engines
-        # are treated identically here because $ENGINE_ERR always held this
-        # round's complete, unfiltered stderr regardless of engine (at the
-        # time it was captured, before this same round's backfill truncated it).
-        if [ "$_capacity_hit" = "1" ]; then
-          _fail_reason="${REVIEW_ENGINE}: capacity exhausted (MODEL_CAPACITY_EXHAUSTED)"
-          # CONV_FILE was already dropped and re-injected (if needed) by call
-          # site 2 above, right after engine_extract() — a capacity-flavored
-          # non-zero exit is still a non-zero exit, no separate handling
-          # needed here (the old duplicate rm+inject pinned to this branch
-          # specifically was provably a no-op: this code only runs inside the
-          # `engine_exit != 0` branch, whose invalidation already ran).
-          # If REST fallback is configured, skip retry immediately — retrying a
-          # capacity-exhausted endpoint wastes the time budget REST needs.
-          if [ -n "${REVIEW_API_URL:-}" ] && [ -n "${REVIEW_API_KEY:-}" ]; then
-            # Persist degraded state: subsequent hooks skip CLI for TTL seconds.
-            if [ "$REVIEW_ENGINE" = "gemini" ]; then
-              printf '%s' "$(date +%s)" > "$DEGRADE_FILE" 2>/dev/null || true
-              log_decision "gemini-degrade-write ts=$(date +%s)"
-            fi
-            echo "plan-review: $REVIEW_ENGINE capacity exhausted, skipping retry (REST fallback available)" >&2
-            log_decision "rest-skip=capacity-fast-break engine=$REVIEW_ENGINE attempt=$engine_attempt"
-            break
-          fi
-          retry_delay="${REVIEW_CAPACITY_DELAY:-25}"
-          echo "plan-review: $REVIEW_ENGINE capacity exhausted, waiting ${retry_delay}s for recovery..." >&2
-        else
-          retry_delay="${REVIEW_RETRY_DELAY:-2}"
-          echo "plan-review: $REVIEW_ENGINE failed (attempt $engine_attempt/2, exit $engine_exit), retrying in ${retry_delay}s..." >&2
-        fi
-        sleep "$retry_delay"
-      fi
-      continue
-    fi
-
-    # Engine succeeded (exit 0) but returned empty → retry
-    if [ -z "$REVIEW" ]; then
-      if [ "$engine_attempt" -lt 2 ]; then
-        echo "plan-review: engine returned empty response (attempt $engine_attempt/2), retrying..." >&2
-        sleep "${REVIEW_RETRY_DELAY:-2}"
-      fi
-      continue
-    fi
-
-    # Non-empty response obtained — exit retry loop
-    break
-  done
-
-  # --- REST API fallback: CLI exhausted, try OpenAI-compatible endpoint ---
-  # Zero-intrusion: only fires when CLI produced no result AND env vars are set.
-  # REVIEW_API_URL/REVIEW_API_KEY empty → skip (preserves original fail-open).
-  if [ -z "$REVIEW" ] && [ -n "${REVIEW_API_URL:-}" ] && [ -n "${REVIEW_API_KEY:-}" ]; then
-    # Persist (or refresh) Gemini degraded state for any failure mode.
-    # Covers timeout (exit 124), network errors (ECONNRESET), empty responses, etc.
-    # Always refreshes the timestamp — even if the file already exists but has expired.
-    # Without refresh, an expired degrade file blocks TTL renewal: the check above lets
-    # Gemini run again (_gemini_skip_cli=0), it fails again, but the stale file prevents
-    # writing a new timestamp, creating an infinite retry-with-40s-REST-budget loop.
-    if [ "$REVIEW_ENGINE" = "gemini" ] && [ "$_gemini_skip_cli" = "0" ]; then
-      printf '%s' "$(date +%s)" > "$DEGRADE_FILE" 2>/dev/null || true
-      log_decision "gemini-degrade-write ts=$(date +%s) reason=rest-fallback-triggered"
-    fi
-    echo "plan-review: CLI exhausted, trying REST API fallback..." >&2
-    log_decision "rest-start url=${REVIEW_API_URL:+(set)} key=${REVIEW_API_KEY:+(set)}"
-
-    # Call site 3 (force): REST is a DIFFERENT engine, not "agy with a maybe-
-    # cleared CONV_FILE" — it never has session memory of its own, so gating
-    # its injection on agy's CONV_FILE state is a category error. `force`
-    # skips that condition entirely; this is what closes the gap where a
-    # round aborts BEFORE ever reaching engine_extract() (agy's own ARG_MAX
-    # guard, ${TIMEOUT_CMD:+...} never invoked, ${_ENGINE_ABORT_RETRY}=1) —
-    # CONV_FILE is untouched in that path and can still look perfectly live,
-    # even though REST, about to receive this exact prompt, has no way to
-    # consume that liveness. HISTORY_INJECTED still guards this from
-    # double-injecting on top of call site 1 or 2 if either already injected
-    # this round.
-    inject_review_thread force
-    rest_invoke
-    rest_extract
-
-    # Cross-ROUND fix (different dimension from the three same-round
-    # injection call sites above — do not fold this into any of them). This
-    # round's CONV_FILE can still be live even after REST — not agy — just
-    # produced the authoritative REVIEW for it (e.g. the ARG_MAX-abort path:
-    # agy's own CLI never ran, so nothing ever touched CONV_FILE). If left
-    # alone, agy's server-side session history silently stops one round
-    # short of current: the NEXT round's composition-time check
-    # (call site 1) sees a non-empty CONV_FILE, concludes agy has native
-    # memory, and skips thread injection — but agy's actual session never
-    # saw this round's REST-produced finding, so the next round gets NEITHER
-    # the injected thread NOR a native memory of what REST just found.
-    # Dropping CONV_FILE here forces the next round onto the thread path
-    # instead, which DOES have this round's finding (written into
-    # HISTORY_FILE via A3 further below). Gated on REVIEW being non-empty:
-    # if REST also failed, this round produced no authoritative result at
-    # all, so agy's (possibly still-valid) session must not be invalidated
-    # for nothing.
-    [ -z "$REVIEW" ] || rm -f "${CONV_FILE:-}"
-
-    : > "$ENGINE_OUT"
-    [ -z "$REVIEW" ] || echo "plan-review: REST API fallback succeeded." >&2
   fi
 
   # All attempts exhausted

--- a/plugins/plan-review/scripts/second-opinion.sh
+++ b/plugins/plan-review/scripts/second-opinion.sh
@@ -85,6 +85,7 @@ _fail() {
 SYS_PROMPT_FILES=()
 PROMPT_FILE_ARG=""
 SESSION_LABEL=""
+SESSION_LABEL_GIVEN=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -101,6 +102,7 @@ while [ $# -gt 0 ]; do
     --session)
       [ $# -ge 2 ] || _fail "--session requires a value"
       SESSION_LABEL="$2"
+      SESSION_LABEL_GIVEN=1
       shift 2
       ;;
     *)
@@ -108,6 +110,25 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
+
+# --- Reject an explicitly-empty --session value. `--session ""` sets
+#     SESSION_LABEL to an empty string, which the later `[ -n "$SESSION_LABEL" ]`
+#     check cannot distinguish from "flag omitted" — it silently falls to the
+#     stateless single-round else-branch. A caller who passed --session
+#     believes it opened a session; it didn't. Fail loud instead of
+#     downgrading silently. ---
+if [ "$SESSION_LABEL_GIVEN" -eq 1 ] && [ -z "$SESSION_LABEL" ]; then
+  _fail "invalid --session label (must not be empty)"
+fi
+
+# --- Charset-validate a given --session label up front, before this driver
+#     consumes stdin for the artifact body (a rejected label should fail
+#     before stdin is read, not after). ---
+if [ -n "$SESSION_LABEL" ]; then
+  case "$SESSION_LABEL" in
+    *[!A-Za-z0-9._-]*) _fail "invalid --session label (allowed charset: [A-Za-z0-9._-]): $SESSION_LABEL" ;;
+  esac
+fi
 
 # --- Validate --system-prompt-file: required, repeatable, each must exist
 #     and be non-empty. Fail loud on any violation — no fallback rubric. ---
@@ -123,10 +144,15 @@ unset _f
 #     sentinel byte is appended before capture and stripped back off after —
 #     this preserves the exact byte sequence of the concatenated files
 #     (no separator is inserted between files; "concatenate in order" is
-#     read literally as back-to-back bytes). ---
+#     read literally as back-to-back bytes). Each file is piped through
+#     `tr -d '\r'` — same normalization plan-review.sh:493 applies to its own
+#     two prompt assets — so a CRLF-authored rubric file doesn't change the
+#     bytes actually sent to the engine (and therefore doesn't change the
+#     --session hash, which is derived from these assembled bytes) relative
+#     to an LF-only file with identical content. ---
 SYSTEM_INSTRUCTIONS=$(
   for _f in "${SYS_PROMPT_FILES[@]}"; do
-    cat "$_f"
+    tr -d '\r' < "$_f"
   done
   printf 'x'
 )
@@ -144,6 +170,12 @@ else
   ARTIFACT=$(cat; printf 'x')
   ARTIFACT="${ARTIFACT%x}"
 fi
+
+# --- Reject an empty artifact body. A `--prompt-file` pointing at a
+#     zero-byte file, or an empty stdin stream, would otherwise silently send
+#     the engine an empty artifact and still return "a review" — symmetric
+#     with the empty-system-prompt-file rejection above (line ~117). ---
+[ -n "$ARTIFACT" ] || _fail "artifact body is empty (--prompt-file or stdin)"
 
 # --- Bootstrap: source shared libs (same pattern as plan-review.sh, but
 #     fail-loud instead of fail-open — a driver invoked directly has no
@@ -205,11 +237,9 @@ COUNTER_DIR="${REVIEW_COUNTER_DIR:-/tmp/claude-reviews}"
 mkdir -p "$COUNTER_DIR"
 DEGRADE_FILE="$COUNTER_DIR/.gemini-degraded"
 
-# --- Session key derivation + CONV_FILE assignment ---
+# --- Session key derivation + CONV_FILE assignment. Charset already
+#     validated up-front (before stdin was consumed) — no re-check here. ---
 if [ -n "$SESSION_LABEL" ]; then
-  case "$SESSION_LABEL" in
-    *[!A-Za-z0-9._-]*) _fail "invalid --session label (allowed charset: [A-Za-z0-9._-]): $SESSION_LABEL" ;;
-  esac
   # Fold the ASSEMBLED system-prompt bytes into the hash input (not just the
   # label) — a newline separator keeps label/content from concatenating into
   # an ambiguous boundary. plan_hash() (lib/common.sh) is reused verbatim,
@@ -249,9 +279,26 @@ REQ_FILE=""
 
 # --- Call the engine state machine. No REVIEW_DRY_RUN synthetic-APPROVE
 #     branch here (this driver does not read that var at all — see header).
-#     No weak hooks defined (consult_on_round_end / consult_on_rest_prepare /
-#     consult_on_rest_success) — this driver has no HISTORY_FILE/round-memory
-#     concept, so `declare -F` inside consult.sh finds nothing and no-ops. ---
+#
+#     consult_on_round_end / consult_on_rest_prepare deliberately stay
+#     UNDEFINED: both exist (in plan-review.sh) only to drive
+#     inject_review_thread() against HISTORY_FILE, the orchestrator-owned
+#     cross-round memory this driver simply doesn't have — it relies solely
+#     on agy's own server-side --conversation session for continuity. With
+#     no HISTORY_FILE concept, `declare -F` inside consult.sh finds neither
+#     and no-ops, exactly as intended.
+#
+#     consult_on_rest_success IS defined, unlike the two above — it isn't
+#     about HISTORY_FILE at all. When the CLI path fails and REST produces a
+#     usable REVIEW, consult.sh calls this hook to invalidate CONV_FILE. The
+#     REST call never went through agy, so its output was never appended to
+#     any agy server-side session history; leaving a stale CONV_FILE behind
+#     would make the NEXT round's --conversation resume a session that is
+#     silently missing this round's finding, while the engine believes its
+#     own history is complete. Dropping CONV_FILE forces a clean first round
+#     next time instead of resuming a session with a gap in it.
+consult_on_rest_success() { rm -f "${CONV_FILE:-}"; }
+
 if ! run_consultation; then
   _fail "engine not found: $ENGINE_PROBE_REASON"
 fi

--- a/plugins/plan-review/scripts/second-opinion.sh
+++ b/plugins/plan-review/scripts/second-opinion.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+# second-opinion.sh — out-of-plugin driver for plan-review's engine
+# infrastructure (agy + Gemini 3.1 Pro + REST fallback + session reuse),
+# built on top of lib/consult.sh's run_consultation() state machine (PR1).
+#
+# Unlike plan-review.sh (a PreToolUse hook with plan-specific policy: plan
+# extraction, ack-round counters, verdict routing, manifest parsing), this
+# is a plain CLI a caller invokes directly to get a second opinion on any
+# artifact. It does NO verdict parsing — stdout is the engine's raw review
+# text, verbatim.
+#
+# Usage:
+#   second-opinion.sh --system-prompt-file <path> [--system-prompt-file <path2> ...]
+#                     [--prompt-file <path>] [--session <label>]
+#
+#   --system-prompt-file <path>  Required, repeatable. Concatenated in
+#                                 command-line order to form the system
+#                                 instructions sent to the engine. Missing
+#                                 (none given), nonexistent, or empty file
+#                                 → fail loud (nonzero exit, empty stdout).
+#   --prompt-file <path>         Artifact body. If omitted, body is read from
+#                                 stdin. If BOTH are given, --prompt-file wins
+#                                 (stdin is the fallback for callers that
+#                                 cannot write files, not a second source to
+#                                 merge with an explicit file).
+#   --session <label>            Opaque label for cross-invocation session
+#                                 continuation (see "Session key derivation"
+#                                 below). Charset: [A-Za-z0-9._-] only — no
+#                                 "/" or "..". Omitted → single-round
+#                                 stateless (a throwaway temp file backs
+#                                 CONV_FILE for this one call, then is
+#                                 removed).
+#
+# stdout: ONLY the review body (no JSON wrapper, no logs).
+# stderr: diagnostics.
+# exit 0: a result was obtained. exit != 0: all engines exhausted, OR a
+#   fail-loud precondition (missing/bad args) was violated. This driver
+#   deliberately does NOT reuse plan-review.sh's fail-OPEN pattern (a
+#   synthesized "looks like a review" response is more dangerous than
+#   getting nothing) — every failure here is fail-CLOSED.
+#
+# Explicitly NOT read: REVIEW_DISABLED, REVIEW_DRY_RUN — those two encode
+# "turn off the ExitPlanMode gate" semantics; an explicit direct invocation
+# of this driver must not be silently reshaped by them.
+#
+# Session key derivation (the design core — see plan issue #165 PR2 §B):
+#   ${REVIEW_COUNTER_DIR:-/tmp/claude-reviews}/.so-<hash(label + system prompt bytes)[:16]>
+# The hash folds in the ASSEMBLED system-prompt bytes, not just the label —
+# so any rubric/prompt change automatically invalidates old sessions instead
+# of silently resuming a stale one under a changed rubric. Reuses
+# plan_hash() from lib/common.sh verbatim (sha256sum > shasum -a 256 >
+# cksum fallback) — no new hash call is written here.
+#
+# CONV_FILE must never be passed empty: lib/engines/agy.sh's persistence
+# step does `mv -f "${CONV_FILE}.tmp.$$" "$CONV_FILE"` — if CONV_FILE were
+# ever an empty string, that `mv` target is empty, the command fails, is
+# swallowed by `|| true`, and the `.tmp.$$` file leaks permanently into
+# this process's cwd. This driver always assigns CONV_FILE a real path
+# (either the derived session path, or a throwaway mktemp for the
+# stateless case, registered into ENGINE_TMP_FILES for cleanup).
+#
+# REVIEW_COUNTER_DIR is shared with plan-review.sh (same DEGRADE_FILE, so
+# Gemini capacity-exhaustion degraded state is shared between the hook and
+# this driver) — this driver does not invent a separate directory.
+#
+# bash 3.2 compatible: no associative arrays, no ${var^^}, no &>>.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+# --- Logging (best-effort side channel; never let a write failure kill the
+#     driver's core logic — same rationale as plan-review.sh) ---
+LOG_DIR="${REVIEW_LOG_DIR:-$HOME/.claude/logs}"
+mkdir -p "$LOG_DIR" 2>/dev/null && LOG_FILE="${LOG_DIR}/second-opinion.log" || LOG_FILE="/dev/null"
+
+# --- Fail-loud helper: this driver's ONE error-reporting path. Always
+#     writes to stderr, never to stdout (stdout is reserved for the review
+#     body), and always exits non-zero. ---
+_fail() {
+  echo "second-opinion: $1" >&2
+  exit 1
+}
+
+# --- Argument parsing ---
+SYS_PROMPT_FILES=()
+PROMPT_FILE_ARG=""
+SESSION_LABEL=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --system-prompt-file)
+      [ $# -ge 2 ] || _fail "--system-prompt-file requires a value"
+      SYS_PROMPT_FILES+=("$2")
+      shift 2
+      ;;
+    --prompt-file)
+      [ $# -ge 2 ] || _fail "--prompt-file requires a value"
+      PROMPT_FILE_ARG="$2"
+      shift 2
+      ;;
+    --session)
+      [ $# -ge 2 ] || _fail "--session requires a value"
+      SESSION_LABEL="$2"
+      shift 2
+      ;;
+    *)
+      _fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+# --- Validate --system-prompt-file: required, repeatable, each must exist
+#     and be non-empty. Fail loud on any violation — no fallback rubric. ---
+[ ${#SYS_PROMPT_FILES[@]} -gt 0 ] || _fail "--system-prompt-file is required (repeatable, at least one)"
+for _f in "${SYS_PROMPT_FILES[@]}"; do
+  [ -s "$_f" ] || _fail "--system-prompt-file not found or empty: $_f"
+done
+unset _f
+
+# --- Concatenate system-prompt files in command-line order. Sentinel-byte
+#     technique (same rationale as plan-review.sh:489-490): a plain $(...)
+#     strips ALL trailing newlines from the last file, so a trailing
+#     sentinel byte is appended before capture and stripped back off after —
+#     this preserves the exact byte sequence of the concatenated files
+#     (no separator is inserted between files; "concatenate in order" is
+#     read literally as back-to-back bytes). ---
+SYSTEM_INSTRUCTIONS=$(
+  for _f in "${SYS_PROMPT_FILES[@]}"; do
+    cat "$_f"
+  done
+  printf 'x'
+)
+SYSTEM_INSTRUCTIONS="${SYSTEM_INSTRUCTIONS%x}"
+unset _f
+
+# --- Artifact body: --prompt-file wins over stdin if both are given (stdin
+#     is the fallback path for callers that cannot write files, not a
+#     second source to merge with an explicit file). ---
+if [ -n "$PROMPT_FILE_ARG" ]; then
+  [ -f "$PROMPT_FILE_ARG" ] || _fail "--prompt-file not found: $PROMPT_FILE_ARG"
+  ARTIFACT=$(cat "$PROMPT_FILE_ARG"; printf 'x')
+  ARTIFACT="${ARTIFACT%x}"
+else
+  ARTIFACT=$(cat; printf 'x')
+  ARTIFACT="${ARTIFACT%x}"
+fi
+
+# --- Bootstrap: source shared libs (same pattern as plan-review.sh, but
+#     fail-loud instead of fail-open — a driver invoked directly has no
+#     "allow the tool call anyway" concept to fall back to). ---
+LIB_COMMON="$SCRIPT_DIR/lib/common.sh"
+LIB_CONSULT="$SCRIPT_DIR/lib/consult.sh"
+
+[ -s "$LIB_COMMON" ] || _fail "lib file missing or empty: $LIB_COMMON"
+# shellcheck source=lib/common.sh
+source "$LIB_COMMON" || _fail "failed to source $LIB_COMMON"
+
+# --- Engine temp-resource cleanup registry (MUST be declared before trap
+#     registration — see plan-review.sh's identical comment: an undeclared
+#     array throws unbound-variable under `set -u` inside the trap). ---
+ENGINE_TMP_FILES=()
+ENGINE_TMP_DIRS=()
+
+_cleanup() {
+  declare -F backfill_engine_err >/dev/null 2>&1 && backfill_engine_err 143 || true
+  rm -f "${PROMPT_FILE:-}" "${ENGINE_OUT:-}" "${ENGINE_ERR:-}"
+  [ ${#ENGINE_TMP_FILES[@]} -eq 0 ] || rm -f "${ENGINE_TMP_FILES[@]}"
+  [ ${#ENGINE_TMP_DIRS[@]}  -eq 0 ] || rmdir "${ENGINE_TMP_DIRS[@]}" 2>/dev/null || true
+  ENGINE_TMP_FILES=()
+  ENGINE_TMP_DIRS=()
+  [ -z "${ENGINE_PID:-}" ] || kill "${ENGINE_PID:-}" 2>/dev/null || true
+}
+trap '_cleanup' EXIT
+trap '_cleanup; exit 130' INT TERM HUP
+
+# --- Engine selection: same whitelist case as plan-review.sh — REVIEW_ENGINE
+#     is externally controlled via env var, never string-concat into
+#     `source` (path-injection surface). ---
+REVIEW_ENGINE="${REVIEW_ENGINE:-gemini}"
+case "$REVIEW_ENGINE" in
+  claude) ENGINE_LIB="claude.sh" ; ENGINE_CMD="claude" ;;
+  codex)  ENGINE_LIB="codex.sh"  ; ENGINE_CMD="${CODEX_BIN:-codex}" ;;
+  *)      ENGINE_LIB="agy.sh"    ; ENGINE_CMD="agy" ;;
+esac
+LIB_ENGINES_DIR="$SCRIPT_DIR/lib/engines"
+LIB_REST="$LIB_ENGINES_DIR/rest.sh"
+LIB_ENGINE_SELECTED="$LIB_ENGINES_DIR/$ENGINE_LIB"
+
+for _lib in "$LIB_REST" "$LIB_ENGINE_SELECTED" "$LIB_CONSULT"; do
+  [ -s "$_lib" ] || _fail "lib file missing or empty: $_lib"
+done
+unset _lib
+
+# shellcheck source=lib/engines/rest.sh
+source "$LIB_REST" || _fail "failed to source $LIB_REST"
+# shellcheck disable=SC1090  # dynamic path — engine chosen by the whitelisted case above
+source "$LIB_ENGINE_SELECTED" || _fail "failed to source $LIB_ENGINE_SELECTED"
+# shellcheck source=lib/consult.sh
+source "$LIB_CONSULT" || _fail "failed to source $LIB_CONSULT"
+
+# --- Shared state directory (same default as plan-review.sh's COUNTER_DIR)
+#     — DEGRADE_FILE must live here for the two callers to share Gemini
+#     degraded-state bookkeeping. ---
+COUNTER_DIR="${REVIEW_COUNTER_DIR:-/tmp/claude-reviews}"
+mkdir -p "$COUNTER_DIR"
+DEGRADE_FILE="$COUNTER_DIR/.gemini-degraded"
+
+# --- Session key derivation + CONV_FILE assignment ---
+if [ -n "$SESSION_LABEL" ]; then
+  case "$SESSION_LABEL" in
+    *[!A-Za-z0-9._-]*) _fail "invalid --session label (allowed charset: [A-Za-z0-9._-]): $SESSION_LABEL" ;;
+  esac
+  # Fold the ASSEMBLED system-prompt bytes into the hash input (not just the
+  # label) — a newline separator keeps label/content from concatenating into
+  # an ambiguous boundary. plan_hash() (lib/common.sh) is reused verbatim,
+  # not reimplemented.
+  SESSION_KEY_INPUT="${SESSION_LABEL}"$'\n'"${SYSTEM_INSTRUCTIONS}"
+  SESSION_HASH=$(plan_hash "$SESSION_KEY_INPUT")
+  CONV_FILE="${COUNTER_DIR}/.so-${SESSION_HASH:0:16}"
+  # ROUND_INDEX inference: the driver does not count rounds itself — it only
+  # distinguishes "first round" (no session file yet) from "continuation
+  # round" (session file already exists, whatever its content). This must be
+  # evaluated BEFORE run_consultation ever touches CONV_FILE this call.
+  if [ -s "$CONV_FILE" ]; then
+    ROUND_INDEX=1
+  else
+    ROUND_INDEX=0
+  fi
+else
+  # Stateless single-round: CONV_FILE must still be a REAL path (see header
+  # comment on the agy.sh mv danger) — a throwaway temp file, registered for
+  # cleanup so it never survives past this invocation.
+  CONV_FILE=$(mktemp)
+  rm -f "$CONV_FILE"
+  ENGINE_TMP_FILES+=("$CONV_FILE")
+  ROUND_INDEX=0
+fi
+
+# --- Artifact body → PROMPT_FILE. Unlike plan-review.sh, this driver has no
+#     GLOBAL_MD/PROJECT_MD/USER_REQ framing to layer on — PROMPT_FILE holds
+#     exactly the artifact body, nothing else. ---
+PROMPT_FILE=$(mktemp)
+printf '%s' "$ARTIFACT" > "$PROMPT_FILE"
+
+ENGINE_OUT=""
+ENGINE_STATUS=""
+ENGINE_PID=""
+REQ_FILE=""
+
+# --- Call the engine state machine. No REVIEW_DRY_RUN synthetic-APPROVE
+#     branch here (this driver does not read that var at all — see header).
+#     No weak hooks defined (consult_on_round_end / consult_on_rest_prepare /
+#     consult_on_rest_success) — this driver has no HISTORY_FILE/round-memory
+#     concept, so `declare -F` inside consult.sh finds nothing and no-ops. ---
+if ! run_consultation; then
+  _fail "engine not found: $ENGINE_PROBE_REASON"
+fi
+
+if [ -z "$REVIEW" ]; then
+  _fail "all review engines exhausted${_fail_reason:+ — ${_fail_reason}}"
+fi
+
+printf '%s' "$REVIEW"

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -2965,7 +2965,53 @@ MOCK_INNER
   local prompt
   prompt=$(cat "${MOCK_BIN}/../.agy-prompt-agy")
   [[ "$prompt" == *"Consultation Context"* ]]
-  [[ "$prompt" == *"Plan to Review"* ]]
+  [[ "$prompt" == *"Artifact to Review"* ]]
+}
+
+# assembly: SYSTEM_INSTRUCTIONS internal ordering — review-plan.md's framing
+# layer must lead, review-common.md's shared discipline/format layer must
+# trail. Grepping for substring presence alone (as the other system-
+# instructions / quality-gate tests do) cannot catch an assembly-order
+# regression where plan-review.sh:493 accidentally swapped the two
+# `tr -d '\r' < ...` operands — both substrings would still be present, just
+# in the wrong order. This test captures the agy FIRST-round -p argument
+# (round 1 always sends the full AGY_PROMPT = SYSTEM_INSTRUCTIONS + '\n\n' +
+# PROMPT_FILE — see agy.sh's engine_invoke, CONV_ID empty branch), which is
+# the one point where the raw assembled SYSTEM_INSTRUCTIONS bytes are
+# observable end-to-end. Byte-position comparison (not a golden file) so the
+# test survives unrelated wording edits to either asset.
+@test "assembly: SYSTEM_INSTRUCTIONS orders review-plan.md ahead of review-common.md" {
+  cat > "${MOCK_BIN}/agy" <<'MOCK_INNER'
+#!/bin/bash
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-p" ]; then printf '%s' "$a" > "$(dirname "$0")/../.agy-prompt-agy"; fi
+  prev="$a"
+done
+printf '%s\n' "$*" > "$(dirname "$0")/../.agy-args-agy"
+printf '{"conversation_id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","response":"<verdict>APPROVE</verdict>","usage":{}}\n'
+MOCK_INNER
+  chmod +x "${MOCK_BIN}/agy"
+  INPUT=$(build_input)
+  run_hook   # round 1 — first round, sends the full static+dynamic prompt
+  assert_ack_approve_json
+
+  local prompt_file="${MOCK_BIN}/../.agy-prompt-agy"
+  [ -s "$prompt_file" ]
+
+  local pos_criteria pos_ground_truth pos_scope pos_gate
+  pos_criteria=$(grep -boF 'Review Criteria' "$prompt_file" | head -1 | cut -d: -f1)
+  pos_ground_truth=$(grep -boF 'Version Identifiers Are Ground Truth' "$prompt_file" | head -1 | cut -d: -f1)
+  pos_scope=$(grep -boF '## Scope Boundary' "$prompt_file" | head -1 | cut -d: -f1)
+  pos_gate=$(grep -boF '## Finding Quality Gate' "$prompt_file" | head -1 | cut -d: -f1)
+
+  [ -n "$pos_criteria" ]
+  [ -n "$pos_ground_truth" ]
+  [ -n "$pos_scope" ]
+  [ -n "$pos_gate" ]
+
+  [ "$pos_criteria" -lt "$pos_ground_truth" ]
+  [ "$pos_scope" -lt "$pos_gate" ]
 }
 
 # conv: non-capacity CLI failure (exit≠0) → resume handle dropped

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -2395,19 +2395,19 @@ Use Task( for analysis.
 # Prompt content integrity
 # ---------------------------------------------------------------------------
 @test "system-instructions: Testability criterion has structured sub-items" {
-  grep -q "Test strategy presence" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "E2E selector cascade" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "evidence-gated" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "Deletion completeness" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "3000 characters" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
+  grep -q "Test strategy presence" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "E2E selector cascade" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "evidence-gated" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "Deletion completeness" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "3000 characters" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
 }
 
-@test "system-instructions: Scope Boundary has training-cutoff / version-identifier ground-truth directive" {
-  grep -q "GROUND TRUTH" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "verify against your memory" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "training knowledge has a cutoff" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "NOT common knowledge" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "never Critical" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
+@test "system-instructions: Version Identifiers Are Ground Truth has training-cutoff / version-identifier ground-truth directive" {
+  grep -q "GROUND TRUTH" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
+  grep -q "verify against your memory" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
+  grep -q "training knowledge has a cutoff" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
+  grep -q "NOT common knowledge" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
+  grep -q "never Critical" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
 }
 
 # ---------------------------------------------------------------------------
@@ -2417,40 +2417,40 @@ Use Task( for analysis.
 # We assert the four gap-closing directives are present in SYSTEM_INSTRUCTIONS.
 # ---------------------------------------------------------------------------
 @test "system-instructions: Finding Quality Gate section present" {
-  grep -q "Finding Quality Gate" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
+  grep -q "Finding Quality Gate" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
 }
 
 @test "quality-gate: gap1 confidence threshold + drop-low-confidence directive" {
-  grep -q "Confidence" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "DROP" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
+  grep -q "Confidence" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
+  grep -q "DROP" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
 }
 
 @test "quality-gate: gap1 gradient exit — low-confidence Critical kept as UNVERIFIED, not dropped" {
-  grep -q "UNVERIFIED" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "not REJECT" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
+  grep -q "UNVERIFIED" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
+  grep -q "not REJECT" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
 }
 
 @test "quality-gate: gap2 false-positive registry present" {
-  grep -q "False-positive registry" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -qi "never raise" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
+  grep -q "False-positive registry" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
+  grep -qi "never raise" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
 }
 
 @test "quality-gate: gap3 verdict-severity pre-flight self-check (prompt-layer, not body-scan)" {
-  grep -q "Verdict↔severity" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
+  grep -q "Verdict↔severity" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
   # Routing must remain verdict-only: the hook must NOT grep the body for severity tags
   ! grep -qE "grep[^|]*'\[Critical\]'" "${HOOK_SCRIPT:?Missing hook script}"
 }
 
 @test "quality-gate: gap4 severity calibration anti-drift" {
-  grep -q "Severity calibration" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "never Major" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
+  grep -q "Severity calibration" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
+  grep -q "never Major" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
 }
 
 @test "quality-gate: UNVERIFIED routes to CONCERNS in verdict rules + output format" {
   # CONCERNS bucket explicitly includes UNVERIFIED suspicions
-  grep -q "UNVERIFIED.*suspicion.*but no confirmed Critical\|including any .UNVERIFIED" "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
+  grep -q "UNVERIFIED.*suspicion.*but no confirmed Critical\|including any .UNVERIFIED" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
   # output format documents the [Major] [UNVERIFIED] emission shape
-  grep -q '\[Major\] \[UNVERIFIED\]' "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
+  grep -q '\[Major\] \[UNVERIFIED\]' "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
 }
 
 # =============================================================================
@@ -2472,13 +2472,13 @@ Use Task( for analysis.
 
 # 116. Criterion 7 token presence — new prompt content has not been reverted
 @test "dispatch-economy: Criterion 7 tokens present in SYSTEM_INSTRUCTIONS" {
-  grep -q "Dispatch Economy"      "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "Full hoarding"         "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "Partial hoarding"      "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "Retrieval work"        "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "split-brain"           "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "Decision work"         "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
-  grep -q "Implementation work"   "${SYSTEM_PROMPT_FILE:?Missing system prompt asset}"
+  grep -q "Dispatch Economy"      "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "Full hoarding"         "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "Partial hoarding"      "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "Retrieval work"        "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "split-brain"           "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "Decision work"         "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "Implementation work"   "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
 }
 
 # 117. manifest detection survives prompt refactor — Task( + manifest reaches engine
@@ -3578,11 +3578,26 @@ MOCK_EOF
 }
 
 # bootstrap: prompt asset file missing entirely → allow + [WARNING].
+# The prompt asset guard (plan-review.sh:476-482) loops over BOTH
+# review-plan.md and review-common.md, so each half needs its own coverage —
+# a regression that only checks one file would otherwise slip past.
 # See REVIEW_DRY_RUN note above the first bootstrap test — same rationale.
-@test "bootstrap: missing prompt asset → allow JSON with WARNING" {
+@test "bootstrap: missing prompt asset (review-plan.md) → allow JSON with WARNING" {
   export REVIEW_DRY_RUN=1
   setup_script_copy
-  rm -f "${COPY_SCRIPT_DIR}/assets/review-system-prompt.md"
+  rm -f "${COPY_SCRIPT_DIR}/assets/review-plan.md"
+
+  run_hook_copy
+
+  assert_approve_json
+  [[ "$HOOK_STDOUT" == *"[WARNING]"* ]]
+  [[ "$HOOK_STDOUT" == *"prompt asset missing/empty"* ]]
+}
+
+@test "bootstrap: missing prompt asset (review-common.md) → allow JSON with WARNING" {
+  export REVIEW_DRY_RUN=1
+  setup_script_copy
+  rm -f "${COPY_SCRIPT_DIR}/assets/review-common.md"
 
   run_hook_copy
 
@@ -3592,11 +3607,24 @@ MOCK_EOF
 }
 
 # bootstrap: prompt asset present but zero bytes → allow + [WARNING].
+# Same per-file split rationale as the missing-asset pair above.
 # See REVIEW_DRY_RUN note above the first bootstrap test — same rationale.
-@test "bootstrap: empty prompt asset → allow JSON with WARNING" {
+@test "bootstrap: empty prompt asset (review-plan.md) → allow JSON with WARNING" {
   export REVIEW_DRY_RUN=1
   setup_script_copy
-  : > "${COPY_SCRIPT_DIR}/assets/review-system-prompt.md"
+  : > "${COPY_SCRIPT_DIR}/assets/review-plan.md"
+
+  run_hook_copy
+
+  assert_approve_json
+  [[ "$HOOK_STDOUT" == *"[WARNING]"* ]]
+  [[ "$HOOK_STDOUT" == *"prompt asset missing/empty"* ]]
+}
+
+@test "bootstrap: empty prompt asset (review-common.md) → allow JSON with WARNING" {
+  export REVIEW_DRY_RUN=1
+  setup_script_copy
+  : > "${COPY_SCRIPT_DIR}/assets/review-common.md"
 
   run_hook_copy
 
@@ -3610,11 +3638,18 @@ MOCK_EOF
 # exactly the gap Fix 5's <verdict> anchor check closes: without it, a
 # truncated-to-whitespace asset would silently proceed to review with an
 # empty instruction set instead of failing open visibly.
+# Post-split, the <verdict> anchor literal lives in review-common.md (see
+# assets/review-common.md's Output Format section), so truncating THAT file
+# is what must trip the anchor check — truncating review-plan.md alone
+# leaves review-common.md's `<verdict>` tag intact in the concatenated
+# SYSTEM_INSTRUCTIONS, so the anchor check must NOT fire in that case
+# (verified manually: truncating review-plan.md alone still produces a
+# normal dry-run APPROVE flow, not a truncated-asset WARNING).
 # See REVIEW_DRY_RUN note above the first bootstrap test — same rationale.
-@test "bootstrap: prompt asset truncated to whitespace-only → allow JSON with WARNING (anchor check)" {
+@test "bootstrap: prompt asset truncated to whitespace-only (review-common.md) → allow JSON with WARNING (anchor check)" {
   export REVIEW_DRY_RUN=1
   setup_script_copy
-  printf ' ' > "${COPY_SCRIPT_DIR}/assets/review-system-prompt.md"
+  printf ' ' > "${COPY_SCRIPT_DIR}/assets/review-common.md"
 
   run_hook_copy
 
@@ -3710,6 +3745,59 @@ MOCK_EOF
   assert_approve_json
   [[ "$HOOK_STDOUT" == *"[WARNING]"* ]]
   [[ "$HOOK_STDOUT" == *"lib file missing"* ]]
+}
+
+# bootstrap: lib/consult.sh (the third member of the second bootstrap block's
+# loop, alongside rest.sh + the REVIEW_ENGINE-selected engine lib — see
+# plan-review.sh:193's `for _lib in "$LIB_REST" "$LIB_ENGINE_SELECTED"
+# "$LIB_CONSULT"` and its `_source_lib` call at :212) missing entirely →
+# allow + [WARNING]. Same rationale as the other lib-file bootstrap tests:
+# proves the loop's existence/non-emptiness check covers this newly
+# extracted file too, not just rest.sh and the engine lib.
+@test "bootstrap: missing consult.sh lib file → allow JSON with WARNING" {
+  export REVIEW_DRY_RUN=1
+  setup_script_copy
+  rm -f "${COPY_SCRIPT_DIR}/lib/consult.sh"
+
+  run_hook_copy
+
+  assert_approve_json
+  [[ "$HOOK_STDOUT" == *"[WARNING]"* ]]
+  [[ "$HOOK_STDOUT" == *"lib file missing"* ]]
+}
+
+# bootstrap: consult.sh exists but is empty (zero bytes) — passes `[ -f ]`
+# clean, `source` of zero bytes "succeeds", and the first call into a helper
+# it was supposed to define (run_consultation) would die with "command not
+# found" (exit 127) absent the `[ -s ]` guard — silent fail-closed.
+@test "bootstrap: empty consult.sh lib file → allow JSON with WARNING" {
+  export REVIEW_DRY_RUN=1
+  setup_script_copy
+  : > "${COPY_SCRIPT_DIR}/lib/consult.sh"
+
+  run_hook_copy
+
+  assert_approve_json
+  [[ "$HOOK_STDOUT" == *"[WARNING]"* ]]
+  [[ "$HOOK_STDOUT" == *"lib file missing"* ]]
+}
+
+# bootstrap: consult.sh exists and is non-empty (passes `[ -s ]`) but has a
+# real bash syntax error — `source` itself fails even though the
+# existence/non-emptiness check does not. Proves consult.sh routes through
+# `_source_lib`'s fail-open-on-source-failure path like the other libs.
+@test "bootstrap: syntax-broken consult.sh lib file → allow JSON with WARNING (source fails, not missing)" {
+  export REVIEW_DRY_RUN=1
+  setup_script_copy
+  # Unbalanced quote + stray paren: guaranteed bash syntax error, file still
+  # exists and is readable.
+  printf '%s\n' 'this is " not valid bash (' >> "${COPY_SCRIPT_DIR}/lib/consult.sh"
+
+  run_hook_copy
+
+  assert_approve_json
+  [[ "$HOOK_STDOUT" == *"[WARNING]"* ]]
+  [[ "$HOOK_STDOUT" == *"failed to load"* ]]
 }
 
 # =============================================================================

--- a/plugins/plan-review/tests/second-opinion.bats
+++ b/plugins/plan-review/tests/second-opinion.bats
@@ -1,0 +1,362 @@
+#!/usr/bin/env bats
+# BDD test suite for second-opinion.sh — the out-of-plugin driver built on
+# lib/consult.sh's run_consultation() (PR2 of issue #165).
+#
+# Scope: this driver is NOT a pure pass-through — it owns four pieces of
+# logic the hook does not need to test in isolation: argument parsing,
+# ordered concatenation of --system-prompt-file, session-key derivation
+# (plan_hash reuse over label + assembled system-prompt bytes), and input
+# validation (fail-loud on missing/malformed args). Reuses
+# common-setup.bash's mock-engine infrastructure (create_mock_engine,
+# agy_args, create_failing_engine) — same isolation guarantees as
+# plan-review.bats (isolated REVIEW_COUNTER_DIR/MOCK_BIN/LOG_DIR per test).
+#
+# Dependencies: bats-core, jq (not required by the driver itself, but by
+# common-setup.bash's build_input helper used incidentally by shared setup)
+
+setup() {
+  load 'test_helper/common-setup'
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+# =============================================================================
+# Argument parsing
+# =============================================================================
+
+# 1. Single --system-prompt-file + --prompt-file → success, review body only
+@test "args: single --system-prompt-file + --prompt-file succeeds" {
+  create_mock_engine "agy" "Single file review."
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'System rubric.' > "$sys_file"
+  printf 'Artifact body.' > "$artifact_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file"
+
+  [ "$SO_EXIT" -eq 0 ]
+  [ "$SO_STDOUT" = "Single file review." ]
+}
+
+# 2. Multiple --system-prompt-file (repeatable) → success
+@test "args: multiple --system-prompt-file (repeatable) succeeds" {
+  create_mock_engine "agy" "Multi file review."
+  local sys1="${TEST_TEMP_DIR}/sys1.md"
+  local sys2="${TEST_TEMP_DIR}/sys2.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'Part one.' > "$sys1"
+  printf 'Part two.' > "$sys2"
+  printf 'Artifact body.' > "$artifact_file"
+
+  run_second_opinion --system-prompt-file "$sys1" --system-prompt-file "$sys2" --prompt-file "$artifact_file"
+
+  [ "$SO_EXIT" -eq 0 ]
+  [ "$SO_STDOUT" = "Multi file review." ]
+}
+
+# 3. Missing --system-prompt-file entirely → fail loud
+@test "args: missing --system-prompt-file fails loud with empty stdout" {
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'Artifact body.' > "$artifact_file"
+
+  run_second_opinion --prompt-file "$artifact_file"
+
+  [ "$SO_EXIT" -ne 0 ]
+  [ -z "$SO_STDOUT" ]
+  [[ "$SO_STDERR" == *"--system-prompt-file is required"* ]]
+}
+
+# 4. Nonexistent --system-prompt-file path → fail loud
+@test "args: nonexistent --system-prompt-file path fails loud" {
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'Artifact body.' > "$artifact_file"
+
+  run_second_opinion --system-prompt-file "${TEST_TEMP_DIR}/does-not-exist.md" --prompt-file "$artifact_file"
+
+  [ "$SO_EXIT" -ne 0 ]
+  [ -z "$SO_STDOUT" ]
+  [[ "$SO_STDERR" == *"not found or empty"* ]]
+}
+
+# 5. Empty --system-prompt-file file (exists, zero bytes) → fail loud
+@test "args: empty --system-prompt-file file fails loud" {
+  local sys_file="${TEST_TEMP_DIR}/empty-sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  : > "$sys_file"
+  printf 'Artifact body.' > "$artifact_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file"
+
+  [ "$SO_EXIT" -ne 0 ]
+  [ -z "$SO_STDOUT" ]
+  [[ "$SO_STDERR" == *"not found or empty"* ]]
+}
+
+# 6. Unknown parameter → rejected
+@test "args: unknown parameter is rejected" {
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  printf 'System rubric.' > "$sys_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --bogus-flag foo
+
+  [ "$SO_EXIT" -ne 0 ]
+  [[ "$SO_STDERR" == *"unknown argument"* ]]
+}
+
+# 7. Flag given without a following value → rejected (not a hang / index error)
+@test "args: --system-prompt-file with no value is rejected" {
+  run_second_opinion --system-prompt-file
+
+  [ "$SO_EXIT" -ne 0 ]
+  [[ "$SO_STDERR" == *"requires a value"* ]]
+}
+
+# =============================================================================
+# Concatenation order
+# =============================================================================
+
+# 8. Two --system-prompt-file are concatenated in command-line order — assert
+#    the ACTUAL bytes reaching the engine (agy_args captures the -p argument).
+@test "concat: two --system-prompt-file concatenate in command-line order" {
+  create_mock_engine "agy" "ok"
+  local sys1="${TEST_TEMP_DIR}/sys1.md"
+  local sys2="${TEST_TEMP_DIR}/sys2.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'AAAA_FIRST' > "$sys1"
+  printf 'BBBB_SECOND' > "$sys2"
+  printf 'the-artifact' > "$artifact_file"
+
+  run_second_opinion --system-prompt-file "$sys1" --system-prompt-file "$sys2" --prompt-file "$artifact_file"
+  [ "$SO_EXIT" -eq 0 ]
+
+  local args
+  args=$(agy_args "agy")
+  # AAAA_FIRST must appear before BBBB_SECOND in the captured -p payload.
+  # bash's own ${var%%pattern} strips everything from the first match
+  # onward — comparing the stripped length to the original tells us the
+  # match position without piping a multiline string through awk/grep
+  # (awk's `index()` chokes on embedded newlines: "newline in string").
+  local before_first before_second
+  before_first="${args%%AAAA_FIRST*}"
+  before_second="${args%%BBBB_SECOND*}"
+  [ "${#before_first}" -lt "${#args}" ]
+  [ "${#before_second}" -lt "${#args}" ]
+  [ "${#before_first}" -lt "${#before_second}" ]
+
+  # Reversed order must reverse the byte order too (proves it's not
+  # coincidental / hardcoded).
+  run_second_opinion --system-prompt-file "$sys2" --system-prompt-file "$sys1" --prompt-file "$artifact_file"
+  [ "$SO_EXIT" -eq 0 ]
+  args=$(agy_args "agy")
+  before_first="${args%%BBBB_SECOND*}"
+  before_second="${args%%AAAA_FIRST*}"
+  [ "${#before_first}" -lt "${#args}" ]
+  [ "${#before_second}" -lt "${#args}" ]
+  [ "${#before_first}" -lt "${#before_second}" ]
+}
+
+# =============================================================================
+# Body source: --prompt-file / stdin / precedence
+# =============================================================================
+
+# 9. Body via --prompt-file
+@test "body: --prompt-file supplies the artifact body" {
+  create_mock_engine "agy" "ok"
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'System rubric.' > "$sys_file"
+  printf 'BODY_FROM_FILE' > "$artifact_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file"
+
+  [ "$SO_EXIT" -eq 0 ]
+  local args
+  args=$(agy_args "agy")
+  [[ "$args" == *"BODY_FROM_FILE"* ]]
+}
+
+# 10. Body via stdin (no --prompt-file given)
+@test "body: stdin supplies the artifact body when --prompt-file is omitted" {
+  create_mock_engine "agy" "ok"
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  printf 'System rubric.' > "$sys_file"
+
+  SO_STDIN="BODY_FROM_STDIN"
+  run_second_opinion --system-prompt-file "$sys_file"
+  unset SO_STDIN
+
+  [ "$SO_EXIT" -eq 0 ]
+  local args
+  args=$(agy_args "agy")
+  [[ "$args" == *"BODY_FROM_STDIN"* ]]
+}
+
+# 11. Precedence: both --prompt-file and stdin given → --prompt-file wins
+@test "body: --prompt-file takes precedence over stdin when both given" {
+  create_mock_engine "agy" "ok"
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'System rubric.' > "$sys_file"
+  printf 'BODY_FROM_FILE' > "$artifact_file"
+
+  SO_STDIN="BODY_FROM_STDIN"
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file"
+  unset SO_STDIN
+
+  [ "$SO_EXIT" -eq 0 ]
+  local args
+  args=$(agy_args "agy")
+  [[ "$args" == *"BODY_FROM_FILE"* ]]
+  [[ "$args" != *"BODY_FROM_STDIN"* ]]
+}
+
+# =============================================================================
+# fail loud
+# =============================================================================
+
+# 12. Engines exhausted (CLI fails, no REST configured) → nonzero exit, empty stdout
+@test "fail-loud: all engines exhausted → nonzero exit and empty stdout" {
+  create_failing_engine "agy" 1
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'System rubric.' > "$sys_file"
+  printf 'Artifact body.' > "$artifact_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file"
+
+  [ "$SO_EXIT" -ne 0 ]
+  [ -z "$SO_STDOUT" ]
+  [[ "$SO_STDERR" == *"engines exhausted"* ]]
+}
+
+# =============================================================================
+# Session key derivation (Section B robustness claim — direct verification)
+# =============================================================================
+
+# 13. Same label + same system prompt → same key (same CONV_FILE path is
+#     reused, proven by seeing --conversation on the SECOND call).
+@test "session: same label + same system prompt reuses the same session key" {
+  create_mock_engine "agy" "review body"
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'Stable rubric.' > "$sys_file"
+  printf 'Artifact body.' > "$artifact_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file" --session "same-label"
+  [ "$SO_EXIT" -eq 0 ]
+  local args_round1
+  args_round1=$(agy_args "agy")
+  [[ "$args_round1" != *"--conversation"* ]]
+
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file" --session "same-label"
+  [ "$SO_EXIT" -eq 0 ]
+  local args_round2
+  args_round2=$(agy_args "agy")
+  [[ "$args_round2" == *"--conversation aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"* ]]
+}
+
+# 14. Same label + one byte changed in system prompt → different key (no
+#     --conversation on the second call — the old session file is orphaned
+#     under its old hash, a NEW hash path has no prior conversation_id).
+@test "session: same label + one-byte-changed system prompt derives a different key" {
+  create_mock_engine "agy" "review body"
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'Stable rubric A.' > "$sys_file"
+  printf 'Artifact body.' > "$artifact_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file" --session "same-label"
+  [ "$SO_EXIT" -eq 0 ]
+
+  # Change exactly one byte (A -> B) in the system prompt.
+  printf 'Stable rubric B.' > "$sys_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file" --session "same-label"
+  [ "$SO_EXIT" -eq 0 ]
+  local args_round2
+  args_round2=$(agy_args "agy")
+  [[ "$args_round2" != *"--conversation"* ]]
+}
+
+# =============================================================================
+# label charset validation
+# =============================================================================
+
+# 15. Label containing "/" → error exit
+@test "session: label with a slash is rejected" {
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  printf 'System rubric.' > "$sys_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --session "has/slash"
+
+  [ "$SO_EXIT" -ne 0 ]
+  [[ "$SO_STDERR" == *"invalid --session label"* ]]
+}
+
+# 16. Label containing ".." → error exit
+@test "session: label with path traversal (..) is rejected" {
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  printf 'System rubric.' > "$sys_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --session "../escape"
+
+  [ "$SO_EXIT" -ne 0 ]
+  [[ "$SO_STDERR" == *"invalid --session label"* ]]
+}
+
+# =============================================================================
+# No --session → temp file, single-round stateless
+# =============================================================================
+
+# 17. No --session given → succeeds, no --conversation ever passed, and no
+#     leftover .so-* session file is created under REVIEW_COUNTER_DIR.
+@test "session: no --session uses a temp file and stays single-round stateless" {
+  create_mock_engine "agy" "review body"
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'System rubric.' > "$sys_file"
+  printf 'Artifact body.' > "$artifact_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file"
+  [ "$SO_EXIT" -eq 0 ]
+  local args
+  args=$(agy_args "agy")
+  [[ "$args" != *"--conversation"* ]]
+
+  # No .so-* file left behind in the shared counter dir.
+  local leftover
+  leftover=$(find "$REVIEW_COUNTER_DIR" -maxdepth 1 -name '.so-*' 2>/dev/null)
+  [ -z "$leftover" ]
+}
+
+# =============================================================================
+# REVIEW_HOOK_BUDGET unset does not crash
+# =============================================================================
+
+# 18. REVIEW_HOOK_BUDGET left unset — run_consultation() internally defaults
+#     it to 595 before any code path (including rest.sh) reads it. Must not
+#     crash under `set -u`.
+@test "env: REVIEW_HOOK_BUDGET unset does not crash the driver" {
+  create_mock_engine "agy" "review body"
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'System rubric.' > "$sys_file"
+  printf 'Artifact body.' > "$artifact_file"
+
+  unset REVIEW_HOOK_BUDGET
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file"
+
+  [ "$SO_EXIT" -eq 0 ]
+  [ "$SO_STDOUT" = "review body" ]
+}
+
+# =============================================================================
+# bash -n coverage note
+# =============================================================================
+# second-opinion.sh's syntax is already covered by plan-review.bats test 115
+# ("dispatch-economy: bash -n reports no syntax errors after heredoc
+# refactor"), whose glob is `find scripts -name '*.sh'` — this new file lands
+# under scripts/ and is picked up automatically, no separate test needed here.

--- a/plugins/plan-review/tests/second-opinion.bats
+++ b/plugins/plan-review/tests/second-opinion.bats
@@ -217,6 +217,60 @@ teardown() {
 # fail loud
 # =============================================================================
 
+# 12a. --prompt-file pointing at an empty (zero-byte) file → fail loud with
+#      the artifact-body-empty message (implementation at ~line 178: `[ -n
+#      "$ARTIFACT" ] || _fail "artifact body is empty..."` — this was
+#      previously untested).
+@test "fail-loud: --prompt-file pointing at an empty file fails with artifact-body-empty" {
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/empty-artifact.md"
+  printf 'System rubric.' > "$sys_file"
+  : > "$artifact_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file"
+
+  [ "$SO_EXIT" -ne 0 ]
+  [ -z "$SO_STDOUT" ]
+  [[ "$SO_STDERR" == *"artifact body is empty"* ]]
+}
+
+# 12b. Empty stdin (no --prompt-file, stdin is /dev/null) → fail loud with the
+#      same artifact-body-empty message — the stdin path through the same
+#      check.
+@test "fail-loud: empty stdin (no --prompt-file) fails with artifact-body-empty" {
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  printf 'System rubric.' > "$sys_file"
+
+  # SO_STDIN deliberately left unset: run_second_opinion's default path feeds
+  # /dev/null when SO_STDIN is unset (see common-setup.bash) — a genuinely
+  # empty stream. `SO_STDIN=""` would NOT work here: `<<< ""` still feeds a
+  # single trailing newline byte, which command substitution then strips down
+  # to a non-empty-looking-but-actually-empty-after-strip edge case that does
+  # NOT reliably trip `[ -n "$ARTIFACT" ]` the same way — /dev/null is the
+  # unambiguous "truly empty" input.
+  run_second_opinion --system-prompt-file "$sys_file"
+
+  [ "$SO_EXIT" -ne 0 ]
+  [ -z "$SO_STDOUT" ]
+  [[ "$SO_STDERR" == *"artifact body is empty"* ]]
+}
+
+# 12c. --session "" (explicitly empty label) → fail loud with the
+#      invalid-session-label message (implementation at ~line 120: `[
+#      "$SESSION_LABEL_GIVEN" -eq 1 ] && [ -z "$SESSION_LABEL" ]` — this was
+#      previously untested; distinct from the charset-rejection tests below,
+#      which cover a non-empty malformed label).
+@test "fail-loud: --session with an explicitly empty value fails with invalid-session-label" {
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  printf 'System rubric.' > "$sys_file"
+
+  run_second_opinion --system-prompt-file "$sys_file" --session ""
+
+  [ "$SO_EXIT" -ne 0 ]
+  [ -z "$SO_STDOUT" ]
+  [[ "$SO_STDERR" == *"invalid --session label"* ]]
+}
+
 # 12. Engines exhausted (CLI fails, no REST configured) → nonzero exit, empty stdout
 @test "fail-loud: all engines exhausted → nonzero exit and empty stdout" {
   create_failing_engine "agy" 1
@@ -391,6 +445,65 @@ teardown() {
   [ "$SO_EXIT" -eq 0 ]
   [[ "$SO_STDOUT" == *"UNIQUE_REAL_REVIEW_BODY_MARKER"* ]]
   [[ "$SO_STDOUT" != *"<verdict>APPROVE</verdict>"* ]]
+}
+
+# =============================================================================
+# consult_on_rest_success driver-side hook (Major #3 fix, second-opinion.sh
+# ~line 300): `consult_on_rest_success() { rm -f "${CONV_FILE:-}"; }` — after
+# the CLI path fails and REST produces a usable REVIEW, the driver must drop
+# CONV_FILE so the NEXT round under the same --session label starts a clean
+# first round instead of resuming an agy session that is silently missing
+# this round's REST-produced finding.
+# =============================================================================
+
+# 21. Round 1 (agy CLI succeeds, --session given) establishes a live CONV_FILE
+#     under REVIEW_COUNTER_DIR/.so-*. Round 2, same --session label: the
+#     artifact is oversized enough to trip agy's own ARG_MAX guard (see
+#     lib/engines/agy.sh's 256000-byte check) — that path sets
+#     _ENGINE_ABORT_RETRY=1 and `break`s the retry loop BEFORE engine_exit is
+#     ever set non-zero and BEFORE engine_extract runs, so consult.sh's OWN
+#     unconditional "engine_exit != 0 → rm CONV_FILE" (consult.sh:166) never
+#     fires — CONV_FILE survives completely untouched by anything except
+#     consult_on_rest_success. This is deliberately the SAME shape as
+#     plan-review.bats's "REST-produced REVIEW after an ARG_MAX abort
+#     invalidates CONV_FILE" precedent (~line 4210) — a plain
+#     create_failing_engine CLI failure would be caught by that unconditional
+#     rm regardless of consult_on_rest_success, and would not actually pin
+#     this fix (verified: see the self-check note below).
+@test "session: REST-succeeds after an ARG_MAX abort clears CONV_FILE established by a prior round" {
+  create_mock_engine "agy" "round 1 review body"
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'Stable rubric.' > "$sys_file"
+  printf 'Artifact body.' > "$artifact_file"
+
+  # Round 1: agy CLI succeeds → persists a conversation_id into CONV_FILE.
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file" --session "rest-clears-conv"
+  [ "$SO_EXIT" -eq 0 ]
+
+  local conv_file
+  conv_file=$(find "$REVIEW_COUNTER_DIR" -maxdepth 1 -name '.so-*' | head -n1)
+  [ -n "$conv_file" ]
+  [ -s "$conv_file" ]
+
+  # Round 2, same --session label: oversized artifact trips agy's ARG_MAX
+  # guard (CONV_FILE untouched by that path), REST is configured and
+  # succeeds. Mirrors plan-review.bats's rest-fallback environment setup
+  # (create_mock_curl_sse + REVIEW_API_URL/REVIEW_API_KEY).
+  local big_artifact_file="${TEST_TEMP_DIR}/big-artifact.md"
+  printf 'x%.0s' $(seq 1 300000) > "$big_artifact_file"
+  export REVIEW_API_URL="http://localhost:9999"
+  export REVIEW_API_KEY="test-key"
+  create_mock_curl_sse "REST-produced review body for round 2."
+
+  run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$big_artifact_file" --session "rest-clears-conv"
+
+  [ "$SO_EXIT" -eq 0 ]
+  [[ "$SO_STDOUT" == *"REST-produced review body for round 2."* ]]
+  # The fix: CONV_FILE from round 1 must be gone — a stale, ungapped-looking
+  # session handle must not survive a round whose authoritative result came
+  # from REST instead of agy.
+  [ ! -e "$conv_file" ]
 }
 
 # =============================================================================

--- a/plugins/plan-review/tests/second-opinion.bats
+++ b/plugins/plan-review/tests/second-opinion.bats
@@ -354,6 +354,46 @@ teardown() {
 }
 
 # =============================================================================
+# REVIEW_DISABLED / REVIEW_DRY_RUN are hook-only — this driver ignores both
+# =============================================================================
+
+# 19. REVIEW_DISABLED=1 does NOT bypass the driver — the hook's own bypass
+#     (plan-review.sh:232) is a hook-specific convenience for skipping the
+#     review gate on demand; the driver has no such gate to skip, so it must
+#     still make a real engine call and return the real review body.
+@test "env: REVIEW_DISABLED=1 does not bypass the driver — still calls the engine" {
+  create_mock_engine "agy" "UNIQUE_REAL_REVIEW_BODY_MARKER"
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'System rubric.' > "$sys_file"
+  printf 'Artifact body.' > "$artifact_file"
+
+  REVIEW_DISABLED=1 run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file"
+
+  [ "$SO_EXIT" -eq 0 ]
+  [[ "$SO_STDOUT" == *"UNIQUE_REAL_REVIEW_BODY_MARKER"* ]]
+}
+
+# 20. REVIEW_DRY_RUN=1 does NOT trigger the hook's synthetic-APPROVE
+#     shortcut (plan-review.sh:641) — the driver has no such branch (see the
+#     "Explicitly NOT read" header comment in second-opinion.sh), so it must
+#     still make a real engine call and return the engine's real output, not
+#     a synthesized "<verdict>APPROVE</verdict>" body.
+@test "env: REVIEW_DRY_RUN=1 does not synthesize APPROVE — still calls the engine" {
+  create_mock_engine "agy" "UNIQUE_REAL_REVIEW_BODY_MARKER"
+  local sys_file="${TEST_TEMP_DIR}/sys.md"
+  local artifact_file="${TEST_TEMP_DIR}/artifact.md"
+  printf 'System rubric.' > "$sys_file"
+  printf 'Artifact body.' > "$artifact_file"
+
+  REVIEW_DRY_RUN=1 run_second_opinion --system-prompt-file "$sys_file" --prompt-file "$artifact_file"
+
+  [ "$SO_EXIT" -eq 0 ]
+  [[ "$SO_STDOUT" == *"UNIQUE_REAL_REVIEW_BODY_MARKER"* ]]
+  [[ "$SO_STDOUT" != *"<verdict>APPROVE</verdict>"* ]]
+}
+
+# =============================================================================
 # bash -n coverage note
 # =============================================================================
 # second-opinion.sh's syntax is already covered by plan-review.bats test 115

--- a/plugins/plan-review/tests/test_helper/common-setup.bash
+++ b/plugins/plan-review/tests/test_helper/common-setup.bash
@@ -9,7 +9,9 @@
 HOOK_SCRIPT="${BATS_TEST_DIRNAME}/../scripts/plan-review.sh"
 PRECOMPACT_SCRIPT="${BATS_TEST_DIRNAME}/../scripts/precompact-review.sh"
 DISPATCH_SCRIPT="${BATS_TEST_DIRNAME}/../scripts/dispatch-check.sh"
-SYSTEM_PROMPT_FILE="${BATS_TEST_DIRNAME}/../scripts/assets/review-system-prompt.md"
+SECOND_OPINION_SCRIPT="${BATS_TEST_DIRNAME}/../scripts/second-opinion.sh"
+SYSTEM_PROMPT_PLAN_FILE="${BATS_TEST_DIRNAME}/../scripts/assets/review-plan.md"
+SYSTEM_PROMPT_COMMON_FILE="${BATS_TEST_DIRNAME}/../scripts/assets/review-common.md"
 
 # --- Setup / Teardown ---
 
@@ -901,6 +903,29 @@ run_hook() {
   # Direct invocation — no eval, no exec indirection, no quote destruction.
   HOOK_STDOUT=$(bash "$HOOK_SCRIPT" <<< "$input" 2>"$stderr_file") || HOOK_EXIT=$?
   HOOK_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+# run_second_opinion [arg ...]
+#   Invokes SECOND_OPINION_SCRIPT with the given args. If SO_STDIN is set,
+#   feeds it as stdin (the driver's stdin-body path); otherwise stdin is
+#   /dev/null (so a test that forgets to supply a body sees the driver's own
+#   stdin `cat` block rather than hanging on a terminal).
+#   Sets: SO_STDOUT, SO_STDERR, SO_EXIT
+run_second_opinion() {
+  SO_STDOUT=""
+  SO_STDERR=""
+  SO_EXIT=0
+
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  if [ -n "${SO_STDIN+x}" ]; then
+    SO_STDOUT=$(bash "$SECOND_OPINION_SCRIPT" "$@" <<< "$SO_STDIN" 2>"$stderr_file") || SO_EXIT=$?
+  else
+    SO_STDOUT=$(bash "$SECOND_OPINION_SCRIPT" "$@" < /dev/null 2>"$stderr_file") || SO_EXIT=$?
+  fi
+  SO_STDERR=$(cat "$stderr_file")
   rm -f "$stderr_file"
 }
 


### PR DESCRIPTION
Closes #165

把 plan-review 的引擎基础设施（agy + Gemini 3.1 Pro + REST 降级 + 会话复用）做成插件外可调用的能力。**动机**：模型追新只在 plan-review 一处发生，调用方自动跟随，不必各自硬编码模型名与调用命令。

## 为什么值得做（实测数据）

`~/.claude/logs/plan-review.log` 近 2000 行：`agy-success` 194 / `rest-start` 56 / `rest-result http=200` 50 / `engines-failed` 6 —— CLI 失败率约 22%，REST 救回 89%。插件外自建的调用没有这条降级链，五次里有一次是空转的。

## Part 1：重构（对外行为零变更）

- **提取 `lib/consult.sh`** 的 `run_consultation()`，hook 与驱动共用引擎状态机（重试 / 容量快断 / degrade TTL / 时间预算守卫 / REST 降级）。plan 专有策略经三个 `declare -F` 弱钩子留缝，沿用 `engine_err_filter` 已有的模式。
- **`agy.sh` resume 分支解耦** plan 专有变量：`$PLAN`→`$ARTIFACT`、`$TOTAL_ROUNDS`→`$ROUND_INDEX`。纯改名。
- **asset 拆分**：`review-system-prompt.md` → `review-plan.md`（plan 专有 criteria）+ `review-common.md`（通用评审规范：Finding Quality Gate / Severity Definitions / 版本标识 ground-truth，可被插件外复用）。common 层措辞中性化（`the plan`→`the artifact`），拼接 seam 补空行以保持 markdown 结构。

**安全网**：约 65 个引擎状态机用例（rest-fallback / rest-sse / budget-guard / degrade / ttl / conv / history / codex / retry / timeout）**一行未改**仍全绿——这是"零行为漂移"的判据，不是附带项。审计确认无新增 skip、无放宽断言。

## Part 2：`second-opinion.sh`

```
second-opinion.sh --system-prompt-file <path> [--system-prompt-file <path2> ...]
                  [--prompt-file <path>] [--session <label>]
```

- `--system-prompt-file` 必填、可重复、按序拼接。缺失 fail loud
- 正文走 `--prompt-file` 或 stdin（stdin 是禁止写文件的调用方的唯一路径）
- stdout 只有评审正文，引擎耗尽 exit 非零。**fail loud 而非 hook 的 fail-open**：合成的"看起来像评审"的文字比拿不到更危险
- 不读 `REVIEW_DISABLED` / `REVIEW_DRY_RUN`（那两个是"关掉 ExitPlanMode 那道闸"的语义，显式调用不该被静默改行为）；共享 `DEGRADE_FILE`；不解析 verdict（驱动是传输层）

**会话延续收 label 而非路径**（与 issue 原建议不同）：key 由 `label + system prompt 字节` 派生哈希，所以 rubric 一改旧会话自动失效——"改了 prompt 要记得弃用旧 session"从一条要人记住的规则变成结构上不可能发生。同时省掉了外部路径的整类校验负担。

## 验证

274 个 bats 全绿（既有 256 + 驱动新增 18）。变异验证：抽掉 `<verdict>` 锚点后 138 个用例转红，确认测试真在测东西。

真实 agy e2e（主上下文亲跑）：
- 首轮 26.6s，exit 0，stdout 纯正文
- **同 label 第二轮引擎回应"上一轮指出的问题未得到任何修改"** —— 会话复用生效
- **改一字节 system prompt → key 从 `9f2d2375...` 变为 `bf96267a...`，引擎回到全新首轮** —— 派生式设计的核心主张
- `git status` 干净，无 `.tmp.<pid>` 残留（这是 `CONV_FILE` 传空会踩的坑）

## 已知限制与后续

- **驱动的调用无法从 `plan-review.log` 追溯**：不设 `SESSION_ID`，不产生 `agy-conversation`/`agy-usage` 行。诊断走 stderr，契约如此。已写入 README。
- **本次未接线任何调用方**：交付的是备好的能力。team-ops redteam 的接线需另开 issue（改动落在 `~/.claude`，非本仓库）。
- **`COUNTER_DIR` 的 `/tmp` 暴露面**：审阅指出 `/tmp/claude-reviews` 存在可预测路径软链接风险。该目录自 2026-05-18（`32b5191`）起承载六类文件、横跨三个脚本，属既存债而非本次引入；一次性迁移须覆盖全部七类文件，另开 issue 处理。
- 缓存实际省多少未验证：`agy.sh` 只提取 `input_tokens`/`total_tokens`，不提 cache 字段。

## 磋商记录

plan 经 plan-review 三轮对抗审阅收敛。Round 1 两条成立（manifest 里说明与 `agent_type` 自相矛盾、PR2 缺单元层覆盖）；Round 2 报 `/tmp` 为 Critical，按对称举证要求补代码证据后撤销（归属是既存债）；Round 3 APPROVE。