### PR TITLE
feat(dispatch-contract): 派发能力护栏 dispatch-capability-guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -84,8 +84,8 @@
     },
     {
       "name": "dispatch-contract",
-      "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop) + background-dispatch sync guard (PreToolUse) + dispatch-rules injection (SubagentStart)",
-      "version": "1.2.2",
+      "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop) + background-dispatch sync guard (PreToolUse) + dispatch-capability guard (PreToolUse) + dispatch-rules injection (SubagentStart)",
+      "version": "1.3.0",
       "author": {
         "name": "WooDragon"
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ WooDragon 的 Claude Code 插件 + 技能包 marketplace。
 | Plugin | deep-research（1 skill + 4 agents + 1 hook） | 7-Stage 深度研究管线 + 多模型采集引擎 + 引用验证门禁 |
 | Plugin | guardrails（2 hooks） | 代码规模提示（信息性）+ git push 防手滑（拦截误推 main/master，非防绕过安全边界） |
 | Plugin | pr-review（1 skill + 2 scripts） | 已开 PR 的 AI 评审：grok 本地同步评审（默认，含多轮对抗复评的 session 状态管理）+ Copilot bot 异步评审（可选） |
-| Plugin | dispatch-contract（1 skill + 1 hook） | 子 agent 派发契约：四条派发铁律 + `%%DONE%%` 定稿门禁（SubagentStop） |
+| Plugin | dispatch-contract（1 skill + 4 hooks） | 子 agent 派发契约：四条派发铁律 + `%%DONE%%` 定稿门禁（SubagentStop）+ background-dispatch 同步守卫 + 派发能力匹配守卫（均 PreToolUse）+ 派发规则注入（SubagentStart） |
 
 ## 版本变更铁律
 
@@ -118,10 +118,13 @@ plugins/
       references/copilot-review.md # Copilot 后端三条路径（REST 首触 / GraphQL 重触 / 状态查询）
     tests/grok-review.bats       # 60 个测试用例（stub grok/gh/uuidgen，git 用真实临时仓库）
     README.md                    # 面向安装者说明
-  dispatch-contract/             # 子 agent 派发契约插件（1 skill + 1 hook）
-    .claude-plugin/plugin.json   # 插件元数据（声明 skill + SubagentStop hook）
-    hooks/hooks.json             # SubagentStop → subagent-done-gate.sh（%%DONE%% 定稿门禁，fail-open）
+  dispatch-contract/             # 子 agent 派发契约插件（1 skill + 4 hooks）
+    .claude-plugin/plugin.json   # 插件元数据（声明 skill + 4 个 hook）
+    hooks/hooks.json             # PreToolUse(Agent,Task) → dispatch-sync-guard.sh + dispatch-capability-guard.sh；SubagentStart → dispatch-rules-inject.sh；SubagentStop → subagent-done-gate.sh（均 fail-open）
     hooks/subagent-done-gate.sh  # 门禁脚本：末行精确匹配 %%DONE%%，不匹配则 deny 并回灌纠正指令
+    hooks/dispatch-sync-guard.sh # PreToolUse 门禁：拦截省略 run_in_background:false 的派发调用
+    hooks/dispatch-rules-inject.sh # SubagentStart 门禁：向每个 spawn 的 subagent 注入派发三铁律
+    hooks/dispatch-capability-guard.sh # PreToolUse 门禁：拦截 subagent_type/model 与任务能力需求不匹配的派发（判据 A/B/C）
     skills/subagent-dispatch/
       SKILL.md                   # 四铁律速查 + %%DONE%% 契约 + 己方端 / 派发端补充纪律
       references/dispatch-contract.md   # 四铁律正反例、persona 规避发作区/安全区展开
@@ -130,6 +133,8 @@ plugins/
       references/workflow-schema.md     # Workflow agent() 强结构化产物 + JSON schema 用法
     tests/
       subagent-done-gate.bats    # 26 个测试用例（门禁行为全覆盖）
+      dispatch-sync-guard.bats   # 同步守卫 + 规则注入器测试
+      dispatch-capability-guard.bats # 40 个测试用例（判据 A/B/C + fail-open + 逃生舱）
       test_helper/
         common-setup.bash        # 测试基础设施
 ```
@@ -144,7 +149,7 @@ plugins/
 | doc-gate | `SKILL_GATE_*`、`RECALL_GATE_*` | [plugins/doc-gate/README.md](plugins/doc-gate/README.md#environment-variables) |
 | deep-research | `GATEWAY_API_KEY`、`TAVILY_API_KEY`、`JINA_API_KEY`（可选凭证） | [plugins/deep-research/README.md](plugins/deep-research/README.md#prerequisites) |
 | pr-review | `GROK_MODEL`、`GROK_EFFORT`、`XDG_STATE_HOME`（session 落盘根） | [plugins/pr-review/README.md](plugins/pr-review/README.md#prerequisites) |
-| dispatch-contract | `ALLOW_UNMARKED_FINAL`（`%%DONE%%` 门禁逃生舱） | [plugins/dispatch-contract/README.md](plugins/dispatch-contract/README.md#environment-variables) |
+| dispatch-contract | `ALLOW_UNMARKED_FINAL`、`ALLOW_BACKGROUND_DISPATCH`、`ALLOW_NO_RULES_INJECT`、`CLAUDE_CODE_FORK_SUBAGENT`、`ALLOW_DISPATCH_CAPABILITY_MISMATCH` | [plugins/dispatch-contract/README.md](plugins/dispatch-contract/README.md#environment-variables) |
 
 敏感变量（如 `REVIEW_API_KEY`）配置在 `~/.claude/settings.json` 的 `"env"` 字段中。Claude Code 启动时自动注入到所有 hook 进程环境，无需污染 shell profile。`~/.claude/settings.local.json` 不是合法的用户级配置路径，env 字段在此处不生效。
 

--- a/plugins/dispatch-contract/.claude-plugin/plugin.json
+++ b/plugins/dispatch-contract/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dispatch-contract",
-  "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop) + background-dispatch sync guard (PreToolUse) + dispatch-rules injection (SubagentStart)",
-  "version": "1.2.2",
+  "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop) + background-dispatch sync guard (PreToolUse) + dispatch-capability guard (PreToolUse) + dispatch-rules injection (SubagentStart)",
+  "version": "1.3.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/subagent-dispatch"]
 }

--- a/plugins/dispatch-contract/README.md
+++ b/plugins/dispatch-contract/README.md
@@ -175,10 +175,24 @@ actually deliver what its own prompt asks for.
 
 It extracts four signals from the prompt text (and the `model` field):
 
-- **EXEC** — exec intent (run tests/scripts/build/lint)
+- **EXEC** — exec intent (run tests/scripts/build/lint). A bare-keyword match
+  (migrated verbatim from the user's local `pre-dispatch-readonly-guard.sh`,
+  where the same word list was used as an *exemption* — widening it only ever
+  widened the pass set, harmless in that direction) is required to sit in an
+  imperative/delegation clause; it is demoted back to a non-hit when the
+  clause containing the match instead governs a research-frame or negated
+  object (`查一下跑测试的脚本在哪`, `分析为什么不要跑测试`, `find where we
+  document how to run the tests`) — reusing the same bare list as a
+  *rejection* signal flips its safety direction, so false positives there
+  now have a real cost.
 - **WRITE** — write intent, anchored on a write verb adjacent to a code
   object or a path-shaped token (a bare write verb alone, e.g. 创建一份调研报告,
-  is not collected — that produces a report, not code)
+  is not collected — that produces a report, not code). The English object
+  list includes bare defect nouns `bug|bugs|issue|issues|error|errors` so
+  that `fix the bug in auth` — no file/code/test noun, only a defect noun —
+  still counts as a write object; the Chinese-side object list separately
+  gained the same tokens (`bug|issue|error`) since 中文句子里 `bug` 常年以英文
+  原词出现且这两条 token 各自独立命中，互不覆盖.
 - **RO** — an explicit read-only declaration
 - **NEG** — an absolute negation of writing (e.g. 不要修改任何文件)
 
@@ -191,13 +205,14 @@ NEEDS_CAP = (EXEC || WRITE) && !RO && !NEG
 Three independent judgments fire off this signal set, each printing its own
 stderr message before a single trailing `exit 2`:
 
-- **Judgment A** (migrated verbatim from the user's local
-  `pre-dispatch-readonly-guard.sh`, condition kept unchanged — uses `!EXEC`,
-  not `!NEEDS_CAP`): `!EXEC && (RO || NEG) && subagent_type ∈ {general-purpose,
-  claude}` → block. A read-only declaration (or absolute negation) sent to a
-  full-privilege agent when Explore's Edit/Write/NotebookEdit are physically
-  disabled and would catch the same scope even if the declaration were wrong.
-  Fix: redispatch to `Explore`.
+- **Judgment A** (originally migrated verbatim from the user's local
+  `pre-dispatch-readonly-guard.sh`; condition since **widened** from `!EXEC`
+  alone to `!EXEC && !WRITE_HIT_A`): `!EXEC && !WRITE_HIT_A && (RO || NEG) &&
+  subagent_type ∈ {general-purpose, claude}` → block. A read-only declaration
+  (or absolute negation) sent to a full-privilege agent, provided the same
+  prompt carries no write intent either — Explore's Edit/Write/NotebookEdit
+  are physically disabled and would catch the same scope even if the
+  declaration were wrong. Fix: redispatch to `Explore`.
 - **Judgment B** (new): `NEEDS_CAP && subagent_type ∈ {explore, plan}` →
   block. The task needs write/exec capability, but Explore/Plan have
   Edit/Write/NotebookEdit disabled and Bash limited to a read-only whitelist
@@ -210,24 +225,39 @@ stderr message before a single trailing `exit 2`:
   judgment-forming action the daily model-tiering rubric excludes from the
   haiku tier. Fix: redispatch at `sonnet` or the task's required tier.
 
-Judgment A keeps its original `!EXEC`-based condition rather than being folded
-into `NEEDS_CAP` — it is a behavior-preserving migration of an existing gate,
-not a rewrite, so its trigger condition is intentionally left exactly as it
-was before this hook widened scope. Judgments B and C are new and share the
-`NEEDS_CAP` predicate because both are instances of the same underlying
-question: does this subagent/model have the capability the prompt is asking
-for.
+**Why A's condition had to widen**: the original `pre-dispatch-readonly-guard.sh`
+had no WRITE signal at all, so `!EXEC` meant "this task needs nothing beyond
+read-only" in that world. Once WRITE was introduced to this hook, a mixed
+prompt like `只读查看现有实现，然后修复 main.py` hit `!EXEC` (true) and `RO`
+(true) and `WRITE` (true) at the same time. Under the old `!EXEC`-only
+condition, A fired and told the caller to redispatch to `Explore` — but
+Explore's Edit/Write is physically disabled, so the redispatch could not do
+what the prompt asked. That was a dead end the gate itself manufactured, not
+a legitimate rejection. Adding `!WRITE_HIT_A` closes it: a prompt carrying
+write intent is no longer routed toward an agent that cannot write, regardless
+of what RO/NEG also say in the same prompt. `WRITE_HIT_A` is judgment A's own
+NEG-scrubbed variant of the WRITE signal (judgment B still uses the raw
+`WRITE_HIT`) — without the scrub, a genuine absolute-negation declaration like
+`不得不改测试，不修改任何文件` would stop triggering A, because a
+write-looking substring sits inside its own already-negated clause.
 
-**Deliberately accepted miss**: a mixed prompt like 调研根因并修复 hits both RO
-and WRITE, so `!RO` is false and `NEEDS_CAP` stays 0 — the dispatch passes.
-This is a known under-block, not a bug: today's behavior for such prompts is
-also "pass" (no regression), and requiring every Explore dispatch to declare
-read-only explicitly was rejected as a fix — it would push dispatchers toward
-`general-purpose` by default, amplifying exactly the over-privilege risk
-judgment A exists to catch.
+**Deliberately accepted miss (judgment B's, not A's)**: a mixed prompt like
+`调研根因并修复` dispatched straight to `subagent_type=explore` still passes,
+because `NEEDS_CAP` folds to 0 whenever `RO_HIT` is 1. This is the same
+under-block that existed before this patch too — today's behavior for such
+prompts is already "pass", so leaving it is a no-op, not a regression — and it
+must not be confused with A's now-fixed dead end above: A's old problem was
+that the gate *actively rejected* and then pointed the caller at an agent that
+physically could not comply; B's miss is merely passive under-coverage — the
+dispatch goes through unexamined, exactly today's baseline. Tightening
+`NEEDS_CAP` to ignore RO for mixed prompts was rejected as the fix here too,
+for the same over-privilege reason given below.
 
 **Fail-open paths**: empty stdin, missing `jq`, non-JSON payload, or an empty
-prompt field all exit 0 silently.
+prompt field all exit 0 silently — except empty stdin and missing `jq`, which
+first write `[GATE-DEGRADE]` to stderr (`empty stdin` / `jq unavailable`) so a
+grep for gate breakage can find them; the two paths were previously silent
+`exit 0` with no stderr trace at all.
 
 **Escape hatch**: `ALLOW_DISPATCH_CAPABILITY_MISMATCH=1` in the `env` block of
 `settings.json` (a plain Bash `export` does not reach this hook's process).
@@ -300,13 +330,21 @@ malformed-stdin shapes), plus the rules-injector's JSON-shape checks (normal
 `agent_type` gets all three rules, `Explore` omits the scope-fence rule, empty stdin
 and `ALLOW_NO_RULES_INJECT=1` both leave stdout fully empty).
 
-`dispatch-capability-guard.bats` has 40 test cases covering: signal extraction
+`dispatch-capability-guard.bats` has 53 test cases covering: signal extraction
 (EXEC/WRITE/RO/NEG, including the double-negation and exclusive-write-scope scrub
 logic), the `NEEDS_CAP` derived predicate and its deliberately-accepted mixed-prompt
 miss, judgments A/B/C individually and in combination (Explore + haiku triggering both
 B and C's messages before one `exit 2`), the `[GATE-BYPASS]`/`[GATE-DEGRADE]` tag
 split, the escape hatch, and fail-open paths (empty stdin, missing `jq`, malformed
-JSON, empty prompt).
+JSON, empty prompt). A later regression batch (`cap #24`–`#45`) pins the four
+post-PR fixes above: judgment A's narrowed `!WRITE_HIT_A` exemption on mixed
+RO+WRITE prompts (including the double-negation edge case that resurfaced once A
+started consulting WRITE), EXEC's research-frame/negation anchoring on both CN
+and EN phrasing, the distinct `[GATE-DEGRADE]` wording for empty-stdin and
+missing-`jq`, and the EN/CN defect-noun objects pinned by two separate cases
+(`cap #42` for the English side, `cap #45` for the Chinese side with no other
+`WRITE_OBJ` word present) since the two token tables are matched independently
+and a deletion on one side would otherwise pass silently under a shared test.
 
 ## Block Response Shape (Deliberate Choice)
 

--- a/plugins/dispatch-contract/README.md
+++ b/plugins/dispatch-contract/README.md
@@ -2,7 +2,7 @@
 
 Subagent dispatch contract enforcement for Claude Code — a `%%DONE%%` finalization gate plus a methodology skill for reliable subagent delegation.
 
-The plugin has four parts: a **PreToolUse hook** that blocks dispatch calls omitting `run_in_background:false`, a **SubagentStart hook** that injects the dispatch rules into every spawned subagent, a **SubagentStop hook** that enforces the `%%DONE%%` finalization marker when it is declared in the dispatch prompt, and a **`subagent-dispatch` skill** that inlines the four dispatch rules, offload-scenario guidance, and background-subagent patterns on demand.
+The plugin has five parts: a **PreToolUse hook** that blocks dispatch calls omitting `run_in_background:false`, a second **PreToolUse hook** that blocks dispatch calls whose `subagent_type`/`model` cannot deliver what the prompt asks for, a **SubagentStart hook** that injects the dispatch rules into every spawned subagent, a **SubagentStop hook** that enforces the `%%DONE%%` finalization marker when it is declared in the dispatch prompt, and a **`subagent-dispatch` skill** that inlines the four dispatch rules, offload-scenario guidance, and background-subagent patterns on demand.
 
 ## Installation
 
@@ -16,14 +16,21 @@ claude plugin add dispatch-contract@WooDragon-cc-plugins
 ```
 PreToolUse (matcher: Agent, Task)
   │
-  └─ dispatch-sync-guard.sh (5s timeout)
-         Blocks a dispatch call that omits run_in_background:false.
-         Omission selects the background delivery channel, and that channel
-         drops completion notifications at a measured 92.7% loss rate with
-         no resend path. Passes silently (fail-open) on teammate context
-         (agent_id present), Lead-starts-a-teammate calls (tool_input.name
-         present), the CLAUDE_CODE_DISABLE_BACKGROUND_TASKS env var, and any
-         malformed or missing payload field.
+  ├─ dispatch-sync-guard.sh (5s timeout)
+  │      Blocks a dispatch call that omits run_in_background:false.
+  │      Omission selects the background delivery channel, and that channel
+  │      drops completion notifications at a measured 92.7% loss rate with
+  │      no resend path. Passes silently (fail-open) on teammate context
+  │      (agent_id present), Lead-starts-a-teammate calls (tool_input.name
+  │      present), the CLAUDE_CODE_DISABLE_BACKGROUND_TASKS env var, and any
+  │      malformed or missing payload field.
+  │
+  └─ dispatch-capability-guard.sh (5s timeout)
+         Blocks a dispatch call whose subagent_type/model cannot deliver
+         what the prompt itself asks for — a read-only declaration sent to
+         a full-privilege agent, or a write/exec-needing task sent to a
+         read-only agent type or the haiku model tier. See "The Dispatch
+         Capability Guard" below for the full judgment matrix.
 
 SubagentStart (matcher: *)
   │
@@ -51,8 +58,9 @@ skills/subagent-dispatch  (no hook — loaded by description match)
          contract is reachable at dispatch time rather than only after a block.
 ```
 
-This plugin registers three hooks: `PreToolUse` (dispatch-sync-guard),
-`SubagentStart` (dispatch-rules-inject), and `SubagentStop` (subagent-done-gate).
+This plugin registers four hooks: `PreToolUse` (dispatch-sync-guard,
+dispatch-capability-guard), `SubagentStart` (dispatch-rules-inject), and
+`SubagentStop` (subagent-done-gate).
 There is no dispatch-side hook that guesses whether a given task needs a
 `%%DONE%%` deliverable — that judgment is semantic, and a keyword guess would
 misfire often enough to be ignored. The skill closes that gap instead.
@@ -157,6 +165,83 @@ synchronous dispatch requestable again. `ALLOW_BACKGROUND_DISPATCH=1` does not f
 case — it silences the guard everywhere, including runtimes where the background
 channel is real and the guard is protecting against an actual notification-loss risk.
 
+## The Dispatch Capability Guard
+
+`dispatch-capability-guard.sh` also runs on `PreToolUse` for `Agent` and `Task`
+calls, alongside `dispatch-sync-guard.sh`. Where the sync guard treats the
+*delivery channel* (background vs. synchronous), this hook treats *capability
+mismatch* — whether the `subagent_type`/`model` a dispatch call names can
+actually deliver what its own prompt asks for.
+
+It extracts four signals from the prompt text (and the `model` field):
+
+- **EXEC** — exec intent (run tests/scripts/build/lint)
+- **WRITE** — write intent, anchored on a write verb adjacent to a code
+  object or a path-shaped token (a bare write verb alone, e.g. 创建一份调研报告,
+  is not collected — that produces a report, not code)
+- **RO** — an explicit read-only declaration
+- **NEG** — an absolute negation of writing (e.g. 不要修改任何文件)
+
+These fold into one derived predicate:
+
+```
+NEEDS_CAP = (EXEC || WRITE) && !RO && !NEG
+```
+
+Three independent judgments fire off this signal set, each printing its own
+stderr message before a single trailing `exit 2`:
+
+- **Judgment A** (migrated verbatim from the user's local
+  `pre-dispatch-readonly-guard.sh`, condition kept unchanged — uses `!EXEC`,
+  not `!NEEDS_CAP`): `!EXEC && (RO || NEG) && subagent_type ∈ {general-purpose,
+  claude}` → block. A read-only declaration (or absolute negation) sent to a
+  full-privilege agent when Explore's Edit/Write/NotebookEdit are physically
+  disabled and would catch the same scope even if the declaration were wrong.
+  Fix: redispatch to `Explore`.
+- **Judgment B** (new): `NEEDS_CAP && subagent_type ∈ {explore, plan}` →
+  block. The task needs write/exec capability, but Explore/Plan have
+  Edit/Write/NotebookEdit disabled and Bash limited to a read-only whitelist
+  — the dispatch would dead-end after a full round trip. Fix: redispatch to
+  `general-purpose` or `dev` (team-ops).
+- **Judgment C** (new): `NEEDS_CAP && model` contains the substring `haiku`
+  (matched as a substring because real values look like
+  `claude-haiku-4-5-20251001`, never the bare word) → block. Interpreting
+  run/test/build output well enough to decide what to do next is a
+  judgment-forming action the daily model-tiering rubric excludes from the
+  haiku tier. Fix: redispatch at `sonnet` or the task's required tier.
+
+Judgment A keeps its original `!EXEC`-based condition rather than being folded
+into `NEEDS_CAP` — it is a behavior-preserving migration of an existing gate,
+not a rewrite, so its trigger condition is intentionally left exactly as it
+was before this hook widened scope. Judgments B and C are new and share the
+`NEEDS_CAP` predicate because both are instances of the same underlying
+question: does this subagent/model have the capability the prompt is asking
+for.
+
+**Deliberately accepted miss**: a mixed prompt like 调研根因并修复 hits both RO
+and WRITE, so `!RO` is false and `NEEDS_CAP` stays 0 — the dispatch passes.
+This is a known under-block, not a bug: today's behavior for such prompts is
+also "pass" (no regression), and requiring every Explore dispatch to declare
+read-only explicitly was rejected as a fix — it would push dispatchers toward
+`general-purpose` by default, amplifying exactly the over-privilege risk
+judgment A exists to catch.
+
+**Fail-open paths**: empty stdin, missing `jq`, non-JSON payload, or an empty
+prompt field all exit 0 silently.
+
+**Escape hatch**: `ALLOW_DISPATCH_CAPABILITY_MISMATCH=1` in the `env` block of
+`settings.json` (a plain Bash `export` does not reach this hook's process).
+
+**Logging**: unlike this plugin's other hooks, which fail open silently, this
+hook writes one of two distinct stderr tags depending on why a check did not
+run: `[GATE-BYPASS]` when the escape hatch is open (a human deliberately
+disabled the check — not a malfunction), checked first so an open hatch is
+never mistaken for broken judgment data; `[GATE-DEGRADE]` when the judgment
+data itself could not be read (empty stdin, missing `jq`, malformed JSON).
+Collapsing the two into one silent fail-open, as this plugin's sibling hooks
+do, would make a grep for real breakage indistinguishable from a session that
+simply has the hatch on.
+
 ## The SubagentStart Rules Injector
 
 `dispatch-rules-inject.sh` runs on `SubagentStart` for every spawned subagent
@@ -195,6 +280,7 @@ The skill triggers on dispatch-related requests: "派发 subagent", "dispatch su
 # Requires bats-core
 bats plugins/dispatch-contract/tests/subagent-done-gate.bats
 bats plugins/dispatch-contract/tests/dispatch-sync-guard.bats
+bats plugins/dispatch-contract/tests/dispatch-capability-guard.bats
 ```
 
 `subagent-done-gate.bats` has 26 test cases covering: core judgment (marker
@@ -214,16 +300,24 @@ malformed-stdin shapes), plus the rules-injector's JSON-shape checks (normal
 `agent_type` gets all three rules, `Explore` omits the scope-fence rule, empty stdin
 and `ALLOW_NO_RULES_INJECT=1` both leave stdout fully empty).
 
+`dispatch-capability-guard.bats` has 40 test cases covering: signal extraction
+(EXEC/WRITE/RO/NEG, including the double-negation and exclusive-write-scope scrub
+logic), the `NEEDS_CAP` derived predicate and its deliberately-accepted mixed-prompt
+miss, judgments A/B/C individually and in combination (Explore + haiku triggering both
+B and C's messages before one `exit 2`), the `[GATE-BYPASS]`/`[GATE-DEGRADE]` tag
+split, the escape hatch, and fail-open paths (empty stdin, missing `jq`, malformed
+JSON, empty prompt).
+
 ## Block Response Shape (Deliberate Choice)
 
-Both hooks in this plugin — `dispatch-sync-guard.sh` (PreToolUse) and
-`subagent-done-gate.sh` (SubagentStop) — block via `exit 2` plus a stderr
-message. Some sibling plugins in this repo use a different shape instead:
-`plan-review`'s `dispatch-check.sh` and `doc-gate`'s `skill-gate.sh` return
-JSON `permissionDecision: deny`. This repo does not use one block-response
-shape across all plugins — `guardrails`' `git-push-guard.sh` also blocks via
-`exit 2`. Within this plugin, consistency with the sibling
-`subagent-done-gate.sh` hook takes priority over matching an unrelated
+All three blocking hooks in this plugin — `dispatch-sync-guard.sh` (PreToolUse),
+`dispatch-capability-guard.sh` (PreToolUse), and `subagent-done-gate.sh`
+(SubagentStop) — block via `exit 2` plus a stderr message. Some sibling plugins
+in this repo use a different shape instead: `plan-review`'s `dispatch-check.sh`
+and `doc-gate`'s `skill-gate.sh` return JSON `permissionDecision: deny`. This
+repo does not use one block-response shape across all plugins — `guardrails`'
+`git-push-guard.sh` also blocks via `exit 2`. Within this plugin, consistency
+across the three blocking hooks takes priority over matching an unrelated
 plugin's shape. The two forms are functionally equivalent here. The runtime
 routes the `exit 2` stderr text through `blockingError` into the tool result
 the model sees. The correction message reaches model context either way.
@@ -236,3 +330,4 @@ the model sees. The correction message reaches model context either way.
 | `ALLOW_BACKGROUND_DISPATCH` | _(unset)_ | `1` disables the background-dispatch sync guard entirely — set in `settings.json`'s `env` section, since `export` in a Bash tool call does not reach the hook process |
 | `ALLOW_NO_RULES_INJECT` | _(unset)_ | `1` disables the SubagentStart rules injector entirely |
 | `CLAUDE_CODE_FORK_SUBAGENT` | _(unset)_ | `0` disables the fork-subagent feature — restores `run_in_background` to the Agent input schema, the correct fix for step 9b's fork-world block |
+| `ALLOW_DISPATCH_CAPABILITY_MISMATCH` | _(unset)_ | `1` disables the dispatch-capability guard entirely — set in `settings.json`'s `env` section, since `export` in a Bash tool call does not reach the hook process |

--- a/plugins/dispatch-contract/hooks/dispatch-capability-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-capability-guard.sh
@@ -12,18 +12,53 @@
 # the same prompt declares the task read-only after all". Three independent
 # judgments fire off that signal set:
 #
-#   A (migrated verbatim from pre-dispatch-readonly-guard.sh, condition
-#      UNCHANGED — uses !EXEC, not !NEEDS_CAP):
-#        !EXEC && (RO || NEG) && TYPE in {general-purpose, claude}
+#   A (originally migrated verbatim from pre-dispatch-readonly-guard.sh;
+#      condition WIDENED from !EXEC to !EXEC && !WRITE_A — see "A's exemption"
+#      below for why the verbatim condition stopped holding; WRITE_A is a
+#      NEG-scrubbed variant of WRITE, not the raw WRITE signal — see
+#      WRITE_HIT_A's own comment near its computation for why the raw
+#      signal is not safe to reuse here):
+#        !EXEC && !WRITE_A && (RO || NEG) && TYPE in {general-purpose, claude}
 #        -> read-only declaration sent to a full-privilege agent; Explore's
 #           Edit/Write/NotebookEdit are physically disabled, so re-dispatch
 #           there cannot exceed scope even if the declaration is wrong.
+#
+#      A's exemption (why !EXEC alone is no longer correct): the original
+#      pre-dispatch-readonly-guard.sh had no WRITE signal, so !EXEC meant
+#      "this task needs nothing beyond read-only" in that world. Once WRITE
+#      was introduced, a prompt like "只读查看现有实现，然后修复 main.py" hits
+#      !EXEC (true, no exec-intent phrase) AND RO (true, "只读查看") AND WRITE
+#      (true, "修复 main.py") at the same time. Under the old !EXEC-only
+#      condition, A fired and told the caller to re-dispatch to Explore — but
+#      Explore's Edit/Write is physically disabled, so the re-dispatch cannot
+#      do what the prompt asks. That is a dead end the gate manufactured,
+#      not a legitimate rejection (see issue's Critical finding #1). Adding
+#      !WRITE closes it: a prompt carrying write intent is no longer routed
+#      toward an agent that cannot write, regardless of what RO/NEG also say
+#      in the same prompt.
 #
 #   B (new): NEEDS_CAP && TYPE in {explore, plan}
 #        -> this task needs write/exec capability, but Explore/Plan have
 #           Edit/Write/NotebookEdit physically disabled and Bash limited to a
 #           read-only whitelist. The dispatch would dead-end after burning a
 #           full round trip. Re-dispatch to general-purpose/dev.
+#
+#      B's accepted miss (NOT the same gap as A's old dead end above): mixed
+#      RO+WRITE prompts dispatched directly to Explore (e.g. "调研根因并修复"
+#      sent straight to subagent_type=explore) still pass, because NEEDS_CAP
+#      folds to 0 whenever RO_HIT is 1 (see NEEDS_CAP's own comment below).
+#      This is a real under-block and it is deliberately kept — tightening
+#      NEEDS_CAP to ignore RO for mixed prompts would flood genuine read-only
+#      research dispatches with false positives. The reason this is safe to
+#      leave as B's problem rather than promoted to a fix: it is a same-shape
+#      miss that existed before this patch too (today's behavior for such
+#      prompts is already "pass"), so leaving it is a no-op, not a regression.
+#      It must not be confused with A's now-fixed dead end: A's problem was
+#      that the gate ACTIVELY REJECTED and then pointed the caller at an
+#      agent that physically cannot comply — a self-inflicted trap with no
+#      good exit. B's miss is merely PASSIVE under-coverage — the dispatch
+#      goes through unexamined, which is exactly today's baseline, not a
+#      regression this patch introduces or a trap this patch built.
 #
 #   C (new): NEEDS_CAP && model contains "haiku"
 #        -> this task needs write/exec capability, which in practice means
@@ -82,9 +117,15 @@ if [[ "${ALLOW_DISPATCH_CAPABILITY_MISMATCH:-}" == "1" ]]; then
   exit 0
 fi
 
-[ -z "$INPUT" ] && exit 0
+if [ -z "$INPUT" ]; then
+  printf '[GATE-DEGRADE] dispatch-capability-guard: empty stdin\n' >&2
+  exit 0
+fi
 
-command -v jq >/dev/null 2>&1 || exit 0
+if ! command -v jq >/dev/null 2>&1; then
+  printf '[GATE-DEGRADE] dispatch-capability-guard: jq unavailable\n' >&2
+  exit 0
+fi
 
 SUBAGENT_TYPE=$(jq -r '.tool_input.subagent_type // empty' <<< "$INPUT" 2>/dev/null) || {
   printf '[GATE-DEGRADE] dispatch-capability-guard: subagent_type extract failed\n' >&2
@@ -113,14 +154,30 @@ TYPE=$(tr '[:upper:]' '[:lower:]' <<< "$SUBAGENT_TYPE")
 PROMPT_LC=$(tr '[:upper:]' '[:lower:]' <<< "$PROMPT")
 MODEL_LC=$(tr '[:upper:]' '[:lower:]' <<< "$MODEL")
 
-# --- Signal 1: EXEC (exec intent) — migrated verbatim from
-# pre-dispatch-readonly-guard.sh. Positive capability requirement: needs Bash
-# execution but does not necessarily write repo files (run tests, run lint,
-# run a review CLI). Deliberately does NOT cover bare 跑一遍 (no execution
-# object) — that would misfire on 跑一遍历史 commit 记录，只读调查, a genuinely
-# read-only task; narrowed to 跑一遍+测试/脚本/用例.
-RE_EXEC='前台(同步)?执行|执行脚本|运行脚本|跑脚本|跑测试|运行测试|执行测试|跑用例|跑一遍(测试|脚本|用例)|跑 ?lint|跑 ?build|跑构建|执行以下命令|执行下列命令'
-RE_EXEC_EN='run (the |this |that )?scripts?|execute (the |this )?scripts?|run (the )?tests?|run (the )?test suite|run (the )?lint|run (the )?build'
+# --- Signal 1: EXEC (exec intent) — the bare keyword list below
+# (RE_EXEC_BARE*) is migrated verbatim from pre-dispatch-readonly-guard.sh,
+# where it was used as an EXEMPTION (widening the word list only ever
+# widened the set of prompts allowed to pass — harmless in that direction).
+# This hook reuses it as a REJECTION signal (judgment B blocks on EXEC_HIT),
+# which flips the safety direction: a bare keyword list now widens the set
+# of prompts BLOCKED, and false positives there have a real cost (실측 in
+# Major finding #2 — "查一下跑测试的脚本在哪" is pure research and got
+# blocked). Per gate-design.md §2 (anchor syntactic shape, not bare
+# keywords), EXEC_HIT now requires a bare-keyword match to sit in an
+# imperative/delegation clause, not a research-frame or negated clause.
+# The word list itself is unchanged from the original migration; only the
+# surrounding clause is inspected before accepting the hit.
+RE_EXEC_BARE_CN='前台(同步)?执行|执行脚本|运行脚本|跑脚本|跑测试|运行测试|执行测试|跑用例|跑一遍(测试|脚本|用例)|跑 ?lint|跑 ?build|跑构建|执行以下命令|执行下列命令'
+RE_EXEC_BARE_EN='run (the |this |that )?scripts?|execute (the |this )?scripts?|run (the )?tests?|run (the )?test suite|run (the )?lint|run (the )?build'
+RE_EXEC_BARE="${RE_EXEC_BARE_CN}|${RE_EXEC_BARE_EN}"
+# Research-frame / negation words that, when they appear in the SAME CLAUSE
+# preceding the bare-keyword hit (i.e. between the nearest clause boundary
+# 逗号/顿号/分号/句号/comma/period and the match), demote it back to a
+# non-hit: the keyword is the OBJECT of a research or negated verb, not an
+# imperative to execute. Mirrors RO_ACT's existing anchor-not-bare-keyword
+# treatment — same design move, applied to EXEC instead of RO.
+RE_EXEC_FRAME_CN='查|找|看|分析|说明|文档|哪里|在哪|为什么|如何|怎么|不要|不用|别|无需|不需要|不必|勿|莫'
+RE_EXEC_FRAME_EN='document how to|find where|explain why|show me where|do not|don.t|dont|why not|should not'
 
 # --- Signal 2: WRITE (write intent, NEW) — anchored per gate-design.md §2:
 # anchor on syntactic shape, not bare keywords. A write verb alone (裸
@@ -130,11 +187,17 @@ RE_EXEC_EN='run (the |this |that )?scripts?|execute (the |this )?scripts?|run (t
 # what keeps the two apart — same reasoning pre-dispatch-readonly-guard.sh's
 # RE_WRITE_SCOPE comment already documents for a different judgment.
 WRITE_VERB='修改|修复|重构|实现|新增|添加|删除|重命名|改写|补充|编写|落地|开发|加一个|加个'
-WRITE_OBJ='文件|代码|源码|函数|方法|测试|用例|脚本|模块|类|接口|配置|字段'
+# bug|issue|error added per Minor finding #4: "fix the bug in auth" carries
+# no code/file/test noun at all, only a defect noun, and was missing from
+# the object list. English tokens kept as-is (not translated) because 中文
+# 句子里 bug 常年以英文原词出现（"修复 auth 模块的 bug"），同一 token 双语都要收。
+WRITE_OBJ='文件|代码|源码|函数|方法|测试|用例|脚本|模块|类|接口|配置|字段|bug|issue|error'
 # Path-shaped token: contains a slash, or a common source/doc extension.
 RE_PATH_TOKEN='[[:alnum:]_.-]*/[[:alnum:]_./-]*|[[:alnum:]_-]+\.(py|sh|ts|tsx|js|jsx|go|md|json|yaml|yml|rb|java|c|cpp|h|rs)'
 RE_WRITE_CN="(${WRITE_VERB})[^。,，;；]{0,20}(${WRITE_OBJ})|(${WRITE_VERB})[^。,，;；]{0,20}(${RE_PATH_TOKEN})"
-RE_WRITE_EN='(implement|fix|refactor|rename|add|remove|modify|write)s? (the |a |an |this )?(file|files|code|function|functions|test|tests|script|scripts|module|modules)'
+# bug|bugs|issue|issues|error|errors added per Minor finding #4: "fix the
+# bug in auth" carried no file/code/test noun, only a defect noun.
+RE_WRITE_EN='(implement|fix|refactor|rename|add|remove|modify|write)s? (the |a |an |this )?(file|files|code|function|functions|test|tests|script|scripts|module|modules|bug|bugs|issue|issues|error|errors)'
 RE_WRITE_PATH_EN="(implement|fix|refactor|rename|add|remove|modify|write)[^.,;]{0,40}(${RE_PATH_TOKEN})"
 
 # --- Signal 3: RO (read-only declaration) — migrated verbatim from
@@ -195,8 +258,25 @@ RE_SCOPE_NEG='(不要|不得|不准|不许|别|请勿|切勿|切莫|禁止|严�
 RE_WRITE_SCOPE_EN='(only|just) (change|modify|edit|touch|write|add)|(change|modify|edit|touch|write) only|limit (changes|edits|modifications) to'
 
 # --- Compute EXEC / WRITE -----------------------------------------------
+# EXEC_HIT: bare-keyword match required, PLUS the clause containing the
+# match must not carry a research-frame or negation word. Clause boundary
+# is the nearest 逗号/顿号/分号/句号 (or English comma/period) to the LEFT of
+# the match — this is what lets "查一下跑测试的脚本在哪，只读调研" (frame word
+# 查 sits in the same clause as 跑测试) stay a non-hit while "只读调研，跑一遍
+# 测试确认" (frame word 只读调研 is in the PRIOR clause, separated by a comma)
+# still hits: the frame word must govern the same clause as the keyword, not
+# merely appear earlier in the sentence.
 EXEC_HIT=0
-[[ "$PROMPT_LC" =~ $RE_EXEC || "$PROMPT_LC" =~ $RE_EXEC_EN ]] && EXEC_HIT=1
+if [[ "$PROMPT_LC" =~ $RE_EXEC_BARE ]]; then
+  EXEC_MATCH="${BASH_REMATCH[0]}"
+  EXEC_PREFIX="${PROMPT_LC%%"$EXEC_MATCH"*}"
+  EXEC_CLAUSE="${EXEC_PREFIX##*[,，、；;。.]}"
+  if [[ "$EXEC_CLAUSE" =~ $RE_EXEC_FRAME_CN || "$EXEC_CLAUSE" =~ $RE_EXEC_FRAME_EN ]]; then
+    EXEC_HIT=0
+  else
+    EXEC_HIT=1
+  fi
+fi
 
 WRITE_HIT=0
 if [[ "$PROMPT_LC" =~ $RE_WRITE_CN || "$PROMPT_LC" =~ $RE_WRITE_EN || "$PROMPT_LC" =~ $RE_WRITE_PATH_EN ]]; then
@@ -221,6 +301,38 @@ while [[ "$SCRUBBED" =~ $RE_DOUBLE_NEG ]]; do
   # PreToolUse——挂起没有逃生舱，值得一行防御。
   [[ -z "$m" || "$SCRUBBED" == "$prev" ]] && break
 done
+
+# WRITE_HIT_A: a judgment-A-only variant of WRITE_HIT, scanned against text
+# with every already-recognized absolute-negation span (RE_NEG/RE_NEG_EN)
+# scrubbed out first. Root cause this works around: RE_WRITE_CN/RE_WRITE_EN
+# are bare substring matches with no clause anchoring, so for "不得不改测试，
+# 不修改任何文件" they match "修改任何文件" INSIDE a clause that RE_NEG also
+# (correctly) matches as an absolute negation — the same substring is
+# simultaneously "a write object" to one regex and "a negated write object"
+# to another. This collision predates this patch (WRITE_OBJ additions did
+# not cause it — the bare verb 修改 + bare object 文件 already collide with
+# RE_NEG on this exact sentence even under the pre-patch word lists) but was
+# invisible before because judgment A never consulted WRITE_HIT. Once A
+# started requiring !WRITE (this patch's Critical fix), the collision
+# surfaced as a regression on a previously-pinned test (cap #25b): a genuine
+# absolute-negation declaration stopped triggering A because a write-looking
+# substring sat inside its own negated clause. Scoping WRITE_HIT_A to the
+# NEG-scrubbed text (reusing the same scrub-by-placeholder mechanism as
+# SCRUBBED/RE_DOUBLE_NEG above, applied one level further) resolves it
+# without touching RE_WRITE_CN/RE_WRITE_EN themselves, so judgment B's
+# WRITE detection (and NEEDS_CAP) are unaffected — only A's local !WRITE
+# check looks at text with recognized negations already removed.
+WRITE_SRC_A=$SCRUBBED
+while [[ "$WRITE_SRC_A" =~ $RE_NEG || "$WRITE_SRC_A" =~ $RE_NEG_EN ]]; do
+  nm=${BASH_REMATCH[0]}
+  nprev=$WRITE_SRC_A
+  WRITE_SRC_A=${WRITE_SRC_A/"$nm"/␡}
+  [[ -z "$nm" || "$WRITE_SRC_A" == "$nprev" ]] && break
+done
+WRITE_HIT_A=0
+if [[ "$WRITE_SRC_A" =~ $RE_WRITE_CN || "$WRITE_SRC_A" =~ $RE_WRITE_EN || "$WRITE_SRC_A" =~ $RE_WRITE_PATH_EN ]]; then
+  WRITE_HIT_A=1
+fi
 
 NEG_HIT=0
 if [[ "$SCRUBBED" =~ $RE_NEG || "$SCRUBBED" =~ $RE_NEG_EN ]]; then
@@ -259,13 +371,24 @@ fi
 
 REJECT=0
 
-# --- Judgment A (migrated, condition unchanged: uses !EXEC, not !NEEDS_CAP) -
+# --- Judgment A (condition WIDENED: !EXEC && !WRITE_A, was !EXEC alone) ----
 # Read-only declaration (or absolute negation) sent to a full-privilege
-# built-in agent. Kept exactly as pre-dispatch-readonly-guard.sh judged it —
-# behavior-preserving migration, not a rewrite.
+# built-in agent, PROVIDED the same prompt carries no write intent either.
+# The !WRITE_A addition is this patch's Critical fix (see the "A's exemption"
+# block comment near the top of this file for the full trace): without it,
+# a mixed prompt like "只读查看现有实现，然后修复 main.py" got told to
+# re-dispatch to Explore, whose Edit/Write is physically disabled — a dead
+# end the gate manufactured rather than a legitimate rejection. With !WRITE_A,
+# such a prompt no longer matches A at all (it needs write capability, so
+# staying on general-purpose/claude is the correct dispatch, not an error).
+# Uses WRITE_HIT_A (NEG-scrubbed variant), not the raw WRITE_HIT judgment B
+# uses: see WRITE_HIT_A's own comment above for why — a write-object
+# substring sitting inside an already-recognized absolute-negation clause
+# ("不修改任何文件") must not disqualify A's read-only declaration just
+# because a bare-substring regex also sees a write-shaped token in it.
 case "$TYPE" in
   general-purpose|claude)
-    if [ "$EXEC_HIT" -eq 0 ] && { [ "$RO_HIT" -eq 1 ] || [ "$NEG_HIT" -eq 1 ]; }; then
+    if [ "$EXEC_HIT" -eq 0 ] && [ "$WRITE_HIT_A" -eq 0 ] && { [ "$RO_HIT" -eq 1 ] || [ "$NEG_HIT" -eq 1 ]; }; then
       printf '[dispatch-capability-guard] 命中判据 A: 只读任务声明但派了全权 agent(subagent_type=%s),应改派内置 Explore(Edit/Write/NotebookEdit 物理禁用,越权改不了文件)。\n' "$TYPE" >&2
       printf '[dispatch-capability-guard] 出路: 改派 subagent_type=Explore。需 code-search/web-search 时在 prompt 内 Skill(...) 加载。任务其实要执行脚本/跑测试(Explore 的 Bash 限只读白名单,会拒执行)时,在 prompt 里写明执行意图(如"前台同步执行"/"跑脚本")即豁免——这类任务留 general-purpose 是对的。\n' >&2
       REJECT=1

--- a/plugins/dispatch-contract/hooks/dispatch-capability-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-capability-guard.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Agent, Task): block ad-hoc dispatch calls whose
+# subagent_type/model cannot deliver what the prompt itself asks for.
+#
+# Two capability-need signals (EXEC, WRITE) and two read-only-declaration
+# signals (RO, NEG) are extracted from the prompt text. They combine into one
+# derived predicate:
+#
+#   NEEDS_CAP = (EXEC || WRITE) && !RO && !NEG
+#
+# ...meaning "this task asks for something beyond read-only, and nothing in
+# the same prompt declares the task read-only after all". Three independent
+# judgments fire off that signal set:
+#
+#   A (migrated verbatim from pre-dispatch-readonly-guard.sh, condition
+#      UNCHANGED — uses !EXEC, not !NEEDS_CAP):
+#        !EXEC && (RO || NEG) && TYPE in {general-purpose, claude}
+#        -> read-only declaration sent to a full-privilege agent; Explore's
+#           Edit/Write/NotebookEdit are physically disabled, so re-dispatch
+#           there cannot exceed scope even if the declaration is wrong.
+#
+#   B (new): NEEDS_CAP && TYPE in {explore, plan}
+#        -> this task needs write/exec capability, but Explore/Plan have
+#           Edit/Write/NotebookEdit physically disabled and Bash limited to a
+#           read-only whitelist. The dispatch would dead-end after burning a
+#           full round trip. Re-dispatch to general-purpose/dev.
+#
+#   C (new): NEEDS_CAP && model contains "haiku"
+#        -> this task needs write/exec capability, which in practice means
+#           interpreting run/test/build output well enough to decide what to
+#           do next — a judgment-forming action the haiku tier is excluded
+#           from by the daily model-tiering rubric (取数活 vs 落地活). Model
+#           substring match, not exact match: real values look like
+#           "claude-haiku-4-5-20251001", never the bare word.
+#
+# B and C are independent: a dispatch can hit both at once (Explore + haiku
+# asked to fix code), and both rejection messages are printed before the
+# single trailing `exit 2` — a caller fixing only one would still get bounced
+# by the other on re-dispatch otherwise.
+#
+# subagent_type default: an ABSENT field means "general-purpose" (the
+# platform's own fallback), not "treat as missing" — same rule
+# pre-dispatch-readonly-guard.sh already applies, kept for A's parity.
+#
+# Escape hatch: ALLOW_DISPATCH_CAPABILITY_MISMATCH=1 in the `env` block of
+# ~/.claude/settings.json (a plain Bash `export` does not reach this hook's
+# process — it is spawned by the CC main process, not by the calling shell).
+# One hook, one switch: the old pre-dispatch-readonly-guard.sh switch name
+# ALLOW_READONLY_DISPATCH_WRITE described judgment A only; this hook's scope
+# widened to bidirectional capability matching (A + B + C), so it gets a name
+# that describes the widened scope instead of carrying the old, now-partial
+# name forward.
+#
+# [GATE-DEGRADE] vs [GATE-BYPASS]: these two stderr tags are NOT the same
+# condition and must not collapse into one. [GATE-BYPASS] means a human
+# deliberately opened the escape hatch — not a malfunction, and checked BEFORE
+# any degrade path so an open hatch is never misreported as broken judgment
+# data. [GATE-DEGRADE] means the judgment data itself could not be read
+# (empty stdin, missing jq, malformed JSON, unexpected field shape) — the gate
+# could not form an opinion at all. Merging the two labels would make a grep
+# for real breakage indistinguishable from every session that simply has the
+# hatch on, which is exactly how issue #164's silent gate death went
+# unnoticed for months. This preamble is inlined rather than sourced from
+# ~/.claude/hooks/lib/gate.sh because that path is a different repo — a
+# cross-repo `source` would make this hook's behavior depend on a file this
+# plugin does not ship and cannot pin.
+#
+# No tool_name filter is implemented here on purpose: this script is wired
+# into hooks.json under two separate matcher entries, "Agent" and "Task".
+# The framework itself gates delivery to those matchers, so a tool_name
+# branch inside the script would be dead code with no reachable false path —
+# writing it would misleadingly imply the check does something.
+set -u
+
+INPUT=$(cat)
+
+# Knowing bypass is checked first: an open hatch is the reason this dispatch
+# passes, not evidence the gate is broken, and it must be reported as such
+# regardless of whether any judgment below would otherwise have fired.
+if [[ "${ALLOW_DISPATCH_CAPABILITY_MISMATCH:-}" == "1" ]]; then
+  printf '[GATE-BYPASS] dispatch-capability-guard: escape hatch ALLOW_DISPATCH_CAPABILITY_MISMATCH=1\n' >&2
+  exit 0
+fi
+
+[ -z "$INPUT" ] && exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+SUBAGENT_TYPE=$(jq -r '.tool_input.subagent_type // empty' <<< "$INPUT" 2>/dev/null) || {
+  printf '[GATE-DEGRADE] dispatch-capability-guard: subagent_type extract failed\n' >&2
+  exit 0
+}
+PROMPT=$(jq -r '.tool_input.prompt // empty' <<< "$INPUT" 2>/dev/null) || {
+  printf '[GATE-DEGRADE] dispatch-capability-guard: prompt extract failed\n' >&2
+  exit 0
+}
+MODEL=$(jq -r '.tool_input.model // empty' <<< "$INPUT" 2>/dev/null) || {
+  printf '[GATE-DEGRADE] dispatch-capability-guard: model extract failed\n' >&2
+  exit 0
+}
+
+[ -z "$PROMPT" ] && exit 0
+
+# subagent_type default differs from prompt/model-style fields: absent means
+# "general-purpose", not "treat as missing" (mirrors
+# pre-dispatch-readonly-guard.sh's same rule, kept for judgment A's parity).
+[ -z "$SUBAGENT_TYPE" ] && SUBAGENT_TYPE="general-purpose"
+TYPE=$(tr '[:upper:]' '[:lower:]' <<< "$SUBAGENT_TYPE")
+
+# Fold ASCII to lowercase so English signals match regardless of case; CJK is
+# unaffected by tr. All English patterns below are written lowercase to match
+# against the folded text. Same treatment as pre-dispatch-readonly-guard.sh.
+PROMPT_LC=$(tr '[:upper:]' '[:lower:]' <<< "$PROMPT")
+MODEL_LC=$(tr '[:upper:]' '[:lower:]' <<< "$MODEL")
+
+# --- Signal 1: EXEC (exec intent) — migrated verbatim from
+# pre-dispatch-readonly-guard.sh. Positive capability requirement: needs Bash
+# execution but does not necessarily write repo files (run tests, run lint,
+# run a review CLI). Deliberately does NOT cover bare 跑一遍 (no execution
+# object) — that would misfire on 跑一遍历史 commit 记录，只读调查, a genuinely
+# read-only task; narrowed to 跑一遍+测试/脚本/用例.
+RE_EXEC='前台(同步)?执行|执行脚本|运行脚本|跑脚本|跑测试|运行测试|执行测试|跑用例|跑一遍(测试|脚本|用例)|跑 ?lint|跑 ?build|跑构建|执行以下命令|执行下列命令'
+RE_EXEC_EN='run (the |this |that )?scripts?|execute (the |this )?scripts?|run (the )?tests?|run (the )?test suite|run (the )?lint|run (the )?build'
+
+# --- Signal 2: WRITE (write intent, NEW) — anchored per gate-design.md §2:
+# anchor on syntactic shape, not bare keywords. A write verb alone (裸
+# 改/写) is NOT collected: 创建一份调研报告 produces a report, not code, and
+# collecting the bare verb would misclassify that genuinely read-only task as
+# a write task. Requiring an adjacent code-object or path-shaped token is
+# what keeps the two apart — same reasoning pre-dispatch-readonly-guard.sh's
+# RE_WRITE_SCOPE comment already documents for a different judgment.
+WRITE_VERB='修改|修复|重构|实现|新增|添加|删除|重命名|改写|补充|编写|落地|开发|加一个|加个'
+WRITE_OBJ='文件|代码|源码|函数|方法|测试|用例|脚本|模块|类|接口|配置|字段'
+# Path-shaped token: contains a slash, or a common source/doc extension.
+RE_PATH_TOKEN='[[:alnum:]_.-]*/[[:alnum:]_./-]*|[[:alnum:]_-]+\.(py|sh|ts|tsx|js|jsx|go|md|json|yaml|yml|rb|java|c|cpp|h|rs)'
+RE_WRITE_CN="(${WRITE_VERB})[^。,，;；]{0,20}(${WRITE_OBJ})|(${WRITE_VERB})[^。,，;；]{0,20}(${RE_PATH_TOKEN})"
+RE_WRITE_EN='(implement|fix|refactor|rename|add|remove|modify|write)s? (the |a |an |this )?(file|files|code|function|functions|test|tests|script|scripts|module|modules)'
+RE_WRITE_PATH_EN="(implement|fix|refactor|rename|add|remove|modify|write)[^.,;]{0,40}(${RE_PATH_TOKEN})"
+
+# --- Signal 3: RO (read-only declaration) — migrated verbatim from
+# pre-dispatch-readonly-guard.sh (RE_RO / RE_RO_DECL), including all inline
+# comments: they record real false-positive history, not noise.
+# 动作表刻意不含 任务/task：它们是名词而非调研动作，收进来会让本条要治的主题词
+# 误报换皮复活（`实现只读任务队列` / `implement a read-only task queue`）。
+# 「这是一个只读任务」这类句式由下面的 RE_RO_DECL 用更窄的句型锚定。
+RO_ACT='查看|查阅|阅读|通读|调查|调研|分析|审查|审阅|评审|梳理|浏览|检索|排查|核查|摸底|巡查'
+RO_ACT_EN='analysis|analyze|analyse|review|investigation|investigate|inspection|inspect|audit|survey|research|exploration|explore'
+# 中文侧容忍 只读 与动作之间的空白与逗号（`只读 查看` / `只读，梳理`），与英文侧
+# 的 [ -]? 对齐——分隔符不改变语义，漏拦却是实的。
+# 方式|模式 收在中缀里以覆盖「以只读方式查看」「以只读模式梳理」——高频显式声明。
+RE_RO="只读(的|地)?(方式|模式)?(下)?[[:space:]，,、:：]*(${RO_ACT})|(${RO_ACT})[[:space:]]*只读|read[ -]?only[ -]?(${RO_ACT_EN})"
+# 显式任务性质声明。两种形态都要求 只读 与 任务 之间有句法承接（系动词或冒号），
+# 故 `实现只读任务队列` 这类偏正短语不命中：
+#   系动词式  `这是一个只读任务` / `is a read-only task`
+#   标签式    `只读任务：…` / `read-only task:`
+RE_RO_DECL='(是|为)(一个|一项)?只读(的)?(任务|工作|活儿)|is a read[ -]?only (task|job)'
+RE_RO_DECL="${RE_RO_DECL}|只读(任务|工作)[[:space:]]*[:：]|read[ -]?only (task|job)[[:space:]]*:"
+RE_RO_DECL="${RE_RO_DECL}|(任务|工作)(是|为)只读"
+
+# --- Signal 4: NEG (absolute negation of writing) — migrated verbatim from
+# pre-dispatch-readonly-guard.sh (RE_NEG / RE_NEG_EN / RE_DOUBLE_NEG /
+# RE_WRITE_SCOPE / RE_SCOPE_NEG), including all inline comments.
+# The distinction that resolves issue #125's main complaint: an ABSOLUTE
+# object (文件/代码, optionally quantified 任何/所有) declares a read-only
+# task, while a RELATIVE object (docs/ 之外的文件, 其他文件, settings.json) is
+# dispatch-contract rule ② scope fencing — the very wording the contract
+# requires of write tasks. Anchoring on the object is what tells them apart;
+# bare 不修改 cannot.
+NEG='不|不要|不得|不准|不许|勿|别|禁止|请勿|严禁|切勿'
+WRITE='修改|改动|更改|变更|编辑|改写|写入|改|写'
+OBJ='文件|代码|源码|源代码|源文件|仓库文件|工程文件|项目文件|内容'
+RE_NEG="(${NEG})(${WRITE})(任何|所有|一切|任一)?(${OBJ})"
+# 宾语前容忍限定词：`do not modify the code` 与 `any files` 同为绝对否定，
+# 只认 any/all 会漏掉更常见的 the/this 形态。
+RE_NEG_EN="(do not|don't|dont|never) (modify|change|edit|write|touch|alter) ?(any|all|the|this|that|these|those)? ?(file|files|code|source)"
+# 双重否定是写声明而非只读声明：`不得不改代码` 内嵌 `不改代码`，子串式否定判据
+# 会把它反读。这些前缀本身就把 NEG 的首字（不/非）吃进去了，故判定时用「否定命中
+# 是否落在双重否定跨度内」来抵消，而非整段作废（见下方 scan 循环）。
+RE_DOUBLE_NEG="(不得不|不能不|不是不|并非不|无法不|非得)(${WRITE})"
+# 排他性写范围声明。豁免的正当性来自「只/仅」带的**排他语义**（我写，但只写这里）
+# ——此时后文的 `不改代码` 与 `不改其他文件` 同义，宾语看着绝对、语义仍相对。
+# 刻意不含裸写动词（创建|新增|追加|新建|chmod）：它们不带排他性，`创建一份调研
+# 报告，不修改任何文件` 是**真只读任务**（产出物是报告不是代码），收进来等于让
+# 日常措辞清空绝对否定这条防线。这类元语言写作任务本就该走 Explore 之外的通道，
+# 不该靠本豁免放行。
+# 左边界排除 不|非：`不只改测试` 是「不止于改测试」，语义与 `只改测试` 相反，
+# 子串匹配会把它误吃成排他写范围、进而放掉后面的绝对否定。
+RE_WRITE_SCOPE='(^|[^不非])(只|仅)(改|修改|动|新增|新建|创建|写|写入|编辑|碰|touch)'
+# 多字否定前缀单列黑名单：`不要只改测试` 的左邻是「要」而非「不」，单靠 [^不非]
+# 挡不住。不能把「要」加进排除集——那会误伤 `需要只改测试` 这类正当排他声明，
+# 故按前缀词显式排除。
+RE_SCOPE_NEG='(不要|不得|不准|不许|别|请勿|切勿|切莫|禁止|严禁|不可|不能|勿)(只|仅)(改|修改|动|新增|新建|创建|写|写入|编辑|碰)'
+# 英文对称：`only change tests, do not modify the code` 与中文 `只改测试，不改代码`
+# 同构，缺了它英文写任务照样被误拦。just 与 limit changes to 是同义高频变体。
+RE_WRITE_SCOPE_EN='(only|just) (change|modify|edit|touch|write|add)|(change|modify|edit|touch|write) only|limit (changes|edits|modifications) to'
+
+# --- Compute EXEC / WRITE -----------------------------------------------
+EXEC_HIT=0
+[[ "$PROMPT_LC" =~ $RE_EXEC || "$PROMPT_LC" =~ $RE_EXEC_EN ]] && EXEC_HIT=1
+
+WRITE_HIT=0
+if [[ "$PROMPT_LC" =~ $RE_WRITE_CN || "$PROMPT_LC" =~ $RE_WRITE_EN || "$PROMPT_LC" =~ $RE_WRITE_PATH_EN ]]; then
+  WRITE_HIT=1
+fi
+
+# --- Compute RO / NEG (verbatim scan/scrub logic, migrated) -------------
+RO_HIT=0
+[[ "$PROMPT_LC" =~ $RE_RO || "$PROMPT_LC" =~ $RE_RO_DECL ]] && RO_HIT=1
+
+# 否定判定按**命中点**做，不按整段也不按子句做布尔运算。见
+# pre-dispatch-readonly-guard.sh 同段注释：双重否定要抵消的只是它自己吃掉的那次
+# 否定命中，与同段其他否定无关；用 ␡ 占位抠掉双重否定跨度，再对残文跑 RE_NEG。
+SCRUBBED=$PROMPT_LC
+while [[ "$SCRUBBED" =~ $RE_DOUBLE_NEG ]]; do
+  m=${BASH_REMATCH[0]}
+  prev=$SCRUBBED
+  # 用 ␡ 占位而非直接删除：直接删会把左右字符拼到一起，可能凭空造出新的否定形态
+  SCRUBBED=${SCRUBBED/"$m"/␡}
+  # 保险丝：当前词表下每轮长度严格递减（m 非空、无零宽匹配），此分支不可达。留着
+  # 是因为将来往 RE_DOUBLE_NEG 加词若引入零宽或 no-op 替换，代价是挂起整个
+  # PreToolUse——挂起没有逃生舱，值得一行防御。
+  [[ -z "$m" || "$SCRUBBED" == "$prev" ]] && break
+done
+
+NEG_HIT=0
+if [[ "$SCRUBBED" =~ $RE_NEG || "$SCRUBBED" =~ $RE_NEG_EN ]]; then
+  NEG_HIT=1
+  # 排他写范围声明修饰的是整个任务的写范围，作用域天然全句，故按整段判定。
+  # 同 scrub 的道理：先把「否定词+只改」这类反义形态抠掉，剩下的才算真排他声明。
+  SCOPE_SRC=$PROMPT_LC
+  while [[ "$SCOPE_SRC" =~ $RE_SCOPE_NEG ]]; do
+    sm=${BASH_REMATCH[0]}
+    sprev=$SCOPE_SRC
+    SCOPE_SRC=${SCOPE_SRC/"$sm"/␡}
+    [[ -z "$sm" || "$SCOPE_SRC" == "$sprev" ]] && break
+  done
+  if [[ "$SCOPE_SRC" =~ $RE_WRITE_SCOPE || "$SCOPE_SRC" =~ $RE_WRITE_SCOPE_EN ]]; then
+    NEG_HIT=0
+  fi
+fi
+
+# --- Derived predicate ----------------------------------------------------
+# NEEDS_CAP: this task asks for something beyond read-only capability, and
+# nothing in the same prompt declares it read-only after all. Mixed prompts
+# (调研根因并修复 hits both RO and WRITE) fall to !RO being false, i.e.
+# NEEDS_CAP=0 — a deliberately accepted miss, not a bug: today's behavior for
+# such prompts is also "pass", so this is no regression, and it stays on the
+# "under-block" side rather than the "over-block" side. Going fail-closed
+# (requiring every Explore dispatch to declare read-only explicitly) was
+# rejected: it would impose a declaration burden on Explore, and the resulting
+# false-positive cost would push dispatchers toward general-purpose instead —
+# amplifying exactly the over-privilege risk judgment A exists to catch.
+NEEDS_CAP=0
+if [ "$EXEC_HIT" -eq 1 ] || [ "$WRITE_HIT" -eq 1 ]; then
+  if [ "$RO_HIT" -eq 0 ] && [ "$NEG_HIT" -eq 0 ]; then
+    NEEDS_CAP=1
+  fi
+fi
+
+REJECT=0
+
+# --- Judgment A (migrated, condition unchanged: uses !EXEC, not !NEEDS_CAP) -
+# Read-only declaration (or absolute negation) sent to a full-privilege
+# built-in agent. Kept exactly as pre-dispatch-readonly-guard.sh judged it —
+# behavior-preserving migration, not a rewrite.
+case "$TYPE" in
+  general-purpose|claude)
+    if [ "$EXEC_HIT" -eq 0 ] && { [ "$RO_HIT" -eq 1 ] || [ "$NEG_HIT" -eq 1 ]; }; then
+      printf '[dispatch-capability-guard] 命中判据 A: 只读任务声明但派了全权 agent(subagent_type=%s),应改派内置 Explore(Edit/Write/NotebookEdit 物理禁用,越权改不了文件)。\n' "$TYPE" >&2
+      printf '[dispatch-capability-guard] 出路: 改派 subagent_type=Explore。需 code-search/web-search 时在 prompt 内 Skill(...) 加载。任务其实要执行脚本/跑测试(Explore 的 Bash 限只读白名单,会拒执行)时,在 prompt 里写明执行意图(如"前台同步执行"/"跑脚本")即豁免——这类任务留 general-purpose 是对的。\n' >&2
+      REJECT=1
+    fi
+    ;;
+esac
+
+# --- Judgment B (new): NEEDS_CAP && TYPE in {explore, plan} -----------------
+case "$TYPE" in
+  explore|plan)
+    if [ "$NEEDS_CAP" -eq 1 ]; then
+      printf '[dispatch-capability-guard] 命中判据 B: 本任务需要超出只读的能力(subagent_type=%s),但 Explore/Plan 的 Edit/Write/NotebookEdit 被平台物理禁用、Bash 限只读白名单,派过去会空转一轮后 dead-end。\n' "$TYPE" >&2
+      printf '[dispatch-capability-guard] 出路: 改派 subagent_type=general-purpose 或 dev(team-ops 场景)。\n' >&2
+      REJECT=1
+    fi
+    ;;
+esac
+
+# --- Judgment C (new): NEEDS_CAP && model contains "haiku" -----------------
+if [ "$NEEDS_CAP" -eq 1 ] && [[ "$MODEL_LC" == *haiku* ]]; then
+  printf '[dispatch-capability-guard] 命中判据 C: 本任务需要超出只读的能力,但 model=%s 落在 haiku 档;解读执行/测试输出并决定下一步属"产出取舍结论"的落地活,daily 模型分层判据把这类工作排除在 haiku 之外。\n' "$MODEL" >&2
+  printf '[dispatch-capability-guard] 出路: 把 model 升到 sonnet(或按任务要求的档位)重派。\n' >&2
+  REJECT=1
+fi
+
+if [ "$REJECT" -eq 1 ]; then
+  printf '[dispatch-capability-guard] 逃生舱：在 ~/.claude/settings.json 的 env 段设置 "ALLOW_DISPATCH_CAPABILITY_MISMATCH": "1"（Bash 内 export 对 hook 进程不生效，仅可作直接调用本脚本时的同进程调试用；临时开启后须销账关闭，长期常开会致门禁全局失效）。\n' >&2
+  exit 2
+fi
+
+exit 0

--- a/plugins/dispatch-contract/hooks/hooks.json
+++ b/plugins/dispatch-contract/hooks/hooks.json
@@ -1,17 +1,19 @@
 {
-  "description": "Dispatch contract: %%DONE%% finalization gate on SubagentStop, background-dispatch sync guard on PreToolUse, dispatch-rules injection on SubagentStart",
+  "description": "Dispatch contract: %%DONE%% finalization gate on SubagentStop, background-dispatch sync guard and dispatch-capability guard on PreToolUse, dispatch-rules injection on SubagentStart",
   "hooks": {
     "PreToolUse": [
       {
         "matcher": "Agent",
         "hooks": [
-          { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-sync-guard.sh", "timeout": 5 }
+          { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-sync-guard.sh", "timeout": 5 },
+          { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-capability-guard.sh", "timeout": 5 }
         ]
       },
       {
         "matcher": "Task",
         "hooks": [
-          { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-sync-guard.sh", "timeout": 5 }
+          { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-sync-guard.sh", "timeout": 5 },
+          { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-capability-guard.sh", "timeout": 5 }
         ]
       }
     ],

--- a/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
@@ -84,4 +84,4 @@ description: |
 
 team-ops 语境下派发由 team-ops 协议（handoff/control-signal）接管，不适用本 skill；web-search 的搜索隔离用 web-search skill 自己的规范。
 
-**即席派发经济性**：可另配 PreToolUse hook 拦截省略 `model` 的派发调用，逼显式指定档位；注册 agent（frontmatter 已钉 model）可豁免。紧急放行：`export ALLOW_AGENT_MODEL_INHERIT=1`。
+**即席派发经济性**：分两件事，别混同。model/agent 取值与任务能力是否匹配（该派 Explore 还是全权 agent、该用 sonnet 还是 haiku）已落地进本插件的 `hooks/dispatch-capability-guard.sh`（PreToolUse，判据 A/B/C），逃生舱 `ALLOW_DISPATCH_CAPABILITY_MISMATCH=1`。「`model` 字段在不在场」是另一件事——仍是插件外可选配置，可另配 PreToolUse hook 拦截省略 `model` 的派发调用逼显式指定档位；注册 agent（frontmatter 已钉 model）可豁免；紧急放行写在 `~/.claude/settings.json` 的 `env` 段设 `"ALLOW_AGENT_MODEL_INHERIT": "1"`（Bash 内 `export` 传不进 hook 进程）。

--- a/plugins/dispatch-contract/tests/dispatch-capability-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-capability-guard.bats
@@ -319,9 +319,17 @@ teardown() {
 # Malformed input fail-open
 # ============================================================
 
-@test "cap #30a: empty stdin -> PASS" {
+@test "cap #30a: empty stdin -> exit 0 with [GATE-DEGRADE] (Major finding #3: empty stdin is a degrade path, not a silent no-signal pass — not assert_cap_pass, same reasoning as #30b)" {
   run_cap_guard_stdin ""
-  assert_cap_pass
+  [ "$CAP_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $CAP_EXIT"
+    echo "stderr: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" == *"[GATE-DEGRADE]"* ]] || {
+    echo "Expected '[GATE-DEGRADE]' in stderr, got: $CAP_STDERR"
+    return 1
+  }
 }
 
 @test "cap #30b: non-JSON string stdin -> exit 0 (fail-open via [GATE-DEGRADE], not assert_cap_pass — that helper's stderr check is for the no-signal case, but jq extraction failure legitimately logs [GATE-DEGRADE] with the hook's own name while still exiting 0)" {
@@ -399,4 +407,171 @@ teardown() {
   payload=$(mk_cap_payload "explore" "修复 main.py" "omit")
   run_cap_guard "$payload"
   assert_cap_block "B"
+}
+
+# ============================================================
+# Regression: 4 defects fixed post-AI-review
+# (WRITE_HIT_A dead-end close, EXEC exec-intent anchor, GATE-DEGRADE for
+# empty stdin / missing jq, WRITE_OBJ bug|issue|error). See preamble in
+# hooks/dispatch-capability-guard.sh ("A's exemption" block comment) for
+# the full trace of what each fix closes.
+# ============================================================
+
+# --- Group 1: Critical dead-end regression (judgment A + !WRITE_A) ---
+# Before the fix, a mixed RO+WRITE prompt on general-purpose/claude hit
+# judgment A on !EXEC alone and was told to re-dispatch to Explore — whose
+# Edit/Write is physically disabled, a dead end the gate manufactured. The
+# fix adds !WRITE_A to A's condition so a prompt carrying write intent no
+# longer matches A at all. Exit code alone does not pin this: a future
+# regression could still exit 0 while the stderr dead-end text is back
+# (e.g. some other change makes A fire but stops short of exit 2), so the
+# assertion below anchors on both exit AND the absence of A's specific
+# re-dispatch-to-Explore wording, not just assert_cap_pass's exit check.
+
+@test "cap #33: general-purpose + 只读查看现有实现，然后修复 main.py -> PASS, no dead-end re-dispatch-to-Explore text in stderr" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "只读查看现有实现，然后修复 main.py" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+  [[ "$CAP_STDERR" != *"改派内置 Explore"* ]] || {
+    echo "Expected no dead-end re-dispatch-to-Explore text, got: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" != *"命中判据 A"* ]] || {
+    echo "Expected judgment A to not fire, got: $CAP_STDERR"
+    return 1
+  }
+}
+
+@test "cap #34: general-purpose + 先只读通读一遍，再重构 auth 模块 (rephrased dead-end regression, different verb/object) -> PASS, no dead-end re-dispatch-to-Explore text" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "先只读通读一遍，再重构 auth 模块" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+  [[ "$CAP_STDERR" != *"改派内置 Explore"* ]] || {
+    echo "Expected no dead-end re-dispatch-to-Explore text, got: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" != *"命中判据 A"* ]] || {
+    echo "Expected judgment A to not fire, got: $CAP_STDERR"
+    return 1
+  }
+}
+
+# --- Group 2: EXEC false-positive regression (clause-anchored EXEC_HIT) ---
+# Bare-keyword EXEC match must sit in an imperative/delegation clause, not a
+# research-frame or negated clause, before counting as EXEC_HIT.
+
+@test "cap #35: Explore + 查一下跑测试的脚本在哪 (research-frame CN, distinct from cap #22's comma-joined variant) -> PASS" {
+  local payload
+  payload=$(mk_cap_payload "explore" "查一下跑测试的脚本在哪" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #36: Explore + 分析为什么不要跑测试 (negation/research-frame CN) -> PASS" {
+  local payload
+  payload=$(mk_cap_payload "explore" "分析为什么不要跑测试" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #37: Explore + find where we document how to run the tests (research-frame EN) -> PASS" {
+  local payload
+  payload=$(mk_cap_payload "explore" "find where we document how to run the tests" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+# --- Group 3: EXEC true-positive retained (guard against group 2 over-fix) ---
+
+@test "cap #38: Explore + 请跑测试看结果 (imperative exec, no research-frame) -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "explore" "请跑测试看结果" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+@test "cap #39: Explore + 跑一遍测试并确认全绿 (imperative exec, no research-frame) -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "explore" "跑一遍测试并确认全绿" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+# --- Group 4: judgment A narrowing (!WRITE_A) stays scoped to write intent ---
+# A must not have gone from "reject !EXEC" to "never reject" — pure
+# read-only declarations with no write object must still block.
+
+@test "cap #40: general-purpose + 只读调研这个模块，然后请跑测试看结果 (RO + EXEC, no WRITE object) -> PASS (EXEC_HIT suppresses A same as before, and suppresses NEEDS_CAP's RO-gated B on this TYPE)" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "只读调研这个模块，然后请跑测试看结果" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #41: general-purpose + 只读调研一下这个模块 (pure RO, no WRITE/EXEC at all) -> BLOCK judgment A (A is narrowed, not disabled)" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "只读调研一下这个模块" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "A"
+}
+
+# --- Group 5: WRITE_OBJ bug|issue|error addition ---
+
+@test "cap #42: Explore + fix the bug in auth (defect noun only, no file/code/test noun) -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "explore" "fix the bug in auth" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+# 中文侧 bug 的专属锚点：cap #42 走的是 RE_WRITE_EN 自己的宾语表，不经过
+# WRITE_OBJ,所以删掉 WRITE_OBJ 里的 bug 时 cap #42 照样绿——中英两侧的 bug
+# token 各有独立落点,只测一侧会让另一侧的删除静默通过。本例钉住 CN 侧。
+# 句中刻意不含「模块」「代码」「文件」等其它 WRITE_OBJ 词：WRITE_OBJ 是并集
+# 匹配,任一词表内词共现都会掩盖 bug 单独被删的效果,那样本用例就名存实亡。
+@test "cap #45: Explore + 修复 auth 的 bug (CN verb + EN defect noun as the ONLY WRITE_OBJ hit) -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "explore" "修复 auth 的 bug" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+# --- Group 6: new GATE-DEGRADE paths (empty stdin / missing jq) ---
+
+@test "cap #43: empty stdin -> exit 0 with [GATE-DEGRADE] and 'empty stdin' text (distinct message from cap #30a's generic check — pins the specific wording this fix introduced)" {
+  run_cap_guard_stdin ""
+  [ "$CAP_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $CAP_EXIT"
+    echo "stderr: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" == *"[GATE-DEGRADE]"* ]] || {
+    echo "Expected '[GATE-DEGRADE]' in stderr, got: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" == *"empty stdin"* ]] || {
+    echo "Expected 'empty stdin' in stderr, got: $CAP_STDERR"
+    return 1
+  }
+}
+
+@test "cap #44: jq unavailable (isolated PATH with bash/cat/tr symlinked but no jq) -> exit 0 with [GATE-DEGRADE] and 'jq unavailable' text" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "修复 main.py" "omit")
+  run_cap_guard_no_jq "$payload"
+  [ "$CAP_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $CAP_EXIT"
+    echo "stderr: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" == *"[GATE-DEGRADE]"* ]] || {
+    echo "Expected '[GATE-DEGRADE]' in stderr, got: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" == *"jq unavailable"* ]] || {
+    echo "Expected 'jq unavailable' in stderr, got: $CAP_STDERR"
+    return 1
+  }
 }

--- a/plugins/dispatch-contract/tests/dispatch-capability-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-capability-guard.bats
@@ -1,0 +1,402 @@
+#!/usr/bin/env bats
+# BDD tests for dispatch-capability-guard.sh (PreToolUse hook, matcher:
+# Agent/Task): blocks ad-hoc dispatch calls whose subagent_type/model cannot
+# deliver what the prompt itself asks for.
+#
+# Three independent judgments, single trailing `exit 2`:
+#   A: !EXEC && (RO||NEG) && TYPE in {general-purpose, claude}  (read-only
+#      declaration sent to a full-privilege agent)
+#   B: NEEDS_CAP && TYPE in {explore, plan}  (write/exec need sent to a
+#      read-only-capability agent)
+#   C: NEEDS_CAP && model contains "haiku"  (write/exec need sent to haiku)
+#
+# BLOCK is exit 2 + "命中判据 <letter>" in stderr (see assert_cap_block, which
+# anchors on which judgment fired, not exit code alone — a stray path that
+# also exits 2 for an unrelated reason must not pass).
+# PASS is exit 0, no "dispatch-capability-guard" in stderr.
+#
+# Fixture self-check discipline: this suite has previously been bitten by a
+# fixture bug disguising itself as a passing fail-open gate (printf eating a
+# marker's percent sign — see feedback-printf-eats-percent-marker memory).
+# Payload-builder-driven tests below re-read the built payload with jq before
+# running the gate, to confirm the fixture carries the field shape claimed.
+
+setup() {
+  load 'test_helper/common-setup'
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+# ============================================================
+# Four-quadrant matrix on Explore: (EXEC||WRITE) x (RO||NEG)
+# ============================================================
+
+@test "cap #1: Explore, WRITE hit + no RO/NEG -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "explore" "修复 main.py" "omit")
+  [[ "$(jq -r '.tool_input.subagent_type' <<< "$payload")" == "explore" ]]
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+@test "cap #2: Explore, EXEC hit + no RO/NEG -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "explore" "跑测试" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+@test "cap #3: Explore, WRITE hit + RO hit (mixed prompt, e.g. 调研根因并修复) -> PASS (accepted under-block)" {
+  local payload
+  payload=$(mk_cap_payload "explore" "调研根因并修复" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #4: Explore, neither EXEC/WRITE nor RO/NEG -> PASS" {
+  local payload
+  payload=$(mk_cap_payload "explore" "请完成任务并汇报结果" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+# ============================================================
+# Judgment A: !EXEC && (RO||NEG) && TYPE in {general-purpose, claude}
+# ============================================================
+
+@test "cap #5: general-purpose + RO declaration -> BLOCK judgment A" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "只读调研，查看代码逻辑" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "A"
+}
+
+@test "cap #6: claude + RO declaration -> BLOCK judgment A" {
+  local payload
+  payload=$(mk_cap_payload "claude" "只读调研，查看代码逻辑" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "A"
+}
+
+@test "cap #7: Explore + RO declaration -> PASS (this is the correct dispatch, not a miss)" {
+  local payload
+  payload=$(mk_cap_payload "explore" "只读调研，查看代码逻辑" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+# ============================================================
+# Judgment B: NEEDS_CAP && TYPE in {explore, plan}
+# ============================================================
+
+@test "cap #8: Explore + write prompt (修复 main.py) -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "explore" "修复 main.py" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+@test "cap #9: Plan + exec prompt (跑测试确认通过) -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "plan" "跑测试确认通过" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+@test "cap #10: general-purpose + write prompt (修复 main.py) -> PASS (full-privilege agent can do this)" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "修复 main.py" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+# ============================================================
+# Judgment C: NEEDS_CAP && model contains "haiku"
+# ============================================================
+
+@test "cap #11: general-purpose + write prompt + model=haiku (bare) -> BLOCK judgment C" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "修复 main.py" "haiku")
+  [[ "$(jq -r '.tool_input.model' <<< "$payload")" == "haiku" ]]
+  run_cap_guard "$payload"
+  assert_cap_block "C"
+}
+
+@test "cap #12: general-purpose + write prompt + model=claude-haiku-4-5-20251001 (full ID) -> BLOCK judgment C" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "修复 main.py" "claude-haiku-4-5-20251001")
+  run_cap_guard "$payload"
+  assert_cap_block "C"
+}
+
+@test "cap #13: general-purpose + write prompt + model=HAIKU (uppercase) -> BLOCK judgment C" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "修复 main.py" "HAIKU")
+  run_cap_guard "$payload"
+  assert_cap_block "C"
+}
+
+@test "cap #14: general-purpose + write prompt + model=sonnet -> PASS" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "修复 main.py" "sonnet")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #15: general-purpose + write prompt + model field absent -> PASS" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "修复 main.py" "omit")
+  # fixture self-check: model key genuinely absent from tool_input
+  [[ "$(jq -e '.tool_input | has("model") | not' <<< "$payload")" == "true" ]]
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+# ============================================================
+# WRITE anchoring: syntactic shape, not bare keyword
+# ============================================================
+
+@test "cap #16: Explore + 修复 main.py (verb + path token) -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "explore" "修复 main.py" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+@test "cap #17: Explore + 重构 auth 模块 (verb + object noun) -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "explore" "重构 auth 模块" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+@test "cap #18: Explore + implement the function (EN verb + object noun) -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "explore" "implement the function" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+@test "cap #19: Explore + 创建一份调研报告 (bare verb, non-code object) -> PASS (report is not code)" {
+  local payload
+  payload=$(mk_cap_payload "explore" "创建一份调研报告" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #20: Explore + 写一篇讨论只读门禁的文档 (bare verb, doc object) -> PASS" {
+  local payload
+  payload=$(mk_cap_payload "explore" "写一篇讨论只读门禁的文档" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+# ============================================================
+# Mixed-task deliberate miss (pin the accepted boundary)
+# ============================================================
+
+@test "cap #21: Explore + 调研根因并修复 (mixed RO+WRITE) -> PASS (deliberately accepted under-block, do not 'fix' this later)" {
+  local payload
+  payload=$(mk_cap_payload "explore" "调研根因并修复" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+# ============================================================
+# False-positive defense
+# ============================================================
+
+@test "cap #22: Explore + 查一下跑测试的脚本在哪，只读调研 -> PASS" {
+  local payload
+  payload=$(mk_cap_payload "explore" "查一下跑测试的脚本在哪，只读调研" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+# ============================================================
+# Double negation scrub
+# ============================================================
+
+@test "cap #23: 不得不改代码 must not be read as RO declaration (general-purpose -> PASS, no judgment A)" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "不得不改代码" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #24: 不得不修改代码 (double-negation write) on Explore -> BLOCK judgment B (it IS a write task, not RO)" {
+  local payload
+  payload=$(mk_cap_payload "explore" "不得不修改代码" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+@test "cap #25: 不得不改测试，仍需继续跑 (double-negation, comma-separated clause with no independent NEG object) -> PASS on general-purpose (no judgment A)" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "不得不改测试，仍需继续跑" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #25b: 不得不改测试，不修改任何文件 -> BLOCK judgment A on general-purpose (the second clause is its OWN independent absolute negation, not part of the double-negation span — traced: RE_DOUBLE_NEG only consumes 不得不改, leaving 不修改任何文件 intact for RE_NEG to match; this is correct, not a false positive)" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "不得不改测试，不修改任何文件" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "A"
+}
+
+# ============================================================
+# Exclusive write-scope exemption (dispatch-contract rule 2 wording)
+# ============================================================
+
+@test "cap #26: 只改测试，不改代码 on general-purpose -> PASS (scope fencing, not an RO declaration)" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "只改测试，不改代码" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #27: 不要只改测试 (left-boundary: negated-scope prefix must not fake the exemption) -> PASS on general-purpose (no WRITE/EXEC object -> NEEDS_CAP=0, no judgment fires)" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "不要只改测试" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #27b: 不要只改测试，不改代码 (left-boundary with absolute-negation object present) -> BLOCK judgment A (真否定声明，非排他豁免)" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "不要只改测试，不改代码" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "A"
+}
+
+# ============================================================
+# B + C combined
+# ============================================================
+
+@test "cap #28: Explore + haiku + 跑测试 -> exit 2 with BOTH judgment B and C messages present" {
+  local payload
+  payload=$(mk_cap_payload "explore" "跑测试" "haiku")
+  run_cap_guard "$payload"
+  [ "$CAP_EXIT" -eq 2 ] || {
+    echo "Expected exit 2, got $CAP_EXIT"
+    echo "stderr: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" == *"命中判据 B"* ]] || {
+    echo "Expected '命中判据 B' in stderr, got: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" == *"命中判据 C"* ]] || {
+    echo "Expected '命中判据 C' in stderr, got: $CAP_STDERR"
+    return 1
+  }
+}
+
+# ============================================================
+# Escape hatch
+# ============================================================
+
+@test "cap #29: judgment-B payload + ALLOW_DISPATCH_CAPABILITY_MISMATCH=1 -> exit 0 with [GATE-BYPASS]" {
+  local payload
+  payload=$(mk_cap_payload "explore" "修复 main.py" "omit")
+  run_cap_guard "$payload" "ALLOW_DISPATCH_CAPABILITY_MISMATCH=1"
+  [ "$CAP_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $CAP_EXIT"
+    echo "stderr: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" == *"[GATE-BYPASS]"* ]] || {
+    echo "Expected '[GATE-BYPASS]' in stderr, got: $CAP_STDERR"
+    return 1
+  }
+}
+
+# ============================================================
+# Malformed input fail-open
+# ============================================================
+
+@test "cap #30a: empty stdin -> PASS" {
+  run_cap_guard_stdin ""
+  assert_cap_pass
+}
+
+@test "cap #30b: non-JSON string stdin -> exit 0 (fail-open via [GATE-DEGRADE], not assert_cap_pass — that helper's stderr check is for the no-signal case, but jq extraction failure legitimately logs [GATE-DEGRADE] with the hook's own name while still exiting 0)" {
+  run_cap_guard_stdin "not json at all"
+  [ "$CAP_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $CAP_EXIT"
+    echo "stderr: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" == *"[GATE-DEGRADE]"* ]] || {
+    echo "Expected '[GATE-DEGRADE]' in stderr, got: $CAP_STDERR"
+    return 1
+  }
+}
+
+@test "cap #30c: tool_input:null -> PASS" {
+  local payload
+  payload=$(mk_cap_payload_null_input)
+  [[ "$(jq -r '.tool_input' <<< "$payload")" == "null" ]]
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #30d: prompt field missing entirely -> PASS" {
+  local payload
+  payload=$(mk_cap_payload "explore" "" "omit" "omit")
+  # fixture self-check: prompt key genuinely absent
+  [[ "$(jq -e '.tool_input | has("prompt") | not' <<< "$payload")" == "true" ]]
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #30e: prompt field present but empty string -> PASS" {
+  local payload
+  payload=$(mk_cap_payload "explore" "" "omit")
+  [[ "$(jq -e '.tool_input | has("prompt")' <<< "$payload")" == "true" ]]
+  [[ "$(jq -r '.tool_input.prompt' <<< "$payload")" == "" ]]
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+# ============================================================
+# subagent_type default (absent -> general-purpose)
+# ============================================================
+
+@test "cap #31: subagent_type absent + RO declaration -> BLOCK judgment A (defaults to general-purpose)" {
+  local payload
+  payload=$(mk_cap_payload "omit" "只读调研，查看代码逻辑" "omit")
+  # fixture self-check: subagent_type key genuinely absent
+  [[ "$(jq -e '.tool_input | has("subagent_type") | not' <<< "$payload")" == "true" ]]
+  run_cap_guard "$payload"
+  assert_cap_block "A"
+}
+
+# ============================================================
+# Case folding on subagent_type (judgment B)
+# ============================================================
+
+@test "cap #32a: subagent_type=EXPLORE (uppercase) + write prompt -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "EXPLORE" "修复 main.py" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+@test "cap #32b: subagent_type=Explore (mixed case) + write prompt -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "Explore" "修复 main.py" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}
+
+@test "cap #32c: subagent_type=explore (lowercase) + write prompt -> BLOCK judgment B" {
+  local payload
+  payload=$(mk_cap_payload "explore" "修复 main.py" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+}

--- a/plugins/dispatch-contract/tests/test_helper/common-setup.bash
+++ b/plugins/dispatch-contract/tests/test_helper/common-setup.bash
@@ -305,3 +305,124 @@ assert_block() {
     return 1
   }
 }
+
+# ============================================================
+# Additions below support dispatch-capability-guard.bats
+# (PreToolUse hook: subagent_type/model capability mismatch guard,
+# judgments A/B/C). Existing functions above are untouched —
+# subagent-done-gate.bats and dispatch-sync-guard.bats depend on them
+# as-is.
+# ============================================================
+
+CAP_GUARD_SCRIPT="${BATS_TEST_DIRNAME}/../hooks/dispatch-capability-guard.sh"
+
+# --- Payload Builder (dispatch-capability-guard) ---
+
+# mk_cap_payload SUBAGENT_TYPE_MODE PROMPT [MODEL_MODE]
+# SUBAGENT_TYPE_MODE: omit | any other string (used verbatim as subagent_type value)
+# PROMPT: prompt text. Pass "" for an explicit empty string (field present but
+#         blank); use PROMPT_MODE=omit (4th positional, see below) to omit the
+#         field entirely instead.
+# MODEL_MODE: omit | any other string (used verbatim as model value)
+# 4th optional arg PROMPT_FIELD_MODE: omit | present(default) — when "omit",
+#   the prompt key itself is absent from tool_input (distinct from prompt:"").
+mk_cap_payload() {
+  local type_mode="$1" prompt="$2" model_mode="${3:-omit}" prompt_field_mode="${4:-present}"
+  local ti='{}'
+  if [[ "$type_mode" != "omit" ]]; then
+    ti=$(jq -cn --argjson base "$ti" --arg v "$type_mode" '$base + {subagent_type:$v}')
+  fi
+  if [[ "$prompt_field_mode" != "omit" ]]; then
+    ti=$(jq -cn --argjson base "$ti" --arg v "$prompt" '$base + {prompt:$v}')
+  fi
+  if [[ "$model_mode" != "omit" ]]; then
+    ti=$(jq -cn --argjson base "$ti" --arg v "$model_mode" '$base + {model:$v}')
+  fi
+  jq -cn --argjson ti "$ti" '{tool_input:$ti}'
+}
+
+# mk_cap_payload_null_input
+# tool_input is JSON null, not an object — malformed-shape fixture.
+mk_cap_payload_null_input() {
+  jq -cn '{tool_input:null}'
+}
+
+# --- Run Helper (dispatch-capability-guard) ---
+
+# run_cap_guard PAYLOAD [env_overrides...]
+# Sets: CAP_STDOUT, CAP_STDERR, CAP_EXIT
+run_cap_guard() {
+  local payload="$1"
+  CAP_STDOUT=""
+  CAP_STDERR=""
+  CAP_EXIT=0
+
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  # 夹具必须隔离调用者环境：若跑测试的 shell 里设了
+  # ALLOW_DISPATCH_CAPABILITY_MISMATCH=1 (本 hook 的逃生舱),门禁会全局失效,
+  # 导致每个 BLOCK 用例假通过。-u 排在显式 override 之前,用例仍能主动传该
+  # 变量做正向测试（见 GATE-BYPASS 用例）。
+  if [[ "${2:-}" != "" ]]; then
+    CAP_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH "${@:2}" bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
+  else
+    CAP_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
+  fi
+  CAP_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+# run_cap_guard_stdin RAW_STDIN [env_overrides...]
+# Like run_cap_guard but takes a raw stdin string instead of building/echoing
+# a JSON payload — for malformed-input fixtures (empty, non-JSON, etc.) where
+# there is no well-formed payload to build.
+run_cap_guard_stdin() {
+  local raw="$1"
+  CAP_STDOUT=""
+  CAP_STDERR=""
+  CAP_EXIT=0
+
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  if [[ "${2:-}" != "" ]]; then
+    CAP_STDOUT=$(printf '%s' "$raw" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH "${@:2}" bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
+  else
+    CAP_STDOUT=$(printf '%s' "$raw" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
+  fi
+  CAP_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+# --- Assertion Helpers (dispatch-capability-guard) ---
+
+# assert_cap_pass — exit 0 and no "dispatch-capability-guard" in stderr
+assert_cap_pass() {
+  [ "$CAP_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $CAP_EXIT"
+    echo "stderr: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" != *"dispatch-capability-guard"* ]] || {
+    echo "Expected no 'dispatch-capability-guard' in stderr, got: $CAP_STDERR"
+    return 1
+  }
+}
+
+# assert_cap_block JUDGMENT(A|B|C) — exit 2 and stderr names the judgment
+# ("命中判据 A" / "命中判据 B" / "命中判据 C"), anchoring the assertion to
+# WHICH branch fired rather than exit code alone (mutation-testing requirement:
+# a stray path that also exits 2 for the wrong reason must not pass this).
+assert_cap_block() {
+  local judgment="$1"
+  [ "$CAP_EXIT" -eq 2 ] || {
+    echo "Expected exit 2, got $CAP_EXIT"
+    echo "stderr: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" == *"命中判据 ${judgment}"* ]] || {
+    echo "Expected '命中判据 ${judgment}' in stderr, got: $CAP_STDERR"
+    return 1
+  }
+}

--- a/plugins/dispatch-contract/tests/test_helper/common-setup.bash
+++ b/plugins/dispatch-contract/tests/test_helper/common-setup.bash
@@ -395,6 +395,47 @@ run_cap_guard_stdin() {
   rm -f "$stderr_file"
 }
 
+# mk_no_jq_path
+# Builds a temp dir containing symlinks to only the commands
+# dispatch-capability-guard.sh itself invokes (bash, cat, tr — printf/command
+# are builtins) MINUS jq, so `command -v jq` genuinely fails inside the
+# hook's subprocess without also breaking bash's own startup (a bare
+# PATH=/nonexistent would make bash itself unresolvable under `env`, giving
+# exit 127 before the script's own jq check ever runs — that is a fixture
+# bug, not a positive test of the jq-unavailable branch). Written into
+# TEST_TEMP_DIR so common_teardown's `rm -rf` reclaims it; the mktemp/ln
+# calls below run in the test's own shell (already on the real PATH), not
+# inside the isolated PATH being constructed.
+mk_no_jq_path() {
+  local dir
+  dir=$(mktemp -d "$TEST_TEMP_DIR/no-jq-path.XXXXXX")
+  ln -s "$(command -v bash)" "$dir/bash"
+  ln -s "$(command -v cat)" "$dir/cat"
+  ln -s "$(command -v tr)" "$dir/tr"
+  echo "$dir"
+}
+
+# run_cap_guard_no_jq PAYLOAD
+# Like run_cap_guard, but runs the hook with PATH pointed at mk_no_jq_path's
+# jq-less directory (via `env -i`, a clean environment, so no ambient PATH
+# leaks jq back in) instead of the real PATH. Sets CAP_STDOUT/CAP_STDERR/CAP_EXIT.
+run_cap_guard_no_jq() {
+  local payload="$1"
+  local no_jq_dir
+  no_jq_dir=$(mk_no_jq_path)
+
+  CAP_STDOUT=""
+  CAP_STDERR=""
+  CAP_EXIT=0
+
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  CAP_STDOUT=$(printf '%s' "$payload" | env -i PATH="$no_jq_dir" bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
+  CAP_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
 # --- Assertion Helpers (dispatch-capability-guard) ---
 
 # assert_cap_pass — exit 0 and no "dispatch-capability-guard" in stderr


### PR DESCRIPTION
## 改动摘要

dispatch-contract 插件新增第 4 个 hook `dispatch-capability-guard.sh`，注册在 `PreToolUse` 的 `Agent` 与 `Task` 两个 matcher（timeout 5）。

治的是「派发时任务能力需求 ↔ agent 能力供给不匹配」，两类实际误发：

1. 派 `Explore`/`Plan` 接写或执行任务——它们 Edit/Write/NotebookEdit 被平台物理禁用、Bash 限只读白名单，必然空转一轮
2. 派 `haiku` 跑测试/执行——解读失败输出属「产出取舍结论」，档位判据排除 haiku

根因是既有门禁（`plan-review` 的 `dispatch-check.sh`、用户本地的 `pre-agent-model-guard.sh`）只校验 `model`/`subagent_type` 字段**是否在场**，不校验**取值组合**，两类误发的字段都在场。

## 判据设计

四信号：`EXEC`（执行意图）/`WRITE`（写意图）/`RO`（只读声明）/`NEG`（绝对否定写），派生：

```
NEEDS_CAP = (EXEC || WRITE) && !RO && !NEG
```

- **判据 A**（从用户本地 `pre-dispatch-readonly-guard.sh` 迁入，行为逐字保持）：`!EXEC && (RO||NEG) && type ∈ {general-purpose, claude}` → BLOCK，出路改派 Explore
- **判据 B**（新增）：`NEEDS_CAP && type ∈ {explore, plan}` → BLOCK，出路改派 general-purpose/dev
- **判据 C**（新增）：`NEEDS_CAP && model 含 haiku`（子串匹配，因实际取值可能是 `claude-haiku-4-5-20251001`）→ BLOCK，出路升 sonnet

逃生舱 `ALLOW_DISPATCH_CAPABILITY_MISMATCH=1`，留痕保留 `[GATE-DEGRADE]`/`[GATE-BYPASS]` 双标签（刻意与同插件其他 hook 的静默 fail-open 不同）。

## 测试情况

- 新增 `dispatch-capability-guard.bats`：40 用例，已做变异验证（逐条把 A/B/C 触发条件改永假，对应用例如实变红，复原后字节一致）
- 全量回归：
  - `dispatch-contract` 三套（capability-guard 40/40、sync-guard 25/25、done-gate 26/26）全绿
  - `doc-gate`：exclude 12/12、skill-gate 62/62、skill-marker 13/13，全绿
  - `guardrails`：code-size 49/49、git-import-scan 18/18、git-push-guard 47/47、instruction-scan 34/34，全绿
  - `plan-review`：dispatch-check 14/14、plan-review 243/243、second-opinion 24/24，全绿
  - `pr-review`：grok-review.bats 60/60（首轮跑超时 143，重跑干净 exit 0 60/60，判断为环境抖动而非回归）
  - pytest：`doc-gate/tests/test_exclude.py` 2/2、`deep-research/tests/` 674/674，全绿
  - 未跑：`ppt-press/assets/scaffold/tests/ppt/generic-ppt.spec.js`——这是脚手架模板资产（供生成的 Astro 项目使用的 Playwright spec），依赖 npm/Astro/Playwright 安装 + 实跑 dev server，不属于本仓自身测试面（无 CI workflow 引用），未安装其依赖也未尝试安装

## 版本 bump

`dispatch-contract` 1.2.2 → 1.3.0（`.claude-plugin/plugin.json` + 根 `.claude-plugin/marketplace.json` 双处），描述文案同步补上第 4 个 hook；README/CLAUDE.md/SKILL.md 文档同步，顺带订正 CLAUDE.md 里「1 skill + 1 hook」的滞后描述（实际已有 4 hook）。

## 已知边界（刻意接受的漏拦）

判据 B 对「调研根因并修复」这类 RO+WRITE 混合 prompt 派给 Explore 时刻意 PASS（不误拦合理的混合调研任务），对应 bats 用例 #3/#21 已标注 `accepted under-block`，非遗漏。