### PR TITLE
fix(doc-gate): 门禁排除清单扩至整个 .agents/ 目录

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
     {
       "name": "doc-gate",
       "description": "Document editing governance — doc-maintenance skill + hard gate + recall advisory",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/doc-gate/.claude-plugin/plugin.json
+++ b/plugins/doc-gate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "doc-gate",
   "description": "Document editing governance — doc-maintenance skill + hard gate + recall advisory",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "author": { "name": "woodragon" },
   "skills": ["./skills/doc-maintenance"]
 }

--- a/plugins/doc-gate/README.md
+++ b/plugins/doc-gate/README.md
@@ -70,11 +70,13 @@ Both gates skip files that shouldn't be governed:
 | Category | Examples |
 |----------|---------|
 | **Basename** | `MEMORY.md`, `SKILL.md`, `CHANGELOG.md`, `LICENSE.md` (case-insensitive) |
-| **Path** | `.claude/*`, `.claude-plugin/*`, `.agents/directives/*`, `node_modules/*`, `.git/*`, `logs/*`, `pipeline/*`, `intake/*`, `deliverables/*` |
+| **Path** | `.claude/*`, `.claude-plugin/*`, `.agents/*`, `node_modules/*`, `.git/*`, `logs/*`, `pipeline/*`, `intake/*`, `deliverables/*` |
 | **Temp dirs** | `/tmp/*`, `/var/tmp/*`, `/var/folders/*`, `/private/tmp/*` |
 | **Non-.md** | Any file not ending in `.md` (case-insensitive) |
 
 `pipeline/*` covers deep-research's machine-generated intermediate artifacts (e.g. `pipeline/verification/*.json`-adjacent notes) — the doc-maintenance workflow doesn't apply to them. `intake/*` covers deep-research's G0 requirement-gate products (e.g. `intake/requirements/research-goal.md`), which the Lead generates semi-automatically before doc-maintenance is relevant.
+
+`.agents/*` covers the whole team-ops runtime workspace, not just `.agents/directives/*` as an earlier version scoped it (#176). `directives/`, `intel/`, `handoffs/`, and `tasks/` are all protocol intermediate artifacts consumed by protocol machinery, not human readers, and downstream `.gitignore` setups already ignore the directory as a whole. The narrower scoping used to deny non-directives roles (e.g. `intel`) that have no `Skill` tool and thus no way to self-invoke doc-maintenance to unlock — and because teammates share `session_id` with the main session while the marker is keyed by `session_id`, the failure showed up intermittently rather than consistently.
 
 As of **v1.6.0**, `*/deliverables/*` is also excluded from the gate. It used to stay governed, but that conflicted structurally with ADR-010 (main-session cost remediation): deliverables writes always go through a subagent, and the gate marker is keyed by `session_id` — since each subagent gets its own session id, no legitimate pass-through path exists, and the gate measured a 100% bypass rate on deliverables edits in practice. deliverables content is governed by its own quality system instead (G1–G3 sufficiency gates + Stage 6 validation review), so excluding it removes pure friction without losing coverage.
 
@@ -164,10 +166,10 @@ python3 -m unittest tests/test_recall_gate.py -v
 
 | Suite | Tests | Coverage |
 |-------|-------|----------|
-| `skill-gate.bats` | 57 | Filters, exclusions, gate enforcement, fail-open, CLAUDE.md governance, stale cleanup, e2e |
+| `skill-gate.bats` | 64 | Filters, exclusions, gate enforcement, fail-open, CLAUDE.md governance, stale cleanup, e2e |
 | `skill-marker.bats` | 13 | Tracked/untracked skills, marker creation, namespacing, kill switch |
 | `recall-gate.bats` | 37 | Filters, kill switch, fail-open, markers, double-deny, BM25 integration, orphan, broken outlinks, monorepo root detection, e2e |
-| `exclude.bats` | 12 | Shared `_doc_gate_exclude.sh` predicate — pipeline/intake/logs/tmp/git/node_modules/deliverables (incl. relative & nested paths) excluded, docs/CLAUDE.md governed |
+| `exclude.bats` | 19 | Shared `_doc_gate_exclude.sh` predicate — pipeline/intake/logs/tmp/git/node_modules/deliverables/`.agents/*` (incl. relative & nested paths) excluded, docs/CLAUDE.md/no-dot-prefix paths governed |
 | `test_recall_gate.py` | 67 | Tokenization, BM25 scoring, link extraction/resolution, corpus building, orphan/broken checks, cmd_gate output, detect_root |
 | `test_exclude.py` | 1 | `build_corpus_and_graph` excludes `pipeline/`, includes `deliverables/` and `docs/` |
 
@@ -175,6 +177,7 @@ python3 -m unittest tests/test_recall_gate.py -v
 
 See [GitHub Issues](https://github.com/WooDragon/cc-plugins/issues) for detailed change logs:
 
+- **v1.7.2** — `.agents/*` exclusion widened from `.agents/directives/*` — the narrower scope denied other team-ops runtime artifacts (`intel/`, `handoffs/`, `tasks/`), and non-`Skill`-equipped roles like `intel` had no way to self-unlock (#176)
 - **v1.7.1** — Removed the writing-standards item digest from both delivery points (SKILL.md §2 table and the `skill-gate.sh` deny message): a readable digest created false satiety, so the model skipped `references/writing-standards.md` and self-checked against rules it never read. Both now carry an unconditional imperative plus the authoritative path only; §5.1/§5.2 checklist pointers go straight to the reference instead of hopping through §2 (#139)
 - **v1.7.0** — Writing-standards reference added (`references/writing-standards.md`): an ambiguity layer (§A, STE-inspired hard constraints) and a typography layer (§B, mechanical/tool-deferrable); SKILL.md §5.1/§5.2 checklists gained corresponding checks; `skill-gate.sh` deny messages now inject a condensed summary with an absolute path to the full reference (#136)
 - **v1.6.0** — `*/deliverables/*` excluded from the gate (ADR-010 conflict: no legitimate pass-through path under subagent-scoped markers, 100% observed bypass); gate exclusion list intentionally diverges from the recall-gate corpus's `EXCLUDED_DIRS`, which still indexes deliverables (#124)

--- a/plugins/doc-gate/scripts/_doc_gate_exclude.sh
+++ b/plugins/doc-gate/scripts/_doc_gate_exclude.sh
@@ -15,8 +15,13 @@ doc_gate_is_excluded_path() {
   # deliverables: 与 ADR-010（主 session 成本根治）结构性冲突而排除——
   # deliverables 写入必走 subagent、marker 按 session_id 落盘，合法过门路径不存在，
   # 实测 100% 旁路率；且有自己的质量体系（G1-G3 + Stage 6），管辖对象与本 gate 不同。
+  # .agents: team-ops 运行时工作区整体排除，不止 directives——handoffs/intel/tasks
+  # 同属协议中间产物，消费者是协议机器而非人类读者，使用侧 .gitignore 也按整目录
+  # 忽略。曾只排除 directives，intel 等角色 tools 不含 Skill、无法自行调
+  # doc-maintenance 解锁而被拦死无法自救；且 teammate 与主 session 共享 session_id
+  # 而 marker 按 session_id 落盘，故障呈间歇性（#176）。
   case "/$fp" in
-    */.claude/*|*/.claude-plugin/*|*/.agents/directives/*|*/node_modules/*|*/.git/*|*/logs/*|*/pipeline/*|*/intake/*|*/deliverables/*) return 0 ;;
+    */.claude/*|*/.claude-plugin/*|*/.agents/*|*/node_modules/*|*/.git/*|*/logs/*|*/pipeline/*|*/intake/*|*/deliverables/*) return 0 ;;
   esac
   # 临时目录排除（绝对路径直配）
   case "$fp" in

--- a/plugins/doc-gate/tests/exclude.bats
+++ b/plugins/doc-gate/tests/exclude.bats
@@ -59,6 +59,31 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "excluded: .agents/intel/5-intel.md (team-ops runtime artifact, #176)" {
+  run doc_gate_is_excluded_path "/project/.agents/intel/5-intel.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "excluded: .agents/handoffs/x-dev-report.md (team-ops runtime artifact, #176)" {
+  run doc_gate_is_excluded_path "/project/.agents/handoffs/x-dev-report.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "excluded: .agents/tasks/t-1.md (team-ops runtime artifact, #176)" {
+  run doc_gate_is_excluded_path "/project/.agents/tasks/t-1.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "excluded: .agents/directives/sprint-x.md (regression, original exemption retained)" {
+  run doc_gate_is_excluded_path "/project/.agents/directives/sprint-x.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "excluded: relative .agents/intel/a.md" {
+  run doc_gate_is_excluded_path ".agents/intel/a.md"
+  [ "$status" -eq 0 ]
+}
+
 # ============================================================
 # NOT excluded (return 1)
 # ============================================================
@@ -70,5 +95,15 @@ setup() {
 
 @test "not excluded: CLAUDE.md" {
   run doc_gate_is_excluded_path "/project/CLAUDE.md"
+  [ "$status" -eq 1 ]
+}
+
+@test "not excluded: docs/foo.md (no dot-prefix, gate must not be pierced)" {
+  run doc_gate_is_excluded_path "/project/docs/foo.md"
+  [ "$status" -eq 1 ]
+}
+
+@test "not excluded: agents/foo.md (no dot-prefix, distinct from .agents)" {
+  run doc_gate_is_excluded_path "/project/agents/foo.md"
   [ "$status" -eq 1 ]
 }

--- a/plugins/doc-gate/tests/skill-gate.bats
+++ b/plugins/doc-gate/tests/skill-gate.bats
@@ -139,6 +139,18 @@ teardown() {
   assert_allowed
 }
 
+@test "path exclude: .agents/intel/5-intel.md → silent allow (team-ops runtime artifact, #176)" {
+  INPUT=$(build_edit_input file_path=/project/.agents/intel/5-intel.md)
+  run_gate
+  assert_allowed
+}
+
+@test "path exclude: .agents/handoffs/x-dev-report.md → silent allow (team-ops runtime artifact, #176)" {
+  INPUT=$(build_edit_input file_path=/project/.agents/handoffs/x-dev-report.md)
+  run_gate
+  assert_allowed
+}
+
 @test "path exclude: relative path .claude/plans/x.md → silent allow" {
   INPUT=$(build_edit_input file_path=.claude/plans/x.md)
   run_gate


### PR DESCRIPTION
## 问题

`doc-gate` 的门禁路径排除清单（`scripts/_doc_gate_exclude.sh`，skill-gate 与 recall-gate 共用）只豁免 `*/.agents/directives/*`，而 skill-gate 的管辖判据是 `.md` 后缀本身、不限目录。结果 team-ops 其余运行时产物（`.agents/intel/`、`.agents/handoffs/`、`.agents/tasks/`）被拦成 `permissionDecision: deny`。

判为覆盖不全而非有意区分：这些子目录与 `directives/` 同属协议中间产物，消费者是协议机器而非人类读者；语料库侧 `tools/_doc_gate_common.py` 的 `EXCLUDED_DIRS` 本来就按整目录排除 `.agents`。

放大因素：被拦的 `intel` 角色 tools 不含 `Skill`，无法自行调 doc-maintenance 解锁；且 teammate 与主 session 共享 `session_id`、marker 按 `session_id` 落盘，故障呈间歇性（主会话恰好调过 skill 的 session 里能写），比稳定失败更难诊断。

## 改动

- `scripts/_doc_gate_exclude.sh`：`*/.agents/directives/*` → `*/.agents/*`，补理据注释
- `tests/exclude.bats`：+7 用例（3 个新子目录、directives 回归、相对路径、两条反向对照）
- `tests/skill-gate.bats`：+2 端到端用例（intel / handoffs 无 marker → silent allow）
- `README.md`：Exclusions 表与说明段同步，Version History 补 v1.7.2
- 版本双写 1.7.1 → 1.7.2

未改 `tools/_doc_gate_common.py` —— 其 `EXCLUDED_DIRS` 已含 `.agents`。

## 验证

跑测前 `unset SKILL_GATE_DISABLED RECALL_GATE_DISABLED`，skill-gate 用 test_helper 分配的独立 `SKILL_GATE_DIR`（已核实 common-setup.bash 第 12 行）。

| 套件 | 结果 |
|---|---|
| `exclude.bats` | 19/19 |
| `skill-gate.bats` | 64/64 |
| `skill-marker.bats` | 13/13 |
| `test_exclude.py` | 2 passed |

变异验证（`git show HEAD:` 取旧版脚本对照，同一输入跑真实 hook）：

```
old  => deny
new  => (空输出 = allow)
反向对照 docs/foo.md against NEW => deny
回归 .agents/directives/sprint-x.md => allow
```

注：`README.md` 测试表里 `recall-gate.bats` / `test_recall_gate.py` 两行对应的文件在仓库中并不存在，属既有偏差，本 PR 未触碰。

合并后需新起 session 才生效（hook 注册在 session 启动时加载）。

fix #176