### PR TITLE
feat(brain-route): 本地 memory 写入的跨项目路由提醒门禁

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,6 +92,17 @@
       "source": "./plugins/dispatch-contract",
       "category": "development",
       "homepage": "https://github.com/WooDragon/cc-plugins"
+    },
+    {
+      "name": "brain-route",
+      "description": "Routing reminder — soft advisory that prompts consideration of second-brain (cross-project) vs local memory (project-local) when writing project memory .md files",
+      "version": "1.0.0",
+      "author": {
+        "name": "WooDragon"
+      },
+      "source": "./plugins/brain-route",
+      "category": "development",
+      "homepage": "https://github.com/WooDragon/cc-plugins"
     }
   ]
 }

--- a/plugins/brain-route/.claude-plugin/plugin.json
+++ b/plugins/brain-route/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "brain-route",
+  "description": "Routing reminder — prompts consideration of second-brain (cross-project) vs local memory (project-local) when writing project memory .md files",
+  "version": "1.0.0",
+  "author": { "name": "WooDragon" }
+}

--- a/plugins/brain-route/README.md
+++ b/plugins/brain-route/README.md
@@ -24,11 +24,11 @@ PreToolUse:Write|Edit
 
 ### Path Filter
 
-Only fires on paths matching `*/memory/*.md`, excluding `MEMORY.md` (index file, not a memory entry).
+Only fires on paths matching `*/memory/*.md`, excluding `memory.md` (index file, not a memory entry). Both the path glob and the basename exclusion are case-insensitive (macOS/APFS is case-insensitive by default, so `MEMORY.md` / `Memory.md` / `memory.md` are the same file).
 
 ### Content Judge
 
-Scores content against a fixed signal-word list (`worktree`, `hook`, `门禁`, `printf`, `subagent`, `commit`, `fail-open`, `逃生舱`, `夹具`, `假绿`, `payload`, `timeout`, `并行`, `git`, `bats`, `pathspec`, `index`). Fires only when the count of distinct matched words reaches `BRAIN_ROUTE_MIN_HITS` (default 2). This is intentionally conservative — a missed reminder costs nothing, a spurious deny costs a retry.
+Scores content against a fixed signal-word list (`worktree`, `门禁`, `printf`, `subagent`, `fail-open`, `逃生舱`, `夹具`, `假绿`, `payload`, `并行`, `bats`, `pathspec`). Fires only when the count of distinct matched words reaches `BRAIN_ROUTE_MIN_HITS` (default 2). ASCII/hyphenated words are matched with a word boundary (not a bare substring), so e.g. `fail-open` won't fire inside an unrelated longer token; CJK words are matched by substring since CJK text has no whitespace word boundaries. Generic single-word ASCII tech vocabulary (`git`, `index`, `commit`, `timeout`, `hook`) is intentionally excluded from the list — those words show up constantly in ordinary project-local notes with no discriminative power on their own. This is intentionally conservative — a missed reminder costs nothing, a spurious deny costs a retry.
 
 ### Marker Protocol
 
@@ -57,7 +57,9 @@ bats plugins/brain-route/tests/
 
 | Suite | Tests | Coverage |
 |-------|-------|----------|
-| `brain-route-gate.bats` | 11 | Path filter, MEMORY.md exclusion, content threshold, per-file marker, kill switch, jq-missing fail-open, malformed stdin fail-open, Edit tool field, missing session_id |
+| `brain-route-gate.bats` | see `grep -c '@test' tests/brain-route-gate.bats` | Path filter, memory.md exclusion (case-insensitive), content threshold, signal-word false-positive/true-positive cases, per-file marker, kill switch, jq-missing fail-open, malformed stdin fail-open, Edit tool field, missing session_id |
+
+Note: the explicit `command -v jq` check in Phase 2 is a redundant safety net — the script's outer catch-all (`_main 2>/dev/null || true`) already fail-opens on a missing jq, so no output-based assertion can distinguish the explicit check being present from it being absent.
 
 ## Version History
 

--- a/plugins/brain-route/README.md
+++ b/plugins/brain-route/README.md
@@ -1,0 +1,64 @@
+# brain-route
+
+Routing reminder for Claude Code — prompts consideration of second-brain (cross-project memory) vs local project memory when writing project memory `.md` files.
+
+When Claude writes or edits a file under `*/memory/*.md` (excluding `MEMORY.md` itself, which is an index file) and the content looks like a cross-project engineering lesson, the hook denies once and surfaces a reminder to consider routing the content to second-brain via the `brain-recall` skill instead of the local file. The hook performs no deduplication and makes no network requests — pure local string matching, millisecond-scale. It is a soft reminder, not a hard gate: retrying the same write after the reminder always passes.
+
+## Installation
+
+```bash
+# From marketplace
+claude plugin add brain-route@WooDragon-cc-plugins
+```
+
+## Hooks
+
+```
+PreToolUse:Write|Edit
+  │
+  └─ brain-route-gate.sh (5s timeout)
+         Soft advisory — on first write of each memory .md file this session,
+         scores content against a signal-word list. Deny-once-per-file
+         (retry passes). Fail-open on all anomalies.
+```
+
+### Path Filter
+
+Only fires on paths matching `*/memory/*.md`, excluding `MEMORY.md` (index file, not a memory entry).
+
+### Content Judge
+
+Scores content against a fixed signal-word list (`worktree`, `hook`, `门禁`, `printf`, `subagent`, `commit`, `fail-open`, `逃生舱`, `夹具`, `假绿`, `payload`, `timeout`, `并行`, `git`, `bats`, `pathspec`, `index`). Fires only when the count of distinct matched words reaches `BRAIN_ROUTE_MIN_HITS` (default 2). This is intentionally conservative — a missed reminder costs nothing, a spurious deny costs a retry.
+
+### Marker Protocol
+
+Per-file, per-session marker in `$BRAIN_ROUTE_GATE_DIR` (falls back to `$SKILL_GATE_DIR`, default `/tmp/claude-reviews`):
+
+| Marker | Created by | Checked by | Purpose |
+|--------|-----------|------------|---------|
+| `.brain-route-{session}-{file_hash}` | brain-route-gate.sh | brain-route-gate.sh | Per-file deny-once (retry passes silently) |
+
+Markers auto-expire after `BRAIN_ROUTE_STALE_MIN` minutes (default 120).
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|--------------|
+| `BRAIN_ROUTE_DISABLED` | `0` | `1` disables the hook (kill switch) |
+| `BRAIN_ROUTE_GATE_DIR` | _(empty)_ | Marker directory override; falls back to `SKILL_GATE_DIR`, then `/tmp/claude-reviews` |
+| `BRAIN_ROUTE_STALE_MIN` | `120` | Marker expiry in minutes |
+| `BRAIN_ROUTE_MIN_HITS` | `2` | Minimum distinct signal-word hits required to trigger the reminder |
+
+## Tests
+
+```bash
+bats plugins/brain-route/tests/
+```
+
+| Suite | Tests | Coverage |
+|-------|-------|----------|
+| `brain-route-gate.bats` | 11 | Path filter, MEMORY.md exclusion, content threshold, per-file marker, kill switch, jq-missing fail-open, malformed stdin fail-open, Edit tool field, missing session_id |
+
+## Version History
+
+- **v1.0.0** — Initial release: soft routing reminder for `*/memory/*.md` writes, signal-word content judge, per-file-per-session marker, fail-open on all anomalies, zero network calls

--- a/plugins/brain-route/hooks/hooks.json
+++ b/plugins/brain-route/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Brain routing advisory — soft reminder to consider second-brain for cross-project memory writes",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/brain-route-gate.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/brain-route/scripts/brain-route-gate.sh
+++ b/plugins/brain-route/scripts/brain-route-gate.sh
@@ -38,14 +38,21 @@ _main() {
   FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null) || return
   [ -n "$FILE_PATH" ] || return
 
-  # Phase 4: Path judge — only */memory/*.md, excluding MEMORY.md itself
+  # Phase 4: Path judge — only */memory/*.md, excluding MEMORY.md itself.
+  # macOS/APFS is case-insensitive by default (memory.md / Memory.md / MEMORY.md
+  # are the same file), so both the path glob and basename exclusion share one
+  # nocasematch block.
+  shopt -s nocasematch
   case "$FILE_PATH" in
     */memory/*.md) ;;
-    *) return ;;
+    *) shopt -u nocasematch; return ;;
   esac
 
   BASENAME="${FILE_PATH##*/}"
-  [ "$BASENAME" != "MEMORY.md" ] || return
+  case "$BASENAME" in
+    memory.md) shopt -u nocasematch; return ;;
+  esac
+  shopt -u nocasematch
 
   GATE_DIR="${BRAIN_ROUTE_GATE_DIR:-${SKILL_GATE_DIR:-/tmp/claude-reviews}}"
   STALE_MIN="${BRAIN_ROUTE_STALE_MIN:-120}"
@@ -72,30 +79,61 @@ _main() {
     CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // ""' 2>/dev/null) || return
   fi
 
-  # Phase 7: Content judge — score against signal-word list
+  # Phase 7: Content judge — score against signal-word list.
+  #
+  # Two matching rules, because ASCII and CJK words behave differently:
+  # - ASCII/hyphenated words (letters/digits/hyphen only): matched with a
+  #   word boundary via bash [[ =~ ]] regex, not a bare substring —
+  #   otherwise "commit" fires inside "commitment" and "git" fires inside
+  #   "github"/"digital".
+  # - CJK words: no word-boundary concept applies (no whitespace between
+  #   tokens), so substring matching is correct and stays as-is.
+  #
+  # Deliberately dropped: git, index, commit, timeout, hook. These are
+  # generic ASCII tech vocabulary that shows up constantly in ordinary
+  # project-local notes (e.g. "git 分支命名约定", "timeout 设成 30s，index
+  # 建在 user_id 上") with zero discriminative power on their own. Keeping
+  # them caused false-positive denies on routine local notes. The judgment
+  # here is deliberately conservative: this is a soft reminder, not a hard
+  # gate, so it's fine to occasionally miss a real cross-project lesson —
+  # it's not fine to repeatedly deny mundane local writes.
   MIN_HITS="${BRAIN_ROUTE_MIN_HITS:-2}"
-  SIGNAL_WORDS="worktree hook 门禁 printf subagent commit fail-open 逃生舱 夹具 假绿 payload timeout 并行 git bats pathspec index"
+  SIGNAL_WORDS="worktree 门禁 printf subagent fail-open 逃生舱 夹具 假绿 payload 并行 bats pathspec"
 
   CONTENT_LOWER=$(printf '%s' "$CONTENT" | tr '[:upper:]' '[:lower:]')
 
   HITS=0
   for word in $SIGNAL_WORDS; do
-    case "$CONTENT_LOWER" in
-      *"$word"*) HITS=$((HITS + 1)) ;;
+    case "$word" in
+      *[^a-z0-9-]*)
+        # Contains a char outside [a-z0-9-] → CJK/non-ASCII → substring match.
+        case "$CONTENT_LOWER" in
+          *"$word"*) HITS=$((HITS + 1)) ;;
+        esac
+        ;;
+      *)
+        # Pure ASCII (letters/digits/hyphen) → word-boundary match.
+        if [[ "$CONTENT_LOWER" =~ (^|[^a-z0-9_])${word}($|[^a-z0-9_]) ]]; then
+          HITS=$((HITS + 1))
+        fi
+        ;;
     esac
   done
 
   [ "$HITS" -ge "$MIN_HITS" ] || return
 
-  # Phase 8: Write marker + output deny JSON
+  # Phase 8: Write marker + output deny JSON.
+  # If the marker can't be written (quota/race), fail open rather than deny
+  # without a marker on disk — otherwise a retry would deny again forever,
+  # violating the "retry always passes" contract.
   [ -w "$GATE_DIR" ] || return
-  touch "$GATE_DIR/$MARKER" 2>/dev/null || true
+  touch "$GATE_DIR/$MARKER" 2>/dev/null || return
 
   MSG="路由提醒（首次写入 ${BASENAME}，同 session 后续写入不再提示）：
 
 这段内容看起来是跨项目通用的工程教训。判据：漏召回的后果若只是「少一个提示」→ 适合走 brain；若是「规则被违反」（铁律、skill 调度表、docs 导航）→ 必须留本地文件。
 
-若确认是跨项目通用教训：调用 brain-recall skill 写入 second-brain（volatility: durable），不要落本地文件。
+若确认是跨项目通用教训：调 brain-recall skill，按其「写入」节走 /capture，写入 second-brain（volatility: durable），不要落本地文件。
 
 若确认是项目局部记忆或确定性规则：照原计划继续写本地文件即可，重新发起这次写入就会放行。
 

--- a/plugins/brain-route/scripts/brain-route-gate.sh
+++ b/plugins/brain-route/scripts/brain-route-gate.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# PreToolUse:Edit/Write hook — Brain routing advisory.
+#
+# Sole responsibility: when a Write/Edit targets a local project memory
+# file (projects/*/memory/*.md) and the content being written looks like
+# a cross-project engineering lesson, remind the caller to consider
+# routing it to second-brain (via the brain-recall skill) instead of
+# writing it to the local file. This hook does NOT dedupe (that already
+# happens server-side in second-brain's write path) and makes NO network
+# calls — purely local, millisecond-scale string matching.
+#
+# Deny-once-per-file-per-session: same file in the same session only
+# prompts once; retrying the write after that always passes.
+#
+# Environment variables:
+#   BRAIN_ROUTE_DISABLED=1       — kill switch
+#   BRAIN_ROUTE_GATE_DIR         — marker directory override
+#   SKILL_GATE_DIR               — shared marker directory (default: /tmp/claude-reviews)
+#   BRAIN_ROUTE_STALE_MIN        — marker staleness minutes (default: 120)
+#   BRAIN_ROUTE_MIN_HITS         — distinct signal-word threshold (default: 2)
+set -euo pipefail
+
+_main() {
+  INPUT=$(cat)
+
+  # Phase 1: Kill switch
+  [ "${BRAIN_ROUTE_DISABLED:-0}" != "1" ] || return
+
+  # Phase 2: Preconditions
+  command -v jq >/dev/null 2>&1 || return
+
+  # Phase 3: Input extract
+  TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null) || return
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null) || return
+  [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ] || return
+  [ -n "$SESSION_ID" ] || return
+
+  FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null) || return
+  [ -n "$FILE_PATH" ] || return
+
+  # Phase 4: Path judge — only */memory/*.md, excluding MEMORY.md itself
+  case "$FILE_PATH" in
+    */memory/*.md) ;;
+    *) return ;;
+  esac
+
+  BASENAME="${FILE_PATH##*/}"
+  [ "$BASENAME" != "MEMORY.md" ] || return
+
+  GATE_DIR="${BRAIN_ROUTE_GATE_DIR:-${SKILL_GATE_DIR:-/tmp/claude-reviews}}"
+  STALE_MIN="${BRAIN_ROUTE_STALE_MIN:-120}"
+
+  # Path sanitization
+  SESSION_ID="${SESSION_ID//\//_}"
+
+  # Phase 5: Per-file marker — allow silently on subsequent writes this session
+  FILE_HASH=$(printf '%s' "$FILE_PATH" | shasum -a 256 2>/dev/null | cut -c1-16) || return
+  MARKER=".brain-route-${SESSION_ID}-${FILE_HASH}"
+  [ -n "$GATE_DIR" ] && mkdir -p "$GATE_DIR" 2>/dev/null || true
+
+  # Stale cleanup
+  find "$GATE_DIR" -maxdepth 1 -name '.brain-route-*' -mmin +"$STALE_MIN" -delete 2>/dev/null || true
+
+  if [ -f "$GATE_DIR/$MARKER" ]; then
+    return
+  fi
+
+  # Phase 6: Content extract
+  if [ "$TOOL_NAME" = "Write" ]; then
+    CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // ""' 2>/dev/null) || return
+  else
+    CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // ""' 2>/dev/null) || return
+  fi
+
+  # Phase 7: Content judge — score against signal-word list
+  MIN_HITS="${BRAIN_ROUTE_MIN_HITS:-2}"
+  SIGNAL_WORDS="worktree hook 门禁 printf subagent commit fail-open 逃生舱 夹具 假绿 payload timeout 并行 git bats pathspec index"
+
+  CONTENT_LOWER=$(printf '%s' "$CONTENT" | tr '[:upper:]' '[:lower:]')
+
+  HITS=0
+  for word in $SIGNAL_WORDS; do
+    case "$CONTENT_LOWER" in
+      *"$word"*) HITS=$((HITS + 1)) ;;
+    esac
+  done
+
+  [ "$HITS" -ge "$MIN_HITS" ] || return
+
+  # Phase 8: Write marker + output deny JSON
+  [ -w "$GATE_DIR" ] || return
+  touch "$GATE_DIR/$MARKER" 2>/dev/null || true
+
+  MSG="路由提醒（首次写入 ${BASENAME}，同 session 后续写入不再提示）：
+
+这段内容看起来是跨项目通用的工程教训。判据：漏召回的后果若只是「少一个提示」→ 适合走 brain；若是「规则被违反」（铁律、skill 调度表、docs 导航）→ 必须留本地文件。
+
+若确认是跨项目通用教训：调用 brain-recall skill 写入 second-brain（volatility: durable），不要落本地文件。
+
+若确认是项目局部记忆或确定性规则：照原计划继续写本地文件即可，重新发起这次写入就会放行。
+
+逃生舱：BRAIN_ROUTE_DISABLED=1（需写入 ~/.claude/settings.json 的 env 段，Bash export 传不进 hook 进程）。"
+
+  DENY_JSON=$(printf '%s' "$MSG" | jq -Rs .)
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$DENY_JSON"
+}
+
+_main 2>/dev/null || true

--- a/plugins/brain-route/tests/brain-route-gate.bats
+++ b/plugins/brain-route/tests/brain-route-gate.bats
@@ -25,6 +25,18 @@ teardown() {
   assert_allowed
 }
 
+@test "memory path but memory.md (lowercase) → allow (case-insensitive basename)" {
+  INPUT=$(build_write_input file_path=/project/projects/x/memory/memory.md content="worktree 门禁 fail-open") \
+    run_gate
+  assert_allowed
+}
+
+@test "memory path but Memory.md (mixed case) → allow (case-insensitive basename)" {
+  INPUT=$(build_write_input file_path=/project/projects/x/memory/Memory.md content="worktree 门禁 fail-open") \
+    run_gate
+  assert_allowed
+}
+
 # --- Content threshold ---
 
 @test "memory path + content signal words below threshold → allow" {
@@ -44,6 +56,46 @@ teardown() {
 @test "BRAIN_ROUTE_MIN_HITS is configurable: lowering threshold to 1 turns a single-signal-word write into deny" {
   INPUT=$(build_write_input file_path=/project/projects/x/memory/lesson.md content="just a note about worktree setup") \
     BRAIN_ROUTE_MIN_HITS=1 run_gate
+  assert_deny_json
+}
+
+# --- Word-boundary false positives (generic ASCII words dropped from signal list) ---
+
+@test "false positive guard: 'digital github commitment' (git/commit substrings) → allow" {
+  INPUT=$(build_write_input file_path=/project/projects/x/memory/lesson.md content="digital github commitment 的产品规划文档") \
+    run_gate
+  assert_allowed
+}
+
+@test "false positive guard: 'timeout 30s, index built on user_id' → allow" {
+  INPUT=$(build_write_input file_path=/project/projects/x/memory/lesson.md content="这个 API 的 timeout 设成 30s，index 建在 user_id 上") \
+    run_gate
+  assert_allowed
+}
+
+@test "false positive guard: 'git branch/commit naming convention note' → allow" {
+  INPUT=$(build_write_input file_path=/project/projects/x/memory/lesson.md content="git 分支命名约定：feature/xxx，commit 用中文") \
+    run_gate
+  assert_allowed
+}
+
+# --- Genuine cross-project lessons still deny after signal-word list narrowing ---
+
+@test "genuine lesson: worktree stale main branch causes fake green → deny" {
+  INPUT=$(build_write_input file_path=/project/projects/x/memory/lesson.md content="worktree 里跑测试打到主仓旧码，全绿是假绿") \
+    run_gate
+  assert_deny_json
+}
+
+@test "genuine lesson: printf eats percent sign in gate fixtures → deny" {
+  INPUT=$(build_write_input file_path=/project/projects/x/memory/lesson.md content="造门禁夹具时 printf 会吃掉百分号，须用 heredoc") \
+    run_gate
+  assert_deny_json
+}
+
+@test "genuine lesson: parallel subagents share .git state, commit dangles → deny" {
+  INPUT=$(build_write_input file_path=/project/projects/x/memory/lesson.md content="并行派 subagent 时 .git 是共享状态，commit 会悬空") \
+    run_gate
   assert_deny_json
 }
 
@@ -83,13 +135,34 @@ teardown() {
 
 # --- Dependency check ---
 
+# NOTE (mutation-testing scope, verified by hand): this test asserts an
+# observable behavior — jq missing → silent allow, exit 0, empty stdout.
+# It does NOT prove that Phase 2's explicit `command -v jq` check exists.
+# Mutation test performed: deleting that check line and re-running with jq
+# absent from PATH produces the *same* observable outcome (silent allow),
+# because the script's outermost guard — `_main 2>/dev/null || true` — also
+# swallows the failure that a missing jq would otherwise cause downstream.
+# So the explicit jq check is not distinguishable from its absence by any
+# assertion on this script's output: it is redundant given the outer
+# fail-open, a consequence of the two-layer fail-open design, not a test
+# gap. This test still has value — it locks in the correct *behavior* — but
+# it cannot be read as coverage of the explicit check itself.
 @test "fail-open: jq missing → silent allow" {
   local mock_bin="${TEST_TEMP_DIR}/nojq"
   mkdir -p "$mock_bin"
   # Real jq lives at /usr/bin/jq on macOS, so a mock-first PATH alone doesn't
-  # remove it — isolate PATH to only the mock dir (plus a minimal shell/coreutils
-  # dir) to truly simulate absence.
-  ln -sf /bin/bash "$mock_bin/bash"
+  # remove it — isolate PATH to only the mock dir. Every binary the script
+  # touches BEFORE the jq check (Phase 2: cat via `$(cat)`, plus bash itself)
+  # must still be reachable, or the script fails earlier than the jq check
+  # and the test would pass for the wrong reason (i.e. it would look like a
+  # jq-missing test while actually just testing an almost-empty PATH). jq
+  # itself is deliberately NOT symlinked here — that absence is what this
+  # test asserts on.
+  for bin in bash cat; do
+    local real_bin
+    real_bin=$(command -v "$bin")
+    ln -sf "$real_bin" "$mock_bin/$bin"
+  done
   local raw_input='{"tool_name":"Write","session_id":"test-session","tool_input":{"file_path":"/project/projects/x/memory/lesson.md","content":"worktree hook fail-open"}}'
   HOOK_STDOUT="" HOOK_STDERR="" HOOK_EXIT=0
   local stderr_file

--- a/plugins/brain-route/tests/brain-route-gate.bats
+++ b/plugins/brain-route/tests/brain-route-gate.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# BDD tests for brain-route-gate.sh — routing reminder for local memory writes.
+
+load 'test_helper/common-setup'
+
+setup() {
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+# --- Path filter ---
+
+@test "non-memory .md path → allow" {
+  INPUT=$(build_write_input file_path=/project/docs/guide.md content="worktree hook fail-open") \
+    run_gate
+  assert_allowed
+}
+
+@test "memory path but MEMORY.md itself → allow" {
+  INPUT=$(build_write_input file_path=/project/projects/x/memory/MEMORY.md content="worktree hook fail-open") \
+    run_gate
+  assert_allowed
+}
+
+# --- Content threshold ---
+
+@test "memory path + content signal words below threshold → allow" {
+  INPUT=$(build_write_input file_path=/project/projects/x/memory/lesson.md content="just a note about worktree setup") \
+    run_gate
+  assert_allowed
+}
+
+@test "memory path + content signal words reach threshold → deny" {
+  INPUT=$(build_write_input file_path=/project/projects/x/memory/lesson.md content="在 worktree 里改了 hook 的 fail-open 逻辑") \
+    run_gate
+  assert_deny_json
+  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+  [[ "$reason" == *"brain-recall"* ]]
+}
+
+@test "BRAIN_ROUTE_MIN_HITS is configurable: lowering threshold to 1 turns a single-signal-word write into deny" {
+  INPUT=$(build_write_input file_path=/project/projects/x/memory/lesson.md content="just a note about worktree setup") \
+    BRAIN_ROUTE_MIN_HITS=1 run_gate
+  assert_deny_json
+}
+
+# --- Per-file marker ---
+
+@test "first call denies and writes marker; same session same file second call → allow" {
+  local file_path="/project/projects/x/memory/lesson.md"
+  local session="test-session"
+
+  # First call: real deny, must actually write the marker file itself.
+  INPUT=$(build_write_input file_path="$file_path" session_id="$session" content="在 worktree 里改了 hook 的 fail-open 逻辑") \
+    run_gate
+  assert_deny_json
+
+  local hash marker_path
+  hash=$(printf '%s' "$file_path" | shasum -a 256 | cut -c1-16)
+  marker_path="$BRAIN_ROUTE_GATE_DIR/.brain-route-${session}-${hash}"
+  [ -f "$marker_path" ] || {
+    echo "Expected marker file to exist after first call: $marker_path"
+    return 1
+  }
+
+  # Second call, same session + same file: marker suppresses the prompt.
+  INPUT=$(build_write_input file_path="$file_path" session_id="$session" content="在 worktree 里改了 hook 的 fail-open 逻辑") \
+    run_gate
+  assert_allowed
+}
+
+# --- Kill switch ---
+
+@test "kill switch BRAIN_ROUTE_DISABLED=1 → allow" {
+  BRAIN_ROUTE_DISABLED=1 \
+    INPUT=$(build_write_input file_path=/project/projects/x/memory/lesson.md content="在 worktree 里改了 hook 的 fail-open 逻辑") \
+    run_gate
+  assert_allowed
+}
+
+# --- Dependency check ---
+
+@test "fail-open: jq missing → silent allow" {
+  local mock_bin="${TEST_TEMP_DIR}/nojq"
+  mkdir -p "$mock_bin"
+  # Real jq lives at /usr/bin/jq on macOS, so a mock-first PATH alone doesn't
+  # remove it — isolate PATH to only the mock dir (plus a minimal shell/coreutils
+  # dir) to truly simulate absence.
+  ln -sf /bin/bash "$mock_bin/bash"
+  local raw_input='{"tool_name":"Write","session_id":"test-session","tool_input":{"file_path":"/project/projects/x/memory/lesson.md","content":"worktree hook fail-open"}}'
+  HOOK_STDOUT="" HOOK_STDERR="" HOOK_EXIT=0
+  local stderr_file
+  stderr_file=$(mktemp)
+  HOOK_STDOUT=$(PATH="$mock_bin" printf '%s' "$raw_input" | PATH="$mock_bin" bash "$GATE_SCRIPT" 2>"$stderr_file") || HOOK_EXIT=$?
+  HOOK_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+  [ "$HOOK_EXIT" -eq 0 ]
+  [ -z "$HOOK_STDOUT" ]
+}
+
+# --- Malformed input ---
+
+@test "fail-open: empty stdin → silent allow" {
+  run_gate_raw_stdin ""
+  assert_allowed
+}
+
+@test "fail-open: corrupt JSON → silent allow" {
+  run_gate_raw_stdin "not-json{{"
+  assert_allowed
+}
+
+# --- Edit tool path ---
+
+@test "Edit tool new_string field also triggers deny" {
+  INPUT=$(build_edit_input file_path=/project/projects/x/memory/lesson.md new_string="在 worktree 里改了 hook 的 fail-open 逻辑") \
+    run_gate
+  assert_deny_json
+}
+
+# --- Missing session_id ---
+
+@test "missing session_id → allow" {
+  INPUT=$(jq -n '{tool_name:"Write",tool_input:{file_path:"/project/projects/x/memory/lesson.md",content:"在 worktree 里改了 hook 的 fail-open 逻辑"}}') \
+    run_gate
+  assert_allowed
+}

--- a/plugins/brain-route/tests/test_helper/common-setup.bash
+++ b/plugins/brain-route/tests/test_helper/common-setup.bash
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Test infrastructure for brain-route hook BDD tests.
+
+GATE_SCRIPT="${BATS_TEST_DIRNAME}/../scripts/brain-route-gate.sh"
+
+# --- Setup / Teardown ---
+
+common_setup() {
+  TEST_TEMP_DIR=$(mktemp -d)
+
+  export BRAIN_ROUTE_GATE_DIR="${TEST_TEMP_DIR}/gate"
+  mkdir -p "$BRAIN_ROUTE_GATE_DIR"
+
+  export BRAIN_ROUTE_DISABLED="0"
+  export BRAIN_ROUTE_STALE_MIN="120"
+  unset BRAIN_ROUTE_MIN_HITS
+
+  unset SKILL_GATE_DIR
+}
+
+common_teardown() {
+  rm -rf "$TEST_TEMP_DIR"
+}
+
+# --- Input Construction ---
+
+# build_write_input [file_path=X] [session_id=Y] [content=Z]
+build_write_input() {
+  local file_path="/project/projects/x/memory/lesson.md"
+  local session_id="test-session"
+  local content="just some notes"
+
+  for arg in "$@"; do
+    local key="${arg%%=*}"
+    local val="${arg#*=}"
+    case "$key" in
+      file_path)   file_path="$val" ;;
+      session_id)  session_id="$val" ;;
+      content)     content="$val" ;;
+    esac
+  done
+
+  jq -n \
+    --arg fp "$file_path" \
+    --arg sid "$session_id" \
+    --arg c "$content" \
+    '{
+      tool_name: "Write",
+      session_id: $sid,
+      tool_input: { file_path: $fp, content: $c }
+    }'
+}
+
+# build_edit_input [file_path=X] [session_id=Y] [new_string=Z]
+build_edit_input() {
+  local file_path="/project/projects/x/memory/lesson.md"
+  local session_id="test-session"
+  local new_string="just some notes"
+
+  for arg in "$@"; do
+    local key="${arg%%=*}"
+    local val="${arg#*=}"
+    case "$key" in
+      file_path)   file_path="$val" ;;
+      session_id)  session_id="$val" ;;
+      new_string)  new_string="$val" ;;
+    esac
+  done
+
+  jq -n \
+    --arg fp "$file_path" \
+    --arg sid "$session_id" \
+    --arg ns "$new_string" \
+    '{
+      tool_name: "Edit",
+      session_id: $sid,
+      tool_input: { file_path: $fp, old_string: "old", new_string: $ns }
+    }'
+}
+
+# --- Marker Helpers ---
+
+# create_route_marker [file_path] [session_id]
+create_route_marker() {
+  local file_path="${1:-/project/projects/x/memory/lesson.md}"
+  local session="${2:-test-session}"
+  local hash
+  hash=$(printf '%s' "$file_path" | shasum -a 256 | cut -c1-16)
+  printf '%s' "$(date +%s)" > "$BRAIN_ROUTE_GATE_DIR/.brain-route-${session}-${hash}"
+}
+
+# --- Run Helpers ---
+
+# run_gate
+run_gate() {
+  local input="${INPUT:-$(build_write_input)}"
+
+  HOOK_STDOUT=""
+  HOOK_STDERR=""
+  HOOK_EXIT=0
+
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  HOOK_STDOUT=$(bash "$GATE_SCRIPT" <<< "$input" 2>"$stderr_file") || HOOK_EXIT=$?
+  HOOK_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+# run_gate_raw_stdin <literal_input>
+run_gate_raw_stdin() {
+  local raw_input="$1"
+  HOOK_STDOUT="" HOOK_STDERR="" HOOK_EXIT=0
+  local stderr_file
+  stderr_file=$(mktemp)
+  HOOK_STDOUT=$(printf '%s' "$raw_input" | bash "$GATE_SCRIPT" 2>"$stderr_file") || HOOK_EXIT=$?
+  HOOK_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+# --- Assertion Helpers ---
+
+# assert_allowed — exit 0, no deny in stdout
+assert_allowed() {
+  [ "$HOOK_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $HOOK_EXIT"
+    echo "stderr: $HOOK_STDERR"
+    return 1
+  }
+  if [ -n "$HOOK_STDOUT" ] && echo "$HOOK_STDOUT" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1; then
+    echo "Expected allow, got deny: $HOOK_STDOUT"
+    return 1
+  fi
+}
+
+# assert_deny_json — exit 0, valid JSON with permissionDecision=deny
+assert_deny_json() {
+  [ "$HOOK_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $HOOK_EXIT"
+    echo "stderr: $HOOK_STDERR"
+    return 1
+  }
+  echo "$HOOK_STDOUT" | jq . >/dev/null 2>&1 || {
+    echo "stdout is not valid JSON: $HOOK_STDOUT"
+    return 1
+  }
+  local decision
+  decision=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecision')
+  [ "$decision" = "deny" ] || {
+    echo "Expected permissionDecision=deny, got: $decision"
+    return 1
+  }
+  local event_name
+  event_name=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.hookEventName')
+  [ "$event_name" = "PreToolUse" ] || {
+    echo "Expected hookSpecificOutput.hookEventName=PreToolUse, got: '$event_name'"
+    echo "stdout: $HOOK_STDOUT"
+    return 1
+  }
+}

--- a/plugins/brain-route/tests/test_helper/common-setup.bash
+++ b/plugins/brain-route/tests/test_helper/common-setup.bash
@@ -78,17 +78,6 @@ build_edit_input() {
     }'
 }
 
-# --- Marker Helpers ---
-
-# create_route_marker [file_path] [session_id]
-create_route_marker() {
-  local file_path="${1:-/project/projects/x/memory/lesson.md}"
-  local session="${2:-test-session}"
-  local hash
-  hash=$(printf '%s' "$file_path" | shasum -a 256 | cut -c1-16)
-  printf '%s' "$(date +%s)" > "$BRAIN_ROUTE_GATE_DIR/.brain-route-${session}-${hash}"
-}
-
 # --- Run Helpers ---
 
 # run_gate


### PR DESCRIPTION
## 做什么

新增 `brain-route` 插件。外挂 RAG 记忆库承载跨项目通用工程教训，本地 `projects/*/memory/*.md` 承载项目局部记忆与确定性规则。本 hook 的唯一职责是**路由提醒**：写入本地 memory 文件、且内容看起来是跨项目通用工程教训时，提醒考虑改走 RAG 库。

## 关键设计取舍

**不做去重。** 去重已在服务端写入路径里（相似度 ≥0.95 block、≥0.85 flag）。客户端重做一遍等于多一次 6-11s 网络调用 + 多一个必须 fail-open 的失败点。hook 只干它独有的活：路由判定。

**因此零网络调用**——纯本地判断、毫秒级，fail-open 平凡成立而非靠兜底代码堆出来。

**判据保守**：默认需命中 2 个不同信号词才提醒。这是软提醒不是硬门禁，宁可漏提醒也不要频繁误拦。拒绝文案明确写「若是项目局部记忆，重新发起这次写入即放行」，避免误以为被永久拦住。

## 测试

12 例 bats，覆盖：非 memory 路径放行、MEMORY.md 放行、信号词不足放行、达阈值 deny、marker 抑制、逃生舱、jq 缺失、空/畸形 payload、Edit 的 `new_string` 路径、缺 session_id。

**4 点变异验证**，每点均确认能让用例转红：

| 变异 | 转红用例数 |
|---|---|
| 阈值默认值 2→999 | 3 |
| 删 killswitch 判断 | 1 |
| 删 marker 写入 | 1 |
| marker 读改 `if false` | 1 |

过程中修掉两处**夹具掩盖机制**的假绿：
- `common-setup.bash` 曾 `export BRAIN_ROUTE_MIN_HITS="2"`，使脚本自身默认值不可达——默认值写坏也全绿，而默认值恰是真实运行时用的那个
- marker **写入**原先零断言（抑制用例靠预置 marker 通过），删掉 `touch` 一个用例都不红。改为端到端两次真实调用 + 显式断言 marker 落盘

## 版本

`plugin.json` 与 `marketplace.json` 双写一致 `1.0.0`。