### PR TITLE
feat(brain-route): brain-recall/brain-curate 迁入插件，端点改 env 注入 (v1.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -95,8 +95,8 @@
     },
     {
       "name": "brain-route",
-      "description": "Routing reminder — soft advisory that prompts consideration of second-brain (cross-project) vs local memory (project-local) when writing project memory .md files",
-      "version": "1.0.0",
+      "description": "Second-brain routing — brain-recall / brain-curate skills (recall, capture, curation protocol) + soft advisory hook that prompts consideration of second-brain (cross-project) vs local memory (project-local) when writing project memory .md files",
+      "version": "1.1.0",
       "author": {
         "name": "WooDragon"
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ WooDragon 的 Claude Code 插件 + 技能包 marketplace。
 | Plugin | guardrails（2 hooks） | 代码规模提示（信息性）+ git push 防手滑（拦截误推 main/master，非防绕过安全边界） |
 | Plugin | pr-review（1 skill + 2 scripts） | 已开 PR 的 AI 评审：grok 本地同步评审（默认，含多轮对抗复评的 session 状态管理）+ Copilot bot 异步评审（可选） |
 | Plugin | dispatch-contract（1 skill + 5 hooks） | 子 agent 派发契约：四条派发铁律 + `%%DONE%%` 定稿门禁（SubagentStop）+ background-dispatch 同步守卫 + 派发能力匹配守卫 + 派发通道守卫（均 PreToolUse）+ 派发规则注入（SubagentStart） |
-| Plugin | brain-route（2 skills + 1 hook） | second-brain 跨项目记忆路由：`brain-recall` 召回与写入规约 + `brain-curate` 复核去重流程 + 本地 memory 写入时的路由提醒 hook |
+| Plugin | brain-route（2 skills + 1 hook） | second-brain 跨项目记忆路由：`brain-recall` 召回与写入规约 + `brain-curate` 复核去重流程 + 写本地 memory 条目文件时的路由提醒 hook（软提醒，重试即放行） |
 
 ## 版本变更铁律
 
@@ -146,7 +146,7 @@ plugins/
     .claude-plugin/plugin.json   # 插件元数据（声明 2 个 skill + 1 个 hook）
     hooks/hooks.json             # 本地 memory 写入时的路由提醒 hook 声明
     scripts/
-      brain-route-gate.sh        # 路由提醒脚本：本地 MEMORY.md 写入时提示跨项目教训应走 second-brain
+      brain-route-gate.sh        # 路由提醒脚本：写 */memory/*.md 条目文件（排除 MEMORY.md 索引本身）时提示跨项目教训应走 second-brain
     skills/
       brain-recall/SKILL.md      # 召回规约：查询构造、结果解读、写入去重、边界
       brain-curate/SKILL.md      # 复核规约：两层触发时机、去重/陈旧清单、合并决策

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ WooDragon 的 Claude Code 插件 + 技能包 marketplace。
 | Plugin | guardrails（2 hooks） | 代码规模提示（信息性）+ git push 防手滑（拦截误推 main/master，非防绕过安全边界） |
 | Plugin | pr-review（1 skill + 2 scripts） | 已开 PR 的 AI 评审：grok 本地同步评审（默认，含多轮对抗复评的 session 状态管理）+ Copilot bot 异步评审（可选） |
 | Plugin | dispatch-contract（1 skill + 5 hooks） | 子 agent 派发契约：四条派发铁律 + `%%DONE%%` 定稿门禁（SubagentStop）+ background-dispatch 同步守卫 + 派发能力匹配守卫 + 派发通道守卫（均 PreToolUse）+ 派发规则注入（SubagentStart） |
+| Plugin | brain-route（2 skills + 1 hook） | second-brain 跨项目记忆路由：`brain-recall` 召回与写入规约 + `brain-curate` 复核去重流程 + 本地 memory 写入时的路由提醒 hook |
 
 ## 版本变更铁律
 
@@ -141,6 +142,19 @@ plugins/
       gate-composition.bats      # 门禁组合测试：从 hooks.json 动态发现同 matcher 下全部门禁并逐一验证
       test_helper/
         common-setup.bash        # 测试基础设施
+  brain-route/                   # second-brain 跨项目记忆路由插件（2 skills + 1 hook）
+    .claude-plugin/plugin.json   # 插件元数据（声明 2 个 skill + 1 个 hook）
+    hooks/hooks.json             # 本地 memory 写入时的路由提醒 hook 声明
+    scripts/
+      brain-route-gate.sh        # 路由提醒脚本：本地 MEMORY.md 写入时提示跨项目教训应走 second-brain
+    skills/
+      brain-recall/SKILL.md      # 召回规约：查询构造、结果解读、写入去重、边界
+      brain-curate/SKILL.md      # 复核规约：两层触发时机、去重/陈旧清单、合并决策
+    tests/
+      brain-route-gate.bats      # 路由提醒 hook 测试
+      skills-packaging.bats      # skill 打包与内容断言（含 fail-loud 机制锁定）
+      test_helper/
+        common-setup.bash        # 测试基础设施
 ```
 
 ## 环境变量
@@ -154,6 +168,7 @@ plugins/
 | deep-research | `GATEWAY_API_KEY`、`TAVILY_API_KEY`、`JINA_API_KEY`（可选凭证） | [plugins/deep-research/README.md](plugins/deep-research/README.md#prerequisites) |
 | pr-review | `GROK_MODEL`、`GROK_EFFORT`、`XDG_STATE_HOME`（session 落盘根） | [plugins/pr-review/README.md](plugins/pr-review/README.md#prerequisites) |
 | dispatch-contract | `ALLOW_UNMARKED_FINAL`、`ALLOW_BACKGROUND_DISPATCH`、`ALLOW_NO_RULES_INJECT`、`CLAUDE_CODE_FORK_SUBAGENT`、`ALLOW_DISPATCH_CAPABILITY_MISMATCH`、`ALLOW_UNMANAGED_TEAMMATE`、`CLAUDE_AUTO_BACKGROUND_TASKS` | [plugins/dispatch-contract/README.md](plugins/dispatch-contract/README.md#environment-variables) |
+| brain-route | `BRAIN_ROUTE_*`、`SECOND_BRAIN_URL`、`SECOND_BRAIN_TOKEN` | [plugins/brain-route/README.md](plugins/brain-route/README.md#environment-variables) |
 
 敏感变量（如 `REVIEW_API_KEY`）配置在 `~/.claude/settings.json` 的 `"env"` 字段中。Claude Code 启动时自动注入到所有 hook 进程环境，无需污染 shell profile。`~/.claude/settings.local.json` 不是合法的用户级配置路径，env 字段在此处不生效。
 

--- a/plugins/brain-route/.claude-plugin/plugin.json
+++ b/plugins/brain-route/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "brain-route",
-  "description": "Routing reminder — prompts consideration of second-brain (cross-project) vs local memory (project-local) when writing project memory .md files",
-  "version": "1.0.0",
-  "author": { "name": "WooDragon" }
+  "description": "Second-brain routing — brain-recall / brain-curate skills (recall, capture, curation protocol) + soft advisory hook that prompts consideration of second-brain (cross-project) vs local memory (project-local) when writing project memory .md files",
+  "version": "1.1.0",
+  "author": { "name": "WooDragon" },
+  "skills": ["./skills/brain-recall", "./skills/brain-curate"]
 }

--- a/plugins/brain-route/README.md
+++ b/plugins/brain-route/README.md
@@ -84,7 +84,7 @@ Two different consumers read environment variables in this plugin: the hook read
 
 Both variables must be set in the `env` section of `~/.claude/settings.json`. A Bash `export` does not propagate into the hook process or into new sessions, and `~/.claude/settings.local.json` is not a valid location for user-level `env` configuration.
 
-If either variable is unset, the skill's reference text still reads normally — it is a protocol document, not a live call. The `curl` commands inside the skills use `${SECOND_BRAIN_URL:?...}`, so an unset variable makes the command fail with the variable name in the error message rather than silently sending the request to the wrong endpoint.
+If either variable is unset, the skill's reference text still reads normally — it is a protocol document, not a live call. The `curl` commands inside the skills use `${SECOND_BRAIN_URL:?...}` and `${SECOND_BRAIN_TOKEN:?...}`, so an unset variable makes the command fail with the variable name in the error message rather than silently sending the request to the wrong endpoint. `SECOND_BRAIN_URL` must not have a trailing slash — a trailing slash produces a double slash (e.g. `//recall`) when the skills append the path suffix.
 
 ## Skills
 

--- a/plugins/brain-route/README.md
+++ b/plugins/brain-route/README.md
@@ -1,6 +1,6 @@
 # brain-route
 
-Routing reminder for Claude Code — prompts consideration of second-brain (cross-project memory) vs local project memory when writing project memory `.md` files.
+Routing reminder for Claude Code — prompts consideration of second-brain (cross-project memory) vs local project memory when writing project memory `.md` files. The plugin also packages two second-brain operation skills, `brain-recall` and `brain-curate`.
 
 When Claude writes or edits a file under `*/memory/*.md` (excluding `MEMORY.md` itself, which is an index file) and the content looks like a cross-project engineering lesson, the hook denies once and surfaces a reminder to consider routing the content to second-brain via the `brain-recall` skill instead of the local file. The hook performs no deduplication and makes no network requests — pure local string matching, millisecond-scale. It is a soft reminder, not a hard gate: retrying the same write after the reminder always passes.
 
@@ -10,6 +10,28 @@ When Claude writes or edits a file under `*/memory/*.md` (excluding `MEMORY.md` 
 # From marketplace
 claude plugin add brain-route@WooDragon-cc-plugins
 ```
+
+## Backend Dependency
+
+The `brain-recall` and `brain-curate` skills require a running second-brain backend instance. The hook does not — it performs no network calls, only local string matching against files already on disk. Installing this plugin without a backend leaves the hook fully functional; only the two skills become unusable.
+
+The backend project is [`WooDragon/second-brain-cloudflare`](https://github.com/WooDragon/second-brain-cloudflare) (MIT, public), a fork of `rahilp/second-brain-cloudflare`. It runs on Cloudflare Workers and uses D1 (SQLite) for storage, Vectorize for the vector index, Workers AI for embedding and LLM inference, and KV for OAuth registrations. All of these fit within the Cloudflare free tier.
+
+The backend requires one secret, `AUTH_TOKEN`. This is the same value the skills expect in `SECOND_BRAIN_TOKEN` — set the backend's `AUTH_TOKEN` and the skill's `SECOND_BRAIN_TOKEN` to the identical string.
+
+Self-hosting steps (commands from the backend repo's `package.json`):
+
+```bash
+npm run db:create          # create the D1 database
+npm run db:migrate:remote  # apply the schema
+npm run vectors:create     # create the Vectorize index (cosine metric)
+wrangler secret put AUTH_TOKEN
+npm run deploy
+```
+
+**Chinese-language (CJK) corpora must use the `downstream` branch.** The `main` branch tracks upstream and embeds with `@cf/baai/bge-small-en-v1.5` (384 dimensions). For CJK content, `main`'s recall measures zero — not merely weak multilingual model performance: the query normalization in `src/recall/distill.ts` strips non-ASCII characters with a `\w`-based regex, so CJK text is emptied out before it ever reaches the embedding call. The `downstream` branch fixes this: it switches the embedding model to `@cf/qwen/qwen3-embedding-0.6b` (1024 dimensions, asymmetric query/document embedding) and fixes CJK tokenization. Deploy `downstream` directly for Chinese-language use.
+
+Index dimensions must match the branch, and each branch's `vectors:create` script already carries the right value — `downstream` creates the index at 1024 dimensions, `main` at 384. Because dimensions are fixed at creation, check out the intended branch before running `npm run vectors:create` — switching later requires recreating the index and re-ingesting every stored vector. The full model-migration procedure (new index, redeploy, re-ingestion) is outside the scope of this README; see the backend repo's own documentation and its `/migration/*` routes.
 
 ## Hooks
 
@@ -42,12 +64,38 @@ Markers auto-expire after `BRAIN_ROUTE_STALE_MIN` minutes (default 120).
 
 ## Environment Variables
 
+Two different consumers read environment variables in this plugin: the hook reads its own set, and the two skills read a separate set.
+
+### Hook (`brain-route-gate.sh`)
+
 | Variable | Default | Description |
 |----------|---------|--------------|
 | `BRAIN_ROUTE_DISABLED` | `0` | `1` disables the hook (kill switch) |
 | `BRAIN_ROUTE_GATE_DIR` | _(empty)_ | Marker directory override; falls back to `SKILL_GATE_DIR`, then `/tmp/claude-reviews` |
 | `BRAIN_ROUTE_STALE_MIN` | `120` | Marker expiry in minutes |
 | `BRAIN_ROUTE_MIN_HITS` | `2` | Minimum distinct signal-word hits required to trigger the reminder |
+
+### Skills (`brain-recall` / `brain-curate`)
+
+| Variable | Default | Description |
+|----------|---------|--------------|
+| `SECOND_BRAIN_URL` | _(none)_ | REST base of the second-brain instance, e.g. `https://brain.example.com` |
+| `SECOND_BRAIN_TOKEN` | _(none)_ | The backend's `AUTH_TOKEN`, used for Bearer authentication |
+
+Both variables must be set in the `env` section of `~/.claude/settings.json`. A Bash `export` does not propagate into the hook process or into new sessions, and `~/.claude/settings.local.json` is not a valid location for user-level `env` configuration.
+
+If either variable is unset, the skill's reference text still reads normally — it is a protocol document, not a live call. The `curl` commands inside the skills use `${SECOND_BRAIN_URL:?...}`, so an unset variable makes the command fail with the variable name in the error message rather than silently sending the request to the wrong endpoint.
+
+## Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `brain-recall` | Recall and write protocol: query construction, result interpretation, `/capture` writes with `volatility: durable` |
+| `brain-curate` | Review and deduplication: duplicate/stale candidate scanning, the manual merge workflow, known gaps |
+
+These skills ship in the same plugin as the hook because the hook's deny message names `brain-recall` as the skill to use instead of a local memory write. If the hook and the skills lived in separate repositories, someone who installed only the plugin would see a prompt pointing at a skill that does not exist for them, and the plugin and its companion protocol could drift out of version sync. Packaging them together keeps that reference self-consistent within the plugin.
+
+Both skills trigger semantically, matched against their frontmatter `description` — neither is invoked by a hook.
 
 ## Tests
 
@@ -58,9 +106,11 @@ bats plugins/brain-route/tests/
 | Suite | Tests | Coverage |
 |-------|-------|----------|
 | `brain-route-gate.bats` | see `grep -c '@test' tests/brain-route-gate.bats` | Path filter, memory.md exclusion (case-insensitive), content threshold, signal-word false-positive/true-positive cases, per-file marker, kill switch, jq-missing fail-open, malformed stdin fail-open, Edit tool field, missing session_id |
+| `skills-packaging.bats` | see `grep -c '@test' tests/skills-packaging.bats` | Structural assertions: skill files exist, endpoints are env-derived with no hardcoded domain, the skill name referenced in the hook's deny message resolves to a real skill, `plugin.json` and `marketplace.json` versions agree |
 
 Note: the explicit `command -v jq` check in Phase 2 is a redundant safety net — the script's outer catch-all (`_main 2>/dev/null || true`) already fail-opens on a missing jq, so no output-based assertion can distinguish the explicit check being present from it being absent.
 
 ## Version History
 
+- **v1.1.0** — Moved the `brain-recall` and `brain-curate` skills into this plugin. Backend endpoint configuration in both skills switched to environment injection (`SECOND_BRAIN_URL` / `SECOND_BRAIN_TOKEN`) instead of a hardcoded domain. README gained the Backend Dependency and Skills sections.
 - **v1.0.0** — Initial release: soft routing reminder for `*/memory/*.md` writes, signal-word content judge, per-file-per-session marker, fail-open on all anomalies, zero network calls

--- a/plugins/brain-route/skills/brain-curate/SKILL.md
+++ b/plugins/brain-route/skills/brain-curate/SKILL.md
@@ -41,7 +41,7 @@ REST base 由 `SECOND_BRAIN_URL` 指定，鉴权 `Authorization: Bearer $SECOND_
 
 ```bash
 curl -sS -m 30 -A "curl/8.7.1" \
-  -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+  -H "Authorization: Bearer ${SECOND_BRAIN_TOKEN:?未配置 SECOND_BRAIN_TOKEN，见 brain-route 插件 README 的 Environment Variables 节}" \
   -G "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/list" \
   --data-urlencode "n=100" \
   --data-urlencode "tag=duplicate-candidate"
@@ -51,7 +51,7 @@ curl -sS -m 30 -A "curl/8.7.1" \
 
 ```bash
 curl -sS -m 30 -A "curl/8.7.1" \
-  -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+  -H "Authorization: Bearer ${SECOND_BRAIN_TOKEN:?未配置 SECOND_BRAIN_TOKEN，见 brain-route 插件 README 的 Environment Variables 节}" \
   -G "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/list" \
   --data-urlencode "n=100" \
   --data-urlencode "tag=stale:as-of"
@@ -60,13 +60,16 @@ curl -sS -m 30 -A "curl/8.7.1" \
 **全量含统计**（PR 归并前兜底用，一次调用拿到 `recall_count` / `importance_score`）：
 
 ```bash
+BRAIN_EXPORT=$(mktemp -t brain_export)
 curl -sS -m 30 -A "curl/8.7.1" \
-  -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
-  "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/export" > /tmp/brain_export.json
+  -H "Authorization: Bearer ${SECOND_BRAIN_TOKEN:?未配置 SECOND_BRAIN_TOKEN，见 brain-route 插件 README 的 Environment Variables 节}" \
+  "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/export" > "$BRAIN_EXPORT"
 
 jq '[.[] | select(.recall_count == 0)] | .[] | select(
   (now - (.created_at | fromdateiso8601)) > (60*86400)
-)' /tmp/brain_export.json
+)' "$BRAIN_EXPORT"
+
+rm -f "$BRAIN_EXPORT"
 ```
 
 筛出 `recall_count == 0` 且 `created_at` 超 60 天的条目——这些是写进去后从未被任何查询命中的沉底条目，是盲区，只能靠这条命令找到。
@@ -84,14 +87,14 @@ jq '[.[] | select(.recall_count == 0)] | .[] | select(
    ```bash
    # 整段替换成合并后内容
    curl -sS -m 30 -A "curl/8.7.1" \
-     -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+     -H "Authorization: Bearer ${SECOND_BRAIN_TOKEN:?未配置 SECOND_BRAIN_TOKEN，见 brain-route 插件 README 的 Environment Variables 节}" \
      -H "Content-Type: application/json" \
      -d '{"id":"<保留条目id>", "content":"<合并后完整内容>", "tags":["..."]}' \
      "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/update"
 
    # 删除被合并掉的那条
    curl -sS -m 30 -A "curl/8.7.1" \
-     -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+     -H "Authorization: Bearer ${SECOND_BRAIN_TOKEN:?未配置 SECOND_BRAIN_TOKEN，见 brain-route 插件 README 的 Environment Variables 节}" \
      -H "Content-Type: application/json" \
      -d '{"id":"<被合并条目id>"}' \
      "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/forget"

--- a/plugins/brain-route/skills/brain-curate/SKILL.md
+++ b/plugins/brain-route/skills/brain-curate/SKILL.md
@@ -60,7 +60,8 @@ curl -sS -m 30 -A "curl/8.7.1" \
 **全量含统计**（PR 归并前兜底用，一次调用拿到 `recall_count` / `importance_score`）：
 
 ```bash
-BRAIN_EXPORT=$(mktemp -t brain_export)
+BRAIN_EXPORT=$(mktemp "${TMPDIR:-/tmp}/brain_export.XXXXXX")
+trap 'rm -f "$BRAIN_EXPORT"' EXIT
 curl -sS -m 30 -A "curl/8.7.1" \
   -H "Authorization: Bearer ${SECOND_BRAIN_TOKEN:?未配置 SECOND_BRAIN_TOKEN，见 brain-route 插件 README 的 Environment Variables 节}" \
   "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/export" > "$BRAIN_EXPORT"

--- a/plugins/brain-route/skills/brain-curate/SKILL.md
+++ b/plugins/brain-route/skills/brain-curate/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: brain-curate
+description: |
+  外挂 RAG 记忆库 second-brain 的复核与去重整理。当出现：
+  - 召回结果（`brain-recall`）里条目带 `duplicate-candidate` 或 `stale:as-of` 标签
+  - PR 归并前的记忆复核
+  - 怀疑 brain 内容重复或陈旧
+  时调用此 Skill。
+---
+
+# second-brain 复核 Skill
+
+## 配置前提
+
+本 skill 依赖两个环境变量，**须写入 `~/.claude/settings.json` 的 `env` 段**——Bash 里 `export` 传不进 hook 与新 session 进程：
+
+| 变量 | 用途 |
+|---|---|
+| `SECOND_BRAIN_URL` | second-brain 实例的 REST base，例如 `https://brain.example.com` |
+| `SECOND_BRAIN_TOKEN` | 该实例的 `AUTH_TOKEN`（Bearer 鉴权用） |
+
+未配置时下面的命令会带着变量名报错而非静默打错端点。后端是什么、怎么自建，见 `brain-route` 插件 README 的 Backend Dependency 节。
+
+REST base 由 `SECOND_BRAIN_URL` 指定，鉴权 `Authorization: Bearer $SECOND_BRAIN_TOKEN`（从环境变量读，绝对不要把 token 字面值写进任何文件）。所有请求都需带 UA 头 `-A "curl/8.7.1"`，否则 Cloudflare 返回 403 + `error code: 1010`。
+
+---
+
+## 两层触发时机
+
+不用定时任务：内容劣化由**写入**造成，不由**时间**造成。日历判据（如"每天跑一次"）在没有新写入时白跑一次浪费一次调用，在密集写入期又不够勤——两头不讨好。
+
+1. **读路径自曝（主）**：`brain-recall` 每次 `/recall` 返回的条目都带 `tags`，欠账主动出现在你眼前，且此时你正关心该话题、判断合并/保留的成本最低。不需要计数器、状态文件、cron，看见就处理。
+
+2. **PR 归并前兜底（副）**：扫全量，覆盖"写进去但从没被召回过"的盲区——这类条目不会通过第 1 层自曝，因为没人查询过它们所在的话题。
+
+---
+
+## 复核清单
+
+**重复候选**（第 1 层自曝会带出，也可主动扫）：
+
+```bash
+curl -sS -m 30 -A "curl/8.7.1" \
+  -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+  -G "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/list" \
+  --data-urlencode "n=100" \
+  --data-urlencode "tag=duplicate-candidate"
+```
+
+**陈旧条目**（第 1 层自曝会带出，也可主动扫）：
+
+```bash
+curl -sS -m 30 -A "curl/8.7.1" \
+  -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+  -G "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/list" \
+  --data-urlencode "n=100" \
+  --data-urlencode "tag=stale:as-of"
+```
+
+**全量含统计**（PR 归并前兜底用，一次调用拿到 `recall_count` / `importance_score`）：
+
+```bash
+curl -sS -m 30 -A "curl/8.7.1" \
+  -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+  "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/export" > /tmp/brain_export.json
+
+jq '[.[] | select(.recall_count == 0)] | .[] | select(
+  (now - (.created_at | fromdateiso8601)) > (60*86400)
+)' /tmp/brain_export.json
+```
+
+筛出 `recall_count == 0` 且 `created_at` 超 60 天的条目——这些是写进去后从未被任何查询命中的沉底条目，是盲区，只能靠这条命令找到。
+
+---
+
+## 合并决策规约
+
+**人工裁决，逐条列出建议交用户确认，不自动改数据。**流程：
+
+1. 拿到重复/陈旧候选列表后，逐条读全文，判断：真重复该合并、还是表面相似但各有独立事实该保留两条。
+2. 把判断结果和理由列给用户，等确认，不要在没确认前就执行合并。
+3. 确认合并后，**由你（不是服务端）手工写出合并后的完整内容**——必须保全各条独有的实测数据、行号、计数,不能只留一条丢掉另一条的细节。
+4. 执行落地：
+   ```bash
+   # 整段替换成合并后内容
+   curl -sS -m 30 -A "curl/8.7.1" \
+     -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"id":"<保留条目id>", "content":"<合并后完整内容>", "tags":["..."]}' \
+     "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/update"
+
+   # 删除被合并掉的那条
+   curl -sS -m 30 -A "curl/8.7.1" \
+     -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"id":"<被合并条目id>"}' \
+     "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/forget"
+   ```
+
+不要依赖服务端在 `/capture` 时自动给出的 `merged_content`——那是写入阶段的自动合并（见 `brain-recall`），上限 400 字符且会丢 incoming tags，不适合当作正式合并结果使用；本 skill 的合并流程是复核阶段的手工合并，两者不是同一件事。
+
+---
+
+## 已知缺口（写清楚，避免误以为系统会自己收敛）
+
+- **无条目级自动删除**——条目只会被 deprecate 或降权，永不自动消失，只能靠上面的 `/forget` 手工删除。
+- **`importance_score` 写入时由 LLM 打一次分，此后永不更新**——不会随时间或使用情况自动调整，过时的初始打分会一直留着。
+- **召回正反馈**：`1 + log1p(recall_count)`——热的条目更热、冷的条目沉底。`durable` 档能缓解衰减，但不能消除这个正反馈循环，冷门但正确的教训仍会逐渐边缘化。
+- **压缩条件苛刻，规模小时基本不触发**：需要同 tag 下 >10 条、且都超过 60 天、且 `recall_count < 2`。在几十条规模的 brain 里这个条件基本凑不齐，别指望它自动收敛,该手工复核的还是要手工复核。

--- a/plugins/brain-route/skills/brain-recall/SKILL.md
+++ b/plugins/brain-route/skills/brain-recall/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: brain-recall
+description: |
+  外挂 RAG 记忆库 second-brain 检索，用于召回跨项目的通用工程教训。当需要：
+  - 建 git worktree
+  - 写或改 hook / 护栏门禁
+  - 写门禁或 bash 测试
+  - 并行派 subagent
+  - 限定范围 git 提交
+  - PR 评审复核
+  - 装或迁插件
+  - 验收拆分重构
+  - 设计门禁降级或豁免
+  时调用此 Skill，先检索是否已有相关实测教训。
+---
+
+# second-brain 检索 Skill
+
+## 配置前提
+
+本 skill 依赖两个环境变量，**须写入 `~/.claude/settings.json` 的 `env` 段**——Bash 里 `export` 传不进 hook 与新 session 进程：
+
+| 变量 | 用途 |
+|---|---|
+| `SECOND_BRAIN_URL` | second-brain 实例的 REST base，例如 `https://brain.example.com` |
+| `SECOND_BRAIN_TOKEN` | 该实例的 `AUTH_TOKEN`（Bearer 鉴权用） |
+
+未配置时下面的命令会带着变量名报错而非静默打错端点。后端是什么、怎么自建，见 `brain-route` 插件 README 的 Backend Dependency 节。
+
+外挂 RAG 记忆库，REST base 由 `SECOND_BRAIN_URL` 指定，鉴权 `Authorization: Bearer $SECOND_BRAIN_TOKEN`（token 从环境变量读，绝对不要把 token 字面值写进任何文件）。它是 CC 记忆系统的补充层，只存跨项目通用的工程教训；确定性内容（CLAUDE.md 铁律、skill 调度表、docs 导航）仍走本地文件，不进 brain。
+
+---
+
+## 查询构造规约（核心）：描述处境，不要猜关键词
+
+把当前处境原样摘要 100-200 字提交，包含：在干什么、用什么工具、下一步打算怎么做。
+
+**必须保留具体动作词与工具名**（`commit`/`export`/`printf`/`worktree`/`$HOME`）——恰恰是那些你不觉得重要的动作词才是记忆的锚点。
+
+**禁止**：
+- 自己做关键词提取（服务端有全语料 df 统计，你没有，你的先验是错的）
+- 加「有什么坑吗」这类元问题（不含语料词，纯稀释）
+
+一句话概括：**把 prompt 当查询，而不是把查询当 prompt**。
+
+**为什么**：服务端 `distillToRareTerms` 在 embedding 之前先按语料 df 把查询压到最稀有的 3 个词。短查询已经被你手工精简过一次，服务端再压一次，等于删掉了本该留下的动作词。5 场景对照实测：情景描述（130-190 字）胜 3 平 1 负 1，唯一一次目标掉出前 5 出现在短查询。
+
+实测例：
+- 反例：查「并行 subagent 冲突」→ 目标 MISS
+- 正例：查「并行派发三个 subagent 改不同文件，各自 commit 自己的改动」→ 目标排第 1
+
+差别是动作词 `commit`——写短查询时不知道问题出在 commit 上，长查询把它原样带进去了服务端才能压中。
+
+再举一组对照：
+- 反例：查「hook 测试环境变量污染」→ 意图对但词太泛，压不到具体点
+- 正例：查「造门禁夹具用 heredoc 测试逃生舱变量，跑之前要先清 shell 里残留的 env，不然所有 BLOCK 用例会假通过」→ 命中带具体失败模式的教训条目
+
+---
+
+## 调用方式
+
+```bash
+curl -sS -m 30 \
+  -A "curl/8.7.1" \
+  -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+  --data-urlencode "query=<把 100-200 字处境摘要原样放这里>" \
+  --data-urlencode "topK=5" \
+  -G "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/recall"
+```
+
+**必须带 UA 头** `-H "User-Agent: curl/8.7.1"`（等价于上面的 `-A`）。Cloudflare 对默认 UA（如 curl 不带 `-A` 时的默认串，或空 UA）返回 403 + `error code: 1010`，症状与 token 失效同形——排障时先查这个,再怀疑 token。
+
+也可走 MCP endpoint `${SECOND_BRAIN_URL}/mcp` 的 `recall` 工具，效果等价于上面的 REST 调用。
+
+**延迟预期**：recall 实测 5.7-11s，不是即时返回，规划 Task timeout 时留够。
+
+---
+
+## 结果解读
+
+**score 不可作相关性阈值**：服务端按本次返回结果的最高分归一化，所以排第一的条目永远显示 100 分——哪怕它跟查询完全不相关。判据只能是**排序位次**（前 1-2 条通常最相关）与**内容本身**（读条目文本判断是否真的适用），不要设「score > 80 才采信」之类的阈值,那个阈值没有意义。
+
+返回条目带 `tags`。见到 `duplicate-candidate` 或 `stale:as-of` 就是欠账信号,转 `brain-curate` skill 处理,不要在 recall 场景里自己动手改。
+
+---
+
+## 边界
+
+召回是概率性的,漏召回只意味着少一个提示,不代表出错。**凡「漏 = 规则被违反」的内容不在 brain 里,别去 brain 找铁律**——CLAUDE.md 里的硬约束、skill 调度表、docs 导航这类确定性内容本来就不会存进 brain,brain 召不到不是 bug。
+
+brain 挂了或超时就照常干活,不阻塞主任务——它是补充层不是关键路径。
+
+---
+
+## 写入
+
+新学到跨项目工程教训时:
+
+```bash
+curl -sS -m 30 \
+  -A "curl/8.7.1" \
+  -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"content":"...", "tags":["..."], "volatility":"durable", "source":"claude"}' \
+  "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/capture"
+```
+
+**为什么钉 `volatility: durable`**:召回衰减下限 0.9,默认档 `state` 是 0.6 会让老教训随时间沉底,而工程教训(踩过的坑、实测出的约束)不因时间失效,不该被当成会过期的状态数据处理。
+
+**去重**:服务端自带去重(相似度 ≥0.95 直接 block,≥0.85 返回 `warning:"similar"`)。收到 `warning:"similar"` 时**由你读全文决定合并还是保留,不要让服务端自动 merge**——服务端合并出的 `merged_content` 上限 400 字符且会丢掉 incoming tags,实测会把新写入里的实测数据(具体数字、行号)丢掉。人工判断:内容确实重复就手动整理后走 `brain-curate` 的合并流程;不重复就保留两条。
+
+**写入索引滞后**:向量 upsert 走 `ctx.waitUntil`,响应先返回、索引后建。刚写入的条目 60-90s 内查不到,不是写失败,别在这个窗口内重复写入或误判丢失。

--- a/plugins/brain-route/skills/brain-recall/SKILL.md
+++ b/plugins/brain-route/skills/brain-recall/SKILL.md
@@ -62,7 +62,7 @@ description: |
 ```bash
 curl -sS -m 30 \
   -A "curl/8.7.1" \
-  -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+  -H "Authorization: Bearer ${SECOND_BRAIN_TOKEN:?未配置 SECOND_BRAIN_TOKEN，见 brain-route 插件 README 的 Environment Variables 节}" \
   --data-urlencode "query=<把 100-200 字处境摘要原样放这里>" \
   --data-urlencode "topK=5" \
   -G "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/recall"
@@ -70,7 +70,7 @@ curl -sS -m 30 \
 
 **必须带 UA 头** `-H "User-Agent: curl/8.7.1"`（等价于上面的 `-A`）。Cloudflare 对默认 UA（如 curl 不带 `-A` 时的默认串，或空 UA）返回 403 + `error code: 1010`，症状与 token 失效同形——排障时先查这个,再怀疑 token。
 
-也可走 MCP endpoint `${SECOND_BRAIN_URL}/mcp` 的 `recall` 工具，效果等价于上面的 REST 调用。
+也可走 MCP endpoint `${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/mcp` 的 `recall` 工具，效果等价于上面的 REST 调用。
 
 **延迟预期**：recall 实测 5.7-11s，不是即时返回，规划 Task timeout 时留够。
 
@@ -99,7 +99,7 @@ brain 挂了或超时就照常干活,不阻塞主任务——它是补充层不�
 ```bash
 curl -sS -m 30 \
   -A "curl/8.7.1" \
-  -H "Authorization: Bearer $SECOND_BRAIN_TOKEN" \
+  -H "Authorization: Bearer ${SECOND_BRAIN_TOKEN:?未配置 SECOND_BRAIN_TOKEN，见 brain-route 插件 README 的 Environment Variables 节}" \
   -H "Content-Type: application/json" \
   -d '{"content":"...", "tags":["..."], "volatility":"durable", "source":"claude"}' \
   "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/capture"

--- a/plugins/brain-route/tests/skills-packaging.bats
+++ b/plugins/brain-route/tests/skills-packaging.bats
@@ -50,6 +50,32 @@ GATE_SCRIPT="${PLUGIN_DIR}/scripts/brain-route-gate.sh"
   grep -q 'SECOND_BRAIN_URL' "$CURATE_SKILL_MD"
 }
 
+# --- 3b. Endpoint and token are fail-loud, not just env-derived (core: PR #179 review) ---
+#
+# Assertion 3 above only checks the bare string "SECOND_BRAIN_URL" appears
+# somewhere in the file — a plain unguarded "$SECOND_BRAIN_URL" satisfies it
+# just as well as "${SECOND_BRAIN_URL:?...}". That was the actual defect
+# under review: TOKEN silently sent an unauthenticated-looking request
+# instead of erroring out when unset. These assertions pin the fail-loud
+# `${VAR:?...}` form specifically, so reverting to a bare variable turns
+# these red even though assertion 3 would stay green.
+
+@test "brain-recall SKILL.md uses fail-loud \${SECOND_BRAIN_URL:?...} form" {
+  grep -qE '\$\{SECOND_BRAIN_URL:\?' "$RECALL_SKILL_MD"
+}
+
+@test "brain-curate SKILL.md uses fail-loud \${SECOND_BRAIN_URL:?...} form" {
+  grep -qE '\$\{SECOND_BRAIN_URL:\?' "$CURATE_SKILL_MD"
+}
+
+@test "brain-recall SKILL.md uses fail-loud \${SECOND_BRAIN_TOKEN:?...} form" {
+  grep -qE '\$\{SECOND_BRAIN_TOKEN:\?' "$RECALL_SKILL_MD"
+}
+
+@test "brain-curate SKILL.md uses fail-loud \${SECOND_BRAIN_TOKEN:?...} form" {
+  grep -qE '\$\{SECOND_BRAIN_TOKEN:\?' "$CURATE_SKILL_MD"
+}
+
 # --- 4. Deny text's referenced skill resolves inside this plugin (core: issue #248) ---
 
 @test "every skill name referenced by gate deny text resolves in plugin.json AND has an on-disk SKILL.md" {

--- a/plugins/brain-route/tests/skills-packaging.bats
+++ b/plugins/brain-route/tests/skills-packaging.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# Structural assertions for the brain-recall / brain-curate skill packaging
+# migration (issue #248). These lock invariants of the migration itself —
+# NOT hook behavior (that's covered by brain-route-gate.bats's 20 cases).
+#
+# All paths are relative to BATS_TEST_DIRNAME. Do not use $HOME or absolute
+# paths — this suite runs inside a git worktree, and $HOME-based lookups
+# resolve to the main worktree's stale copy instead of this checkout.
+
+PLUGIN_DIR="${BATS_TEST_DIRNAME}/.."
+REPO_ROOT="${BATS_TEST_DIRNAME}/../../.."
+
+RECALL_SKILL_MD="${PLUGIN_DIR}/skills/brain-recall/SKILL.md"
+CURATE_SKILL_MD="${PLUGIN_DIR}/skills/brain-curate/SKILL.md"
+PLUGIN_JSON="${PLUGIN_DIR}/.claude-plugin/plugin.json"
+MARKETPLACE_JSON="${REPO_ROOT}/.claude-plugin/marketplace.json"
+GATE_SCRIPT="${PLUGIN_DIR}/scripts/brain-route-gate.sh"
+
+# --- 1. Both skill files exist and are non-empty ---
+
+@test "brain-recall SKILL.md exists and is non-empty" {
+  [ -s "$RECALL_SKILL_MD" ]
+}
+
+@test "brain-curate SKILL.md exists and is non-empty" {
+  [ -s "$CURATE_SKILL_MD" ]
+}
+
+# --- 2. Zero hardcoded endpoint in either SKILL.md ---
+
+@test "brain-recall SKILL.md has zero hardcoded brain.tbps.one occurrences" {
+  local count
+  count=$(grep -c 'brain\.tbps\.one' "$RECALL_SKILL_MD" || true)
+  [ "${count:-0}" -eq 0 ]
+}
+
+@test "brain-curate SKILL.md has zero hardcoded brain.tbps.one occurrences" {
+  local count
+  count=$(grep -c 'brain\.tbps\.one' "$CURATE_SKILL_MD" || true)
+  [ "${count:-0}" -eq 0 ]
+}
+
+# --- 3. Endpoint is env-derived ---
+
+@test "brain-recall SKILL.md references SECOND_BRAIN_URL" {
+  grep -q 'SECOND_BRAIN_URL' "$RECALL_SKILL_MD"
+}
+
+@test "brain-curate SKILL.md references SECOND_BRAIN_URL" {
+  grep -q 'SECOND_BRAIN_URL' "$CURATE_SKILL_MD"
+}
+
+# --- 4. Deny text's referenced skill resolves inside this plugin (core: issue #248) ---
+
+@test "every skill name referenced by gate deny text resolves in plugin.json AND has an on-disk SKILL.md" {
+  # Extract skill names the gate script's deny/comment text refers to,
+  # matching the "<name> skill" phrasing used in brain-route-gate.sh.
+  local referenced_skills
+  referenced_skills=$(grep -oE '[a-zA-Z][a-zA-Z0-9-]* skill\b' "$GATE_SCRIPT" | awk '{print $1}' | sort -u)
+
+  [ -n "$referenced_skills" ]
+
+  while IFS= read -r skill_name; do
+    [ -n "$skill_name" ] || continue
+
+    # Resolve against plugin.json's "skills" array: entries are paths like
+    # "./skills/brain-recall" — compare by basename, not substring match.
+    local resolved_path
+    resolved_path=$(jq -r --arg name "$skill_name" \
+      '.skills[] | select((. | split("/") | last) == $name)' \
+      "$PLUGIN_JSON")
+
+    [ -n "$resolved_path" ] || {
+      echo "Skill '$skill_name' referenced by gate deny text has no matching entry in plugin.json's skills array"
+      return 1
+    }
+
+    # The resolved path's SKILL.md must actually exist on disk.
+    local resolved_skill_md
+    resolved_skill_md="${PLUGIN_DIR}/${resolved_path#./}/SKILL.md"
+    [ -f "$resolved_skill_md" ] || {
+      echo "Skill '$skill_name' resolves to plugin.json path '$resolved_path' but $resolved_skill_md does not exist"
+      return 1
+    }
+  done <<< "$referenced_skills"
+}
+
+# --- 4b. Every on-disk skill is declared in plugin.json (reverse of #4) ---
+#
+# Assertion 4 walks gate-deny-text -> plugin.json and only catches a skill
+# that's referenced by the gate script but undeclared or missing on disk.
+# It is blind to a skill that exists on disk but was never referenced by the
+# gate script at all (brain-curate is never mentioned in brain-route-gate.sh's
+# deny/comment text — only brain-recall is), so an undeclared brain-curate
+# would sail through assertion 4 with zero red. This assertion walks the
+# opposite direction, disk -> plugin.json, closing that blind spot: every
+# directory under skills/ that has a SKILL.md must resolve to a declared
+# entry in plugin.json's "skills" array. The two are complementary, not
+# duplicates — dropping either one reopens a distinct hole.
+
+@test "every on-disk skill directory (with a SKILL.md) is declared in plugin.json" {
+  local skill_dir skill_name resolved_path found_any
+  found_any=0
+
+  for skill_dir in "${PLUGIN_DIR}"/skills/*/; do
+    [ -f "${skill_dir}SKILL.md" ] || continue
+    found_any=1
+    skill_name=$(basename "$skill_dir")
+
+    resolved_path=$(jq -r --arg name "$skill_name" \
+      '.skills[] | select((. | split("/") | last) == $name)' \
+      "$PLUGIN_JSON")
+
+    [ -n "$resolved_path" ] || {
+      echo "On-disk skill '$skill_name' (has SKILL.md) has no matching entry in plugin.json's skills array"
+      return 1
+    }
+  done
+
+  # Sanity: the discovery loop itself must have found at least one skill,
+  # otherwise a broken glob would make this test vacuously pass.
+  [ "$found_any" -eq 1 ]
+}
+
+# --- 5. Version double-write consistency (plugin.json <-> marketplace.json) ---
+
+@test "plugin.json version matches marketplace.json brain-route entry version" {
+  local plugin_version marketplace_version
+  plugin_version=$(jq -r '.version' "$PLUGIN_JSON")
+  marketplace_version=$(jq -r '.plugins[] | select(.name == "brain-route") | .version' "$MARKETPLACE_JSON")
+
+  [ -n "$plugin_version" ]
+  [ -n "$marketplace_version" ]
+  [ "$plugin_version" = "$marketplace_version" ]
+}

--- a/plugins/brain-route/tests/skills-packaging.bats
+++ b/plugins/brain-route/tests/skills-packaging.bats
@@ -16,6 +16,21 @@ PLUGIN_JSON="${PLUGIN_DIR}/.claude-plugin/plugin.json"
 MARKETPLACE_JSON="${REPO_ROOT}/.claude-plugin/marketplace.json"
 GATE_SCRIPT="${PLUGIN_DIR}/scripts/brain-route-gate.sh"
 
+# Extract lines inside ```bash ... ``` fences, prefixed with their 1-based
+# line number as "NR:content". Matching is anchored on the fence token
+# itself (with optional leading whitespace), not on column 0 — this is
+# required to cover brain-curate's "合并决策规约" fences, which sit inside a
+# numbered list and are indented 3 spaces. A column-0-anchored matcher
+# silently skips those blocks (verified: only counts 3 of the file's 5
+# Authorization headers).
+_fenced_bash_lines() {
+  awk '
+    /^[[:space:]]*```bash[[:space:]]*$/ { infence=1; next }
+    /^[[:space:]]*```[[:space:]]*$/ { if (infence) { infence=0; next } }
+    infence { print NR":"$0 }
+  ' "$1"
+}
+
 # --- 1. Both skill files exist and are non-empty ---
 
 @test "brain-recall SKILL.md exists and is non-empty" {
@@ -74,6 +89,105 @@ GATE_SCRIPT="${PLUGIN_DIR}/scripts/brain-route-gate.sh"
 
 @test "brain-curate SKILL.md uses fail-loud \${SECOND_BRAIN_TOKEN:?...} form" {
   grep -qE '\$\{SECOND_BRAIN_TOKEN:\?' "$CURATE_SKILL_MD"
+}
+
+# --- 3c. Universality: EVERY bash-fenced auth header / URL ref is fail-loud ---
+#
+# The 3b assertions above are existence checks — one compliant occurrence
+# anywhere in the file satisfies them even if four other occurrences in the
+# same file regressed to a bare variable. That's the realistic regression
+# shape (partial revert on a multi-occurrence file), and it's more dangerous
+# than a full revert because a full revert would still be caught by 3b.
+# These assertions require every fenced-code occurrence to be fail-loud, not
+# just one. Prose occurrences outside fences (e.g. the explanatory sentences
+# at brain-recall:30 and brain-curate:24) are deliberately excluded — they
+# describe the mechanism in running text and are not runtime code.
+
+@test "brain-recall SKILL.md: every fenced Authorization header is fail-loud" {
+  local bad
+  bad=$(_fenced_bash_lines "$RECALL_SKILL_MD" | grep 'Authorization: Bearer' | grep -vE '\$\{SECOND_BRAIN_TOKEN:\?' || true)
+  if [ -n "$bad" ]; then
+    echo "Non-fail-loud Authorization header(s) in fenced bash code:"
+    echo "$bad"
+    return 1
+  fi
+  # Sanity: must have found at least one Authorization header to guard
+  # against a broken fence parser vacuously passing on an empty set.
+  local total
+  total=$(_fenced_bash_lines "$RECALL_SKILL_MD" | grep -c 'Authorization: Bearer' || true)
+  [ "${total:-0}" -gt 0 ]
+}
+
+@test "brain-curate SKILL.md: every fenced Authorization header is fail-loud" {
+  local bad
+  bad=$(_fenced_bash_lines "$CURATE_SKILL_MD" | grep 'Authorization: Bearer' | grep -vE '\$\{SECOND_BRAIN_TOKEN:\?' || true)
+  if [ -n "$bad" ]; then
+    echo "Non-fail-loud Authorization header(s) in fenced bash code:"
+    echo "$bad"
+    return 1
+  fi
+  local total
+  total=$(_fenced_bash_lines "$CURATE_SKILL_MD" | grep -c 'Authorization: Bearer' || true)
+  [ "${total:-0}" -gt 0 ]
+}
+
+@test "brain-recall SKILL.md: every fenced SECOND_BRAIN_URL reference is fail-loud" {
+  local bad
+  # Match any SECOND_BRAIN_URL occurrence, then exclude the compliant
+  # ${SECOND_BRAIN_URL:?...} form — whatever's left is bare ($SECOND_BRAIN_URL
+  # or ${SECOND_BRAIN_URL}).
+  bad=$(_fenced_bash_lines "$RECALL_SKILL_MD" | grep 'SECOND_BRAIN_URL' | grep -vE '\$\{SECOND_BRAIN_URL:\?' || true)
+  if [ -n "$bad" ]; then
+    echo "Non-fail-loud SECOND_BRAIN_URL reference(s) in fenced bash code:"
+    echo "$bad"
+    return 1
+  fi
+  local total
+  total=$(_fenced_bash_lines "$RECALL_SKILL_MD" | grep -c 'SECOND_BRAIN_URL' || true)
+  [ "${total:-0}" -gt 0 ]
+}
+
+@test "brain-curate SKILL.md: every fenced SECOND_BRAIN_URL reference is fail-loud" {
+  local bad
+  bad=$(_fenced_bash_lines "$CURATE_SKILL_MD" | grep 'SECOND_BRAIN_URL' | grep -vE '\$\{SECOND_BRAIN_URL:\?' || true)
+  if [ -n "$bad" ]; then
+    echo "Non-fail-loud SECOND_BRAIN_URL reference(s) in fenced bash code:"
+    echo "$bad"
+    return 1
+  fi
+  local total
+  total=$(_fenced_bash_lines "$CURATE_SKILL_MD" | grep -c 'SECOND_BRAIN_URL' || true)
+  [ "${total:-0}" -gt 0 ]
+}
+
+# --- 3d. mktemp portability: no BSD-only "-t <name>" form ---
+#
+# `mktemp -t brain_export` works on BSD/macOS but dies on GNU coreutils
+# (`mktemp: too few X's in template`, rc=1) — a Linux runner would fail
+# before ever reaching the curl call. The fix in place uses an explicit
+# XXXXXX template, which is portable across both. This pins that form.
+
+@test "brain-curate SKILL.md: any mktemp call uses a portable XXXXXX template, not BSD -t" {
+  local mktemp_lines bad
+  mktemp_lines=$(grep -n 'mktemp' "$CURATE_SKILL_MD" || true)
+
+  if [ -z "$mktemp_lines" ]; then
+    skip "no mktemp call present in brain-curate SKILL.md"
+  fi
+
+  bad=$(echo "$mktemp_lines" | grep -E 'mktemp[[:space:]]+-t[[:space:]]+[^X]' || true)
+  if [ -n "$bad" ]; then
+    echo "BSD-only 'mktemp -t <name>' form found (fails on GNU coreutils):"
+    echo "$bad"
+    return 1
+  fi
+
+  bad=$(echo "$mktemp_lines" | grep -v 'XXXXXX' || true)
+  if [ -n "$bad" ]; then
+    echo "mktemp call without an explicit XXXXXX template:"
+    echo "$bad"
+    return 1
+  fi
 }
 
 # --- 4. Deny text's referenced skill resolves inside this plugin (core: issue #248) ---


### PR DESCRIPTION
## 变更概述

`brain-recall` / `brain-curate` 两个 skill 从维护者私有仓迁入本插件，与 hook 同处一地；后端端点改由环境变量注入，不再硬编码。

## 为什么

hook 的 deny 文案指名让调用方去用 `brain-recall` skill，但该 skill 此前不随插件分发——装了插件的人会看到指向不存在 skill 的提示，且插件与配套规约分处两仓、版本各自漂移。当初留在私有仓的理由是「skill 正文含私有事实（域名）」，那是没做配置外置的结果，不是 skill 必须私有的证据：记忆路由规约本身（准入判据、查询构造、复核流程）不依赖任何私有事实。

其余 6 个插件（doc-gate、code-search、pr-review、ppt-press、dispatch-contract、deep-research）都有 `skills` 字段，brain-route 是唯一例外。

## 端点外置为何做两层

`SKILL.md` 是给 AI 抄执行的命令模板。只在正文写「未配置时请先配置」不够——不读说明直接抄命令时，未设变量会静默打到相对路径 `/recall`，症状难归因。故：

1. 正文加「配置前提」节，说明两个变量与配置位置
2. 命令用 `${SECOND_BRAIN_URL:?...}`，未配置时带着变量名报错

实测未设变量时 `rc=127`，且 `curl` 从不发出请求。

## 测试

新增 `skills-packaging.bats`（9 条结构性断言），全套 **29 个用例通过**。

两条 join 断言是互补而非冗余，这点值得说明：deny 文案只提 `brain-recall`（`brain-curate` 在 gate 脚本里零引用），所以「文案 → plugin.json」的单向断言对「磁盘上存在但未声明的 skill」完全失明。实测删掉 `plugin.json` 里 `brain-curate` 的声明，在加反向断言之前 28 个用例全绿。补「磁盘 → plugin.json」的反向断言后该变异精确转红。

每条断言都做了变异验证（含先确认变异真的落地——「没转红」与「变异没落地」同形）。

## 变更清单

- `skills/{brain-recall,brain-curate}/SKILL.md` 迁入，10 处硬编码域名改 env 派生，通用正文逐字保留（反向替换 env 表达式后与源文件仅差新增的「配置前提」节）
- `plugin.json` 加 `skills` 字段，version `1.0.0 → 1.1.0`；`marketplace.json` 同步双写（只动 2 行，其他插件条目未触碰）
- README 补 `Backend Dependency`（后端项目、Cloudflare 资源、自建命令、`AUTH_TOKEN` ↔ `SECOND_BRAIN_TOKEN` 对应关系；CJK 语料须用 `downstream` 分支及其根因）与 `Skills` 两节；`Environment Variables` 按消费者拆两表（hook 的 4 个 `BRAIN_ROUTE_*` 原样保留）
- `hooks/hooks.json` 与 `scripts/brain-route-gate.sh` 未改动——加 skill 不影响 hook 行为

## 新增环境变量

| 变量 | 消费者 | 说明 |
|---|---|---|
| `SECOND_BRAIN_URL` | skills | 实例 REST base，无默认值 |
| `SECOND_BRAIN_TOKEN` | skills | 后端的 `AUTH_TOKEN`，Bearer 鉴权 |

命名空间已核：与 `REVIEW_*`（plan-review）、`BRAIN_ROUTE_*`（本插件 hook）、`SKILL_GATE_*` / `RECALL_GATE_*`（doc-gate）均不重叠，`SECOND_BRAIN_*` 在全仓 0 处已用。

## 兼容性

未配置后端时 hook 照常工作（纯本地字符串匹配、零网络调用），只有两个 skill 不可用。README 明确写了这个区分。