### PR TITLE
fix(brain-route): brain-curate 的 /export jq 从未跑通过 (v1.1.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -96,7 +96,7 @@
     {
       "name": "brain-route",
       "description": "Second-brain routing — brain-recall / brain-curate skills (recall, capture, curation protocol) + soft advisory hook that prompts consideration of second-brain (cross-project) vs local memory (project-local) when writing project memory .md files",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/brain-route/.claude-plugin/plugin.json
+++ b/plugins/brain-route/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "brain-route",
   "description": "Second-brain routing — brain-recall / brain-curate skills (recall, capture, curation protocol) + soft advisory hook that prompts consideration of second-brain (cross-project) vs local memory (project-local) when writing project memory .md files",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/brain-recall", "./skills/brain-curate"]
 }

--- a/plugins/brain-route/skills/brain-curate/SKILL.md
+++ b/plugins/brain-route/skills/brain-curate/SKILL.md
@@ -75,7 +75,7 @@ rm -f "$BRAIN_EXPORT"
 
 筛出 `recall_count == 0` 且 `created_at` 超 60 天的条目——这些是写进去后从未被任何查询命中的沉底条目，是盲区，只能靠这条命令找到。
 
-**返回 `[]` 先别当命令坏了**：库里最老条目不足 60 天时，空结果就是正确答案。先用 `jq '[.entries[]|select(.recall_count==0)]|length'` 看有多少零召回条目、用 `jq -r '[.entries[]|(now-(.created_at/1000))/86400]|max|floor'` 看最老条目多少天，再判断是筛空还是解析错。
+**返回 `[]` 先别当命令坏了**：库里最老条目不足 60 天时，空结果就是正确答案。先用 `jq '[.entries[]|select(.recall_count==0)]|length'` 看有多少零召回条目、用 `jq -r '[.entries[]|(now-(.created_at/1000))/86400]|max // 0|floor'` 看最老条目多少天，再判断是筛空还是解析错——两条命令在 `entries` 为空时都返回 `0`，不会报错（`max` 在空数组上原生返回 `null` 会导致后续 `floor` 报 `number required` 崩掉，`// 0` 兜底避免这个问题）。
 
 **三个端点的返回形态不同，jq 不能照抄**：
 

--- a/plugins/brain-route/skills/brain-curate/SKILL.md
+++ b/plugins/brain-route/skills/brain-curate/SKILL.md
@@ -66,14 +66,26 @@ curl -sS -m 30 -A "curl/8.7.1" \
   -H "Authorization: Bearer ${SECOND_BRAIN_TOKEN:?未配置 SECOND_BRAIN_TOKEN，见 brain-route 插件 README 的 Environment Variables 节}" \
   "${SECOND_BRAIN_URL:?未配置 second-brain 端点，请设置 SECOND_BRAIN_URL，见 brain-route 插件 README 的 Environment Variables 节}/export" > "$BRAIN_EXPORT"
 
-jq '[.[] | select(.recall_count == 0)] | .[] | select(
-  (now - (.created_at | fromdateiso8601)) > (60*86400)
-)' "$BRAIN_EXPORT"
+jq '[.entries[]
+     | select(.recall_count == 0)
+     | select((now - (.created_at / 1000)) > (60 * 86400))]' "$BRAIN_EXPORT"
 
 rm -f "$BRAIN_EXPORT"
 ```
 
 筛出 `recall_count == 0` 且 `created_at` 超 60 天的条目——这些是写进去后从未被任何查询命中的沉底条目，是盲区，只能靠这条命令找到。
+
+**返回 `[]` 先别当命令坏了**：库里最老条目不足 60 天时，空结果就是正确答案。先用 `jq '[.entries[]|select(.recall_count==0)]|length'` 看有多少零召回条目、用 `jq -r '[.entries[]|(now-(.created_at/1000))/86400]|max|floor'` 看最老条目多少天，再判断是筛空还是解析错。
+
+**三个端点的返回形态不同，jq 不能照抄**：
+
+| 端点 | 条目在哪 | `tags` | `created_at` |
+|---|---|---|---|
+| `/recall` | `.results[]` | 数组 | number（epoch **毫秒**） |
+| `/list` | 顶层就是数组，`.[]` | **JSON 字符串**，需 `fromjson` 才能当数组用 | number（毫秒） |
+| `/export` | `.entries[]`（顶层是 `{ok, version, exported_at, entries, edges}`） | 数组 | number（毫秒） |
+
+两个易错点：对 `/export` 写 `.[]` 会迭代到 `ok`（布尔）并报 `Cannot index boolean with string ...`；`created_at` 是毫秒数字，`fromdateiso8601` 只吃 ISO 字符串，对它用必然失败——要除 1000 而不是转换。
 
 ---
 

--- a/plugins/brain-route/tests/fixtures/export-shape.json
+++ b/plugins/brain-route/tests/fixtures/export-shape.json
@@ -1,0 +1,36 @@
+{
+  "ok": true,
+  "version": 1,
+  "exported_at": 1700000000000,
+  "entries": [
+    {
+      "id": "entry-old-zero-recall",
+      "content": "recall_count 0, created_at 2020 (old) -- should be selected",
+      "tags": ["fixture"],
+      "recall_count": 0,
+      "created_at": 1577836800000
+    },
+    {
+      "id": "entry-new-zero-recall",
+      "content": "recall_count 0, created_at 2099 (new) -- should NOT be selected",
+      "tags": ["fixture"],
+      "recall_count": 0,
+      "created_at": 4070908800000
+    },
+    {
+      "id": "entry-old-nonzero-recall",
+      "content": "recall_count 5, created_at 2020 (old) -- should NOT be selected",
+      "tags": ["fixture"],
+      "recall_count": 5,
+      "created_at": 1577836800000
+    },
+    {
+      "id": "entry-new-nonzero-recall",
+      "content": "recall_count 3, created_at 2099 (new) -- should NOT be selected",
+      "tags": ["fixture"],
+      "recall_count": 3,
+      "created_at": 4070908800000
+    }
+  ],
+  "edges": []
+}

--- a/plugins/brain-route/tests/skills-packaging.bats
+++ b/plugins/brain-route/tests/skills-packaging.bats
@@ -15,6 +15,7 @@ CURATE_SKILL_MD="${PLUGIN_DIR}/skills/brain-curate/SKILL.md"
 PLUGIN_JSON="${PLUGIN_DIR}/.claude-plugin/plugin.json"
 MARKETPLACE_JSON="${REPO_ROOT}/.claude-plugin/marketplace.json"
 GATE_SCRIPT="${PLUGIN_DIR}/scripts/brain-route-gate.sh"
+FIXTURE_EXPORT="${BATS_TEST_DIRNAME}/fixtures/export-shape.json"
 
 # Extract lines inside ```bash ... ``` fences, prefixed with their 1-based
 # line number as "NR:content". Matching is anchored on the fence token
@@ -201,44 +202,67 @@ _fenced_bash_lines() {
 # correct conversion divides by 1000. Both defects were verified live
 # against a real /export response before the SKILL.md fix landed.
 
-@test "brain-curate SKILL.md: /export jq filter reads entries via .entries[], not bare .[]" {
-  # Scoped to fenced bash blocks only (via _fenced_bash_lines) -- the prose
-  # in the "返回 [] 先别当命令坏了" paragraph includes an inline worked
-  # example (`jq '[.entries[]|select(.recall_count==0)]|length'`) as running
-  # text for humans, not runnable code from the actual /export filter block.
-  # An unscoped whole-file scan would let that prose satisfy both the
-  # sanity check and the entries-vs-bare-[] check even if the real filter
-  # block were deleted or reverted -- both must be fenced-scoped together.
-  local recall_lines
-  recall_lines=$(_fenced_bash_lines "$CURATE_SKILL_MD" | grep 'select(\.recall_count' || true)
 
-  # Sanity: at least one recall_count filter must exist in fenced code,
-  # otherwise this assertion would vacuously pass if the whole filter
-  # block were deleted.
-  [ -n "$recall_lines" ] || {
-    echo "No 'select(.recall_count' line found in fenced bash code in $CURATE_SKILL_MD -- the zero-recall filter block may have been deleted"
+# Extracts the /export jq filter expression from fenced bash code: finds the
+# first fenced line containing "jq", then accumulates lines (stripping "\"
+# line-continuations) until a line ending in "]'" closes the single-quoted
+# jq program. Tolerates the jq invocation and its opening "'[.entries[]"
+# being reflowed across two lines (e.g. "jq \\\n'[.entries[]") -- a
+# semantically-identical rewrite that a same-line text grep cannot survive
+# (verified live: reflowing turns a same-line grep red with zero behavior
+# change).
+_extract_export_jq_filter() {
+  local file="$1" sq="'" raw expr
+  raw=$(_fenced_bash_lines "$file" | awk -F: '
+    { line = substr($0, index($0, ":") + 1) }
+    !capturing && line ~ /jq/ { capturing = 1 }
+    capturing {
+      sub(/\\[[:space:]]*$/, "", line)
+      buf = buf line "\n"
+      if (line ~ /\]'"'"'/) exit
+    }
+    END { printf "%s", buf }
+  ')
+  expr="${raw#*$sq}"
+  expr="${expr%$sq*}"
+  printf '%s' "$expr"
+}
+
+@test "brain-curate SKILL.md: /export jq filter reads entries via .entries[], not bare .[]" {
+  # Executes the actual jq filter extracted from fenced bash code against a
+  # fixed fixture (fixtures/export-shape.json) and asserts the exact
+  # selected id set, instead of grepping for a specific token arrangement.
+  # A prior text-form state machine here required "jq" and "[.entries[]" on
+  # the SAME line -- reflowing them across two lines (a semantically
+  # identical, legal rewrite) turned it red with zero behavior change
+  # (verified live). Executing the real filter against a real fixture
+  # survives that reflow and catches the real defect (a boolean-indexing
+  # crash on bare `.[]`, or selecting the wrong entries) by its real
+  # symptom instead of by text shape.
+  local expr result status ids
+
+  expr="$(_extract_export_jq_filter "$CURATE_SKILL_MD")"
+  [ -n "$expr" ] || {
+    echo "Could not extract a jq filter expression from fenced bash code in $CURATE_SKILL_MD -- the /export filter block may have been deleted"
     return 1
   }
 
-  # Walk the fenced bash lines top to bottom, tracking whether the most
-  # recently opened jq array comprehension entered via .entries[] (ok) or
-  # a bare .[] (bad). Any select(.recall_count...) line reached while the
-  # bad state is active is a violation -- this catches the exact mutation
-  # of "[.entries[]" back to "[.[]" without needing to parse the full
-  # multi-line jq expression.
-  local bad
-  bad=$(_fenced_bash_lines "$CURATE_SKILL_MD" | awk -F: '
-    { line = substr($0, index($0, ":") + 1) }
-    line ~ /jq.*\[\.entries\[\]/ { entries_ok=1 }
-    line ~ /jq.*\[\.\[\]/ { entries_ok=0 }
-    line ~ /select\(\.recall_count/ { if (!entries_ok) print $0 }
-  ')
+  result=$(printf '%s' "$expr" | jq -f /dev/stdin "$FIXTURE_EXPORT" 2>&1)
+  status=$?
 
-  if [ -n "$bad" ]; then
-    echo "recall_count filter not reached via .entries[] (bare .[] iteration on /export's object root):"
-    echo "$bad"
+  if [ "$status" -ne 0 ]; then
+    echo "Extracted jq filter failed to execute against fixture (exit $status):"
+    echo "Filter: $expr"
+    echo "Error: $result"
     return 1
   fi
+
+  ids=$(printf '%s' "$result" | jq -r '[.[].id] | sort | join(",")')
+  [ "$ids" = "entry-old-zero-recall" ] || {
+    echo "Expected selected id set to be exactly {entry-old-zero-recall}, got: $ids"
+    echo "Filter: $expr"
+    return 1
+  }
 }
 
 @test "brain-curate SKILL.md: created_at treated as epoch milliseconds, not ISO date string" {

--- a/plugins/brain-route/tests/skills-packaging.bats
+++ b/plugins/brain-route/tests/skills-packaging.bats
@@ -190,6 +190,85 @@ _fenced_bash_lines() {
   fi
 }
 
+# --- 3e. /export jq filter shape: entries[] not bare .[], created_at as epoch-ms ---
+#
+# `/export` returns a top-level OBJECT {ok, version, exported_at, entries,
+# edges} — a bare `.[]` on that object iterates into `ok` (a boolean) and
+# blows up with "Cannot index boolean with string ...". The fix reads
+# through `.entries[]` instead. Separately, `created_at` is an epoch
+# millisecond NUMBER on every endpoint, not an ISO 8601 string, so
+# `fromdateiso8601` (which only parses strings) fails outright on it; the
+# correct conversion divides by 1000. Both defects were verified live
+# against a real /export response before the SKILL.md fix landed.
+
+@test "brain-curate SKILL.md: /export jq filter reads entries via .entries[], not bare .[]" {
+  # Scoped to fenced bash blocks only (via _fenced_bash_lines) -- the prose
+  # in the "返回 [] 先别当命令坏了" paragraph includes an inline worked
+  # example (`jq '[.entries[]|select(.recall_count==0)]|length'`) as running
+  # text for humans, not runnable code from the actual /export filter block.
+  # An unscoped whole-file scan would let that prose satisfy both the
+  # sanity check and the entries-vs-bare-[] check even if the real filter
+  # block were deleted or reverted -- both must be fenced-scoped together.
+  local recall_lines
+  recall_lines=$(_fenced_bash_lines "$CURATE_SKILL_MD" | grep 'select(\.recall_count' || true)
+
+  # Sanity: at least one recall_count filter must exist in fenced code,
+  # otherwise this assertion would vacuously pass if the whole filter
+  # block were deleted.
+  [ -n "$recall_lines" ] || {
+    echo "No 'select(.recall_count' line found in fenced bash code in $CURATE_SKILL_MD -- the zero-recall filter block may have been deleted"
+    return 1
+  }
+
+  # Walk the fenced bash lines top to bottom, tracking whether the most
+  # recently opened jq array comprehension entered via .entries[] (ok) or
+  # a bare .[] (bad). Any select(.recall_count...) line reached while the
+  # bad state is active is a violation -- this catches the exact mutation
+  # of "[.entries[]" back to "[.[]" without needing to parse the full
+  # multi-line jq expression.
+  local bad
+  bad=$(_fenced_bash_lines "$CURATE_SKILL_MD" | awk -F: '
+    { line = substr($0, index($0, ":") + 1) }
+    line ~ /jq.*\[\.entries\[\]/ { entries_ok=1 }
+    line ~ /jq.*\[\.\[\]/ { entries_ok=0 }
+    line ~ /select\(\.recall_count/ { if (!entries_ok) print $0 }
+  ')
+
+  if [ -n "$bad" ]; then
+    echo "recall_count filter not reached via .entries[] (bare .[] iteration on /export's object root):"
+    echo "$bad"
+    return 1
+  fi
+}
+
+@test "brain-curate SKILL.md: created_at treated as epoch milliseconds, not ISO date string" {
+  # fromdateiso8601 only parses ISO 8601 strings; created_at is an
+  # epoch-millisecond number on every endpoint (per the format table),
+  # so applying fromdateiso8601 to it fails outright. Must never reappear
+  # in runnable jq code. Scoped to fenced bash blocks (via
+  # _fenced_bash_lines), NOT the whole file -- the prose at line 88
+  # deliberately names fromdateiso8601 as the documented anti-pattern to
+  # avoid, so a whole-file grep would false-positive on that sentence.
+  local bad
+  bad=$(_fenced_bash_lines "$CURATE_SKILL_MD" | grep 'fromdateiso8601' || true)
+  if [ -n "$bad" ]; then
+    echo "fromdateiso8601 found in fenced bash code -- created_at is an epoch-millisecond number, not an ISO string:"
+    echo "$bad"
+    return 1
+  fi
+
+  # The correct handling divides created_at by 1000 to convert ms -> s.
+  # Tolerate whitespace variance around the '/' (e.g. "created_at / 1000"
+  # or "created_at/1000"). Scoped to fenced bash blocks -- the prose at
+  # line 78 also mentions "created_at/1000" as running text (a worked
+  # example for humans, not runnable jq), which would let this check pass
+  # even after the real division in the executable jq filter was removed.
+  _fenced_bash_lines "$CURATE_SKILL_MD" | grep -qE '\.created_at[[:space:]]*/[[:space:]]*1000' || {
+    echo "No '.created_at / 1000' (epoch-ms to seconds) conversion found in fenced bash code in $CURATE_SKILL_MD"
+    return 1
+  }
+}
+
 # --- 4. Deny text's referenced skill resolves inside this plugin (core: issue #248) ---
 
 @test "every skill name referenced by gate deny text resolves in plugin.json AND has an on-disk SKILL.md" {


### PR DESCRIPTION
## 缺陷

`brain-curate` 的「全量含统计」那段 jq **从落地起就跑不通**，两个 bug 叠加，实测：

```
jq: error (at /tmp/ex.json:829): Cannot index boolean with string "recall_count"
```

| # | Bug | 实测依据 |
|---|---|---|
| 1 | `/export` 返回**对象** `{ok, version, exported_at, entries, edges}`，原文写 `jq '[.[] \| select(.recall_count == 0)]'` —— `.[]` 迭代对象会遍历到 `ok`（布尔） | 上面那行报错 |
| 2 | `created_at` 是 epoch **毫秒数字**，原文用 `fromdateiso8601`（只吃 ISO 字符串） | 样本值 `1786324261562` |

两个 bug 各自都足以让命令挂掉。

**影响**：这段是 ADR 决策所述「PR 归并前兜底扫描」的唯一入口——「写进去但从没被召回过」的盲区条目只能靠它找出（读路径自曝那层覆盖不到，因为没人查询过那些话题）。等于该能力一直不可用。

## 修复

```bash
jq '[.entries[]
     | select(.recall_count == 0)
     | select((now - (.created_at / 1000)) > (60 * 86400))]' "$BRAIN_EXPORT"
```

**端到端验证**（不是另写一份能跑的命令，而是验 skill 里那段本身能跑）：从 `SKILL.md` 原样抽出整个代码块执行 → `rc=0`、输出 `[]`。「9 条零召回条目」这个中间结果证明 `.entries[]` 与 `recall_count` 解析正确。

## 三端点形态差异（已列表钉进 skill）

抄错是结构性风险，不是一次性笔误：

| 端点 | 条目在哪 | `tags` | `created_at` |
|---|---|---|---|
| `/recall` | `.results[]` | 数组 | number（epoch 毫秒） |
| `/list` | 顶层即数组 `.[]` | **JSON 字符串**，需 `fromjson` | number（毫秒） |
| `/export` | `.entries[]` | 数组 | number（毫秒） |

## 另补一条判据

该命令返回 `[]` 时**先别当它坏了**——库里最老条目不足 60 天时，空结果就是正确答案（本机实测最老 2 天，故 `[]` 正确）。skill 里附了两条分辨命令（数零召回条目总数、看最老条目天数），免得下次把正确的空结果误判成解析错。

## 测试

新增两条断言锁形态（`.entries` 取值、`created_at` 除 1000 且禁 `fromdateiso8601`），**38 → 40 个用例全绿**。

两条断言都**限定在 bash 围栏内**扫描。这点是必需的而非讲究：正文散文里有同形字样（第 78 行的分辨命令示例含 `.entries[]` 与 `created_at/1000`），不限定范围会被示例文本假通过——落地过程中两条断言的初稿都中了这个，靠变异验证才暴露。

变异验证 4 轮 + 我独立复验 2 轮：`.entries[]` → `.[]`、重新引入 `fromdateiso8601`、去掉除法但不引入 iso、整段删除（验 vacuous 哨兵），各自精确转红后恢复。

## 版本

`1.1.0 → 1.1.1`，`plugin.json` 与 `marketplace.json` 双写一致（marketplace 只动 brain-route 条目那一行）。