### PR TITLE
fix(pr-review): reject unsupported Grok xhigh effort

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,7 +63,7 @@
     {
       "name": "pr-review",
       "description": "AI review for open GitHub PRs — grok CLI local synchronous review (default, with adversarial multi-round follow-up over a persisted session) + GitHub Copilot bot asynchronous review (optional)",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/pr-review/.claude-plugin/plugin.json
+++ b/plugins/pr-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pr-review",
   "description": "AI review for open GitHub PRs — grok CLI local synchronous review (default, with adversarial multi-round follow-up over a persisted session) + GitHub Copilot bot asynchronous review (optional)",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/pr-review"]
 }

--- a/plugins/pr-review/README.md
+++ b/plugins/pr-review/README.md
@@ -66,7 +66,7 @@ Guardrails baked into the script:
 | grok | `grok` CLI on `PATH`, `gh` (authenticated), `git` |
 | copilot | `gh` (authenticated), Copilot code review enabled on the repo |
 
-`GROK_MODEL` (default `grok-4.5`) and `GROK_EFFORT` (default `high`) override the model and reasoning effort; on a follow-up round the persisted session's values win unless the flag is given explicitly.
+`GROK_MODEL` (default `grok-4.5`) and `GROK_EFFORT` (default `high`) override the model and reasoning effort. Supported effort values are exactly `none`, `minimal`, `low`, `medium`, and `high`; `xhigh` is not supported. On a follow-up round, persisted session values win unless the flag is given explicitly. If a persisted legacy session records `xhigh`, the script migrates that value to `high` once before the review runs.
 
 ## Tests
 
@@ -74,4 +74,4 @@ Guardrails baked into the script:
 bats plugins/pr-review/tests/grok-review.bats
 ```
 
-60 cases covering argument parsing, session state files, path construction, fail-fast semantics, directory permissions, GC, and the secret-file heuristics. External commands (`grok`, `gh`, `uuidgen`) are stubbed; `git` is real, against a per-test temp repo.
+66 cases covering argument parsing, session state files, path construction, fail-fast semantics, directory permissions, GC, effort validation and migration, and the secret-file heuristics. External commands (`grok`, `gh`, `uuidgen`) are stubbed; `git` is real, against a per-test temp repo.

--- a/plugins/pr-review/skills/pr-review/SKILL.md
+++ b/plugins/pr-review/skills/pr-review/SKILL.md
@@ -64,7 +64,7 @@ session 状态本就落盘（state file），复核轮的派发 A 用同一 sess
 "${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/grok-review.sh" <PR> [--repo owner/name]
 ```
 
-**cwd 必须是被评审 PR 所在的仓库工作区**——脚本按 `git rev-parse --show-toplevel` 钉死 session 身份、按 cwd 取增量 diff，不是"不依赖 cwd"。结果直接打印到终端，不发 PR 评论。参数细节、工作原理、故障排查见 `references/grok-review.md`。
+**cwd 必须是被评审 PR 所在的仓库工作区**——脚本按 `git rev-parse --show-toplevel` 钉死 session 身份、按 cwd 取增量 diff，不是"不依赖 cwd"。结果直接打印到终端，不发 PR 评论。支持的 `--effort` / `GROK_EFFORT` 值严格为 `none`、`minimal`、`low`、`medium`、`high`，默认 `high`；不支持 `xhigh`。复核轮读到旧持久 state 的 `EFFORT=xhigh` 时，脚本会在调用前一次性迁移为 `high`。参数细节、工作原理、故障排查见 `references/grok-review.md`。
 
 **派发给子任务时的路径发现**：`${CLAUDE_PLUGIN_ROOT}` 在 subagent 正文里不展开。解析命令已内置于 `references/grok-review.md`「派发 A 模板」，复制该模板即可——路径解析只留这一处，避免主线与模板各解析一次形成双轨。
 

--- a/plugins/pr-review/skills/pr-review/references/grok-review.md
+++ b/plugins/pr-review/skills/pr-review/references/grok-review.md
@@ -49,7 +49,7 @@ scripts/grok-review.sh <PR> --followup "<复核指令>" [--since <ref>] [--sessi
 | `<PR>` | PR 编号（必填，纯数字） | — |
 | `--repo owner/name` | 目标仓库，跨仓库评审时指定 | 当前 `gh` 仓库 |
 | `--model M` | grok 模型 | `grok-4.5`（可用环境变量 `GROK_MODEL` 覆盖） |
-| `--effort E` | 推理强度，合法值 `none/minimal/low/medium/high/xhigh` | `high`（可用环境变量 `GROK_EFFORT` 覆盖）。日常想省 token 可 `--effort low/medium` 或 `GROK_EFFORT=low` |
+| `--effort E` | 推理强度。支持的值严格为 `none/minimal/low/medium/high`；不支持 `xhigh`。 | `high`（可用环境变量 `GROK_EFFORT` 覆盖）。日常想省 token 可 `--effort low/medium` 或 `GROK_EFFORT=low`。旧持久 state 中的 `EFFORT=xhigh` 会在复核前一次性迁移为 `high`。 |
 | `--followup "<文本>"` | 进入复核轮：`-r` 续接同一 session，只发 followup 文本 + 本轮增量 diff（不重发首轮全量） | 不传即为首轮 |
 | `--since <ref>` | 仅复核轮生效：增量 diff 改用 `git diff <ref>` 计算基准（会先 `rev-parse --verify` 校验 ref） | 默认 `git diff <状态文件 BASE_SHA>`（首轮 HEAD）＋ untracked；`BASE_SHA` 从未记录时用 `git diff HEAD`，记录存在却不可达则 **Fail Fast**（不静默降级） |
 | `--session <UUID>` | 显式覆盖本轮使用的 SID，优先级高于状态文件 | 读状态文件里的 `SID` |
@@ -129,7 +129,7 @@ grok 的 `--output-format json` 输出**不是合法 JSON**——`thought` 字�
 - 内容：简单 KV——`SID` / `MODEL` / `EFFORT` / `CWD`（首轮工作区 toplevel；**只要在 git 仓就记录**，与是否给 grok 传 `--cwd` 解耦，供复核轮"工作区身份钉"比对）/ `BASE_SHA`（首轮 HEAD，作复核默认基线；只要在 git 仓就记录）/ `CREATED`（epoch 秒）。
 - 生命周期：首轮**在 grok 成功返回后**才写入/覆盖同 PR 的旧文件——首轮失败不会留下误导性 SID/BASE_SHA（"不覆盖进行中会话"**仅对 grok 失败路径成立**）。成功路径**会**覆写同 PR 既有 state：因此无参重跑首轮（漏写 `--followup`）会用新 SID 覆盖活跃 session、丢掉旧会话记忆并再烧一轮全量 diff token——脚本在**调 grok 前**就大字警告"覆写已存在的活跃 session（旧 SID→新 SID）……若本意是复核请改用 --followup"，误触可当场 Ctrl-C 止损；不默认 Fail Fast，因为重跑首轮求全新 session 是合法常见操作。复核轮只读 SID/BASE_SHA，但**成功后会 `touch` 状态文件刷新 mtime**，防止活跃 session 被 GC 误清。不建 TTL 有效性判断（靠 Fail Fast 兜底失效场景）。每次首轮写入前顺手做 30 天 GC（`find ... -name '*.session' -mtime +30 -delete`），防止状态文件无限累积。
 
-- 复核轮默认**沿用首轮的 model/effort**（从状态文件 `MODEL`/`EFFORT` 读回，保证同一 session 各轮推理强度一致）；命令行显式给出 `--model` / `--effort` 时以命令行为准（优先级：命令行 flag > 状态文件 > 默认/环境变量）。**显式覆盖仅本轮生效、不写回 state**——下一轮不带 flag 会回到首轮记录值（非 sticky）；state 里 `MODEL` 读回时也过 `check_model` 校验（防损坏值注入 `-m`）。
+- 复核轮默认**沿用首轮的 model/effort**（从状态文件 `MODEL`/`EFFORT` 读回，保证同一 session 各轮推理强度一致）；命令行显式给出 `--model` / `--effort` 时以命令行为准（优先级：命令行 flag > 状态文件 > 默认/环境变量）。支持的 effort 值严格为 `none/minimal/low/medium/high`，默认 `high`，不支持 `xhigh`。旧持久 state 中唯一允许出现的 `EFFORT=xhigh` 会在复核前一次性迁移为 `high`；新的命令行或环境输入 `xhigh` 会被拒绝。**显式覆盖仅本轮生效、不写回 state**——下一轮不带 flag 会回到首轮记录值（非 sticky）；state 里 `MODEL` 读回时也过 `check_model` 校验（防损坏值注入 `-m`）。
 
 ## 设计说明
 

--- a/plugins/pr-review/skills/pr-review/scripts/grok-review.sh
+++ b/plugins/pr-review/skills/pr-review/scripts/grok-review.sh
@@ -23,6 +23,7 @@ set -euo pipefail
 
 MODEL="${GROK_MODEL:-grok-4.5}"
 EFFORT="${GROK_EFFORT:-high}"
+ENV_EFFORT="${GROK_EFFORT:-}"
 # 命令行是否显式给出 model/effort（复核轮据此决定沿用 state 还是尊重 flag；set -u 下必须先初始化）
 MODEL_EXPLICIT=0
 EFFORT_EXPLICIT=0
@@ -42,9 +43,14 @@ die() { echo "错误: $*" >&2; exit 1; }
 # effort 合法值校验（首轮入口 + 复核轮 state 读回后各调一次，单一事实源）
 check_effort() {
   case "$1" in
-    none|minimal|low|medium|high|xhigh) ;;
-    *) die "非法 effort: $1（合法: none/minimal/low/medium/high/xhigh）" ;;
+    none|minimal|low|medium|high) ;;
+    *) die "非法 effort: $1（合法: none/minimal/low/medium/high）" ;;
   esac
+}
+
+# 老版 xhigh 只允许从持久 state 迁移；新的 CLI/环境输入一律拒绝。
+is_legacy_xhigh() {
+  [[ "$1" == "xhigh" ]]
 }
 
 # 疑似敏感文件名判定（单一事实源，untracked 跳过 + tracked 告警共用）：$1=basename，命中返回 0。
@@ -123,6 +129,23 @@ state_write() {
   } > "$sw_tmp"
   chmod 600 "$sw_tmp"
   mv -f "$sw_tmp" "$STATE_FILE"
+}
+
+# 将旧 state 的 EFFORT=xhigh 原子迁到 high，同时逐行保留 SID 和其余字段。
+migrate_legacy_effort() {
+  local sw_tmp line
+  [[ -f "$STATE_FILE" ]] || return 0
+  sw_tmp=$(mktemp "$STATE_DIR/.tmp.XXXXXX") || die "mktemp 失败"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" == EFFORT=xhigh ]]; then
+      printf 'EFFORT=high\n'
+    else
+      printf '%s\n' "$line"
+    fi
+  done < "$STATE_FILE" > "$sw_tmp"
+  chmod 600 "$sw_tmp"
+  mv -f "$sw_tmp" "$STATE_FILE"
+  echo "警告: 已将旧 session 的 EFFORT=xhigh 迁移为 high。" >&2
 }
 
 # 首轮：拉 PR 元信息 + 全量 diff，组装 prompt-file。设 PROMPT_FILE 全局变量暴露路径。
@@ -341,6 +364,11 @@ FOLLOWUP_MODE=0
 if (( ! FOLLOWUP_MODE )) || (( EFFORT_EXPLICIT )); then
   check_effort "$EFFORT"
 fi
+# 环境变量也是新输入；xhigh 即使复核轮会优先读 state 也必须在调用 grok 前拒绝。
+# 其他旧环境脏值仍不可挡住合法 state 回放，维持既有兼容行为。
+if (( FOLLOWUP_MODE )) && (( ! EFFORT_EXPLICIT )) && is_legacy_xhigh "$ENV_EFFORT"; then
+  die "非法 effort: xhigh（合法: none/minimal/low/medium/high）"
+fi
 # MODEL 同理：首轮或显式 --model 立即校验；复核轮非显式推迟到 state 读回后校验最终值
 if (( ! FOLLOWUP_MODE )) || (( MODEL_EXPLICIT )); then
   check_model "$MODEL"
@@ -397,9 +425,15 @@ if (( FOLLOWUP_MODE )); then
   if (( ! MODEL_EXPLICIT )); then
     _s=$(state_get MODEL); [[ -n "$_s" ]] && { check_model "$_s"; MODEL="$_s"; }
   fi
-  if (( ! EFFORT_EXPLICIT )); then
-    _s=$(state_get EFFORT)
-    [[ -n "$_s" ]] && { check_effort "$_s"; EFFORT="$_s"; }
+  _s=$(state_get EFFORT)
+  if is_legacy_xhigh "$_s"; then
+    # 旧 state 是唯一允许出现 xhigh 的来源：保留其余 state 字段并在调用 grok 前完成迁移。
+    migrate_legacy_effort
+    _s=high
+  fi
+  if (( ! EFFORT_EXPLICIT )) && [[ -n "$_s" ]]; then
+    check_effort "$_s"
+    EFFORT="$_s"
   fi
   # 校验最终生效的 MODEL/EFFORT（覆盖 state 无值却 env GROK_MODEL/GROK_EFFORT 非法的情形）
   check_model "$MODEL"

--- a/plugins/pr-review/tests/grok-review.bats
+++ b/plugins/pr-review/tests/grok-review.bats
@@ -658,3 +658,65 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"无法获取 PR #42 head"* ]]
 }
+
+# ---------- 14. effort 收敛：xhigh 只允许作为旧 state 一次性迁移 ----------
+
+@test "effort: 新 CLI 输入 xhigh 在调用 grok 前被拒绝" {
+  run bash "$SCRIPT" 42 --effort xhigh
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"非法 effort: xhigh"* ]]
+  [ ! -f "$GROK_ARGS_LOG" ]
+}
+
+@test "effort: 新环境输入 xhigh 在调用 grok 前被拒绝" {
+  run env GROK_EFFORT=xhigh bash "$SCRIPT" 42
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"非法 effort: xhigh"* ]]
+  [ ! -f "$GROK_ARGS_LOG" ]
+}
+
+@test "effort: 所有有效值精确转发给 grok" {
+  for effort in none minimal low medium high; do
+    rm -f "$GROK_ARGS_LOG"
+    run bash "$SCRIPT" 42 --effort "$effort"
+    [ "$status" -eq 0 ]
+    [ "$(get_arg_value "$GROK_ARGS_LOG" "--effort")" = "$effort" ]
+  done
+}
+
+@test "effort: 旧 state xhigh 迁移为 high，保留 SID 和其他字段并设为 600" {
+  mkdir -p "$STATE_DIR"; chmod 700 "$STATE_DIR"
+  cwd=$(git -C "$WORK/repo" rev-parse --show-toplevel)
+  printf 'SID=SID-LEGACY\nMODEL=grok-4.5\nEFFORT=xhigh\nCWD=%s\nBASE_SHA=\nCREATED=123\n' "$cwd" > "$STATE_FILE_42"
+  chmod 644 "$STATE_FILE_42"
+  run env -u GROK_EFFORT bash "$SCRIPT" 42 --followup "复核"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"迁移为 high"* ]]
+  grep -qx 'SID=SID-LEGACY' "$STATE_FILE_42"
+  grep -qx 'MODEL=grok-4.5' "$STATE_FILE_42"
+  grep -qx 'EFFORT=high' "$STATE_FILE_42"
+  grep -qx "CWD=$cwd" "$STATE_FILE_42"
+  grep -qx 'BASE_SHA=' "$STATE_FILE_42"
+  grep -qx 'CREATED=123' "$STATE_FILE_42"
+  [ "$(get_perm "$STATE_FILE_42")" = "600" ]
+  [ "$(get_arg_value "$GROK_ARGS_LOG" "--effort")" = "high" ]
+}
+
+@test "effort: 显式有效值优先于旧 state，但仍迁移 xhigh" {
+  mkdir -p "$STATE_DIR"; chmod 700 "$STATE_DIR"
+  printf 'SID=SID-PRECEDENCE\nMODEL=grok-4.5\nEFFORT=xhigh\nCWD=%s\nBASE_SHA=\nCREATED=1\n' "$(git -C "$WORK/repo" rev-parse --show-toplevel)" > "$STATE_FILE_42"
+  run bash "$SCRIPT" 42 --followup "复核" --effort medium
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"迁移为 high"* ]]
+  grep -qx 'EFFORT=high' "$STATE_FILE_42"
+  [ "$(get_arg_value "$GROK_ARGS_LOG" "--effort")" = "medium" ]
+}
+
+@test "effort: 复核轮非显式环境 xhigh 即使 state 合法也在调用 grok 前被拒绝" {
+  mkdir -p "$STATE_DIR"; chmod 700 "$STATE_DIR"
+  printf 'SID=SID-VALID\nMODEL=grok-4.5\nEFFORT=high\nCWD=%s\nBASE_SHA=\nCREATED=1\n' "$(git -C "$WORK/repo" rev-parse --show-toplevel)" > "$STATE_FILE_42"
+  run env GROK_EFFORT=xhigh bash "$SCRIPT" 42 --followup "复核"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"非法 effort: xhigh"* ]]
+  [ ! -f "$GROK_ARGS_LOG" ]
+}


### PR DESCRIPTION
## Summary
- reject `xhigh` for new Grok CLI and environment inputs
- migrate persisted legacy `EFFORT=xhigh` session state to `high`
- align BDD coverage, public docs, and plugin metadata at v1.0.2

## Verification
- `bash -n plugins/pr-review/skills/pr-review/scripts/grok-review.sh`
- `bats plugins/pr-review/tests/grok-review.bats` (66/66 passed)
- plugin validator
- `git diff --check`

Fixes #186