### PR TITLE
feat(deep-research): deterministic sanitized harvest handoff

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "deep-research",
       "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate + deterministic report.md -> report.html renderer",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/deep-research/.claude-plugin/plugin.json
+++ b/plugins/deep-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "description": "Deep research framework — 7-Stage pipeline + role-specialized subagents (harvester/analyst/reviewer/publisher) + multi-model harvest & citation-verification gate + deterministic report.md -> report.html renderer",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/deep-research"],
   "agents": [

--- a/plugins/deep-research/CLAUDE.md
+++ b/plugins/deep-research/CLAUDE.md
@@ -9,6 +9,7 @@
 | 模块 | 职责 |
 |------|------|
 | `scripts/harvest.py` | 主编排：pipeline / worker / judge / merge / verify / CLI |
+| `scripts/harvest_handoff.py` | harvest 交接：WIP 校验、compact manifest 与 evidence ledger、hash 绑定。本模块是零外部依赖叶子，不 import harvest。 |
 | `scripts/harvest_safety.py` | SSRF 守卫 / 域黑名单 / 路径沙箱 / 限流 / URL 规范化（零外部依赖叶子） |
 | `scripts/harvest_search/` | 3 个 web search backend（gemini-grounding/tavily/duckduckgo）+ do_search 编排 |
 | `scripts/harvest_search/social.py` | 独立社交搜索链（search_social tool，backend-agnostic，现仅 grok-x） |

--- a/plugins/deep-research/README.md
+++ b/plugins/deep-research/README.md
@@ -16,7 +16,7 @@ The methodology (skill + subagents) works out of the box. The **multi-model harv
 
 | Dependency | Needed for | How |
 |------------|-----------|-----|
-| `GATEWAY_API_KEY` (env) | harvest.py panel models (gemini/gpt/claude via your OpenAI-compatible gateway) **and the primary `gemini-grounding` search backend** | Set gateway `base_url` + key in `scripts/harvest.config.json` / env |
+| `GATEWAY_API_KEY` (env) | harvest.py configured panel (`panel_models` in `scripts/harvest.config.json`, via your OpenAI-compatible gateway) **and the primary `gemini-grounding` search backend** | Set gateway `base_url` + key in `scripts/harvest.config.json` / env |
 | `curl_cffi` (Python, optional) | `curl-cffi` fetch backend (direct free fetch) | `pip3 install --user curl_cffi` — else harvest.py exits 4 with install hint |
 | `TAVILY_API_KEY` / `JINA_API_KEY` (env, optional) | tavily/jina search & fetch fallbacks | Set as env vars if used |
 | `grok` CLI (optional, `grok login`) | `grok-4.5` panel model + `grok-x` social search backend | Install locally + authenticate; if absent, `grok-*` panel models and `grok-x` social backends are dropped/skipped and the pipeline still completes |

--- a/plugins/deep-research/agents/research-analyst.md
+++ b/plugins/deep-research/agents/research-analyst.md
@@ -31,6 +31,8 @@ color: blue
 
 **铁律**：禁止读 `pipeline/1_raw/`，禁止修改 `pipeline/2_cleaned/`。
 
+handoff-enabled track 的消费顺序：先读 `pipeline/2_cleaned/harvest-manifest.json`。应无条件展开 manifest 标出的 anomaly ranges。再按目标选其余 ledger ranges。仍可读其他 `2_cleaned` 文件。旧项目 / local / legacy 继续全量读 cleaned。不应重算 consensus 标签。schema 权威在 `scripts/harvest_handoff.py`。
+
 ## 输出
 
 | 产物 | 目录 | Stage |
@@ -50,7 +52,7 @@ color: blue
 按业务领域分割 cleaned 数据，每域产出独立分析文件。
 
 **执行步骤**：
-1. 扫描 `pipeline/2_cleaned/` 全部文件，建立内容索引
+1. 若存在 `harvest-manifest.json`，先读 manifest，展开 anomaly ranges，再按目标选其余 ledger ranges。否则扫描 `pipeline/2_cleaned/` 全部文件，建立内容索引
 2. 按 Lead 指定的域划分（或自动识别域边界）
 3. 每域产出一个独立文件到 `pipeline/3_structured/`
 4. 域文件命名：`YYYYMMDD_HHMMSS_domain_{domain_name}.md`

--- a/plugins/deep-research/agents/research-harvester.md
+++ b/plugins/deep-research/agents/research-harvester.md
@@ -37,19 +37,19 @@ Lead 的采集指令，必须包含：
 
 ## 工具链
 
-**主路径：多模型采集脚本（异构 gemini/gpt/claude 三面板并行）**
+**主路径：configured panel 采集脚本（`harvest.config.json` 的 `panel_models` + `quorum`）**
 
-项目启用多模型采集脚本时，harvester 的职责从「自己搜索」转为「驱动脚本 + 解读产物」：
+项目启用多模型采集脚本时，harvester 的职责从「自己搜索」转为「驱动脚本 + 完成确定性交接」：
 
-执行多模型采集时，使用 **Lead 在 Task 指令中提供的 harvest.py 绝对路径**（Lead 已通过 deep-research skill 的路径发现约定解析出该路径）。命令形如 `python3 <Lead提供的harvest.py绝对路径> run --goal-file <goal-file> --out pipeline/1_raw/`。若 Task 指令未提供该路径，向 Lead 索要，不要自行猜测或硬编码。
+执行采集时，使用 **Lead 在 Task 指令中提供的 harvest.py 绝对路径**（Lead 已通过 deep-research skill 的路径发现约定解析出该路径）。命令形如 `python3 <Lead提供的harvest.py绝对路径> run --goal-file <goal-file> --out pipeline/1_raw/`。若 Task 指令未提供该路径，向 Lead 索要，不要自行猜测或硬编码。
 
 | 步骤 | 动作 | 产物/落点 |
 |------|------|----------|
 | 1 | 准备 `research-goal.md` 对应的 goal-file（研究目标/范围/约束） | 传给 `harvest.py run --goal-file` |
 | 2 | 准备本地材料（可选）：PDF 等二进制先转文本，**前置完成 L1/L2 脱敏**后放入 `intake/local_sources/` | 见下「本地材料前置脱敏」 |
-| 3 | 执行 `python3 <harvest.py绝对路径> run --goal-file <goal-file> --out pipeline/1_raw/` | `pipeline/1_raw/harvest/<model>/findings.json`、`merged-findings.json`、`fetch-report.md`、`pipeline/verification/harvest-verify.json` |
-| 4 | 解读 merged 输出：共识标签、coverage_gaps、blind_spots | 补采裁判指出的 gaps（若有） |
-| 5 | 执行 Sanitization（脱敏落盘到 `pipeline/2_cleaned/`） | 同现行流程 |
+| 3 | 执行 `python3 <harvest.py绝对路径> run --goal-file <goal-file> --out pipeline/1_raw/` | `pipeline/1_raw/harvest/<model>/findings.json`、`merged-findings.json`、`fetch-report.md`、`pipeline/verification/harvest-verify.json`（`verdict=OK`，`handoff_status=PENDING_SANITIZATION`） |
+| 4 | 读 merged 的 `coverage_gaps` / `blind_spots`，按需补采。不应解读 consensus 标签——标签由 `finalize-handoff` 写入 manifest，不是 raw merge 产物 | 补采裁判指出的 gaps（若有） |
+| 5 | 对 raw merged 做 L1/L2 脱敏，写 WIP，再 finalize | `pipeline/2_cleaned/harvest-handoff.wip.json`（supplementary：`track_<raw_dir.name>-harvest-handoff.wip.json`；unclustered 脱敏正文走 `unclustered_claims`），然后 `python3 harvest.py finalize-handoff --project-dir <proj> --out <raw_dir> --wip <wip>`。primary 正式产物：`harvest-manifest.json` + `harvest-evidence.jsonl`。verify 变为 `READY` 后才可请求 G1 |
 
 **单模型 step 预算耗尽 = 强制收尾，非该模型失败**：每个 panel 模型的 agentic loop 有 `max_steps_per_model` 轮工具预算。预算耗尽时 harvest.py **不丢弃该模型已 fetch 的证据**，而是强制发一次收尾 synthesis 调用（用 prompt 指令要求模型停止调工具、把已采证据收敛成 findings，tools 块保持不变以稳住 KV-cache 前缀），再走引用机械门校验；只有收尾仍无合法产出才判该模型 `step_limit_no_synthesis` 失败。因此单个模型跑到步数上限通常仍会贡献有效 claims，不必视为异常——真正影响整轮的是存活模型数是否达 quorum（见下 exit 3）。
 
@@ -103,7 +103,7 @@ Lead 的采集指令，必须包含：
 
 现行脱敏协议是「采集后脱敏」（`1_raw` → `2_cleaned`）。本地内部材料（`intake/local_sources/`）走 harvest.py 的 `read_local` 工具时是**唯一例外**：脱敏必须**前移到进入该目录之前**完成。
 
-原因：面板模型调用 = 内容上传外部聚合网关。一旦文件放进 `intake/local_sources/`，harvest.py 就会把它原文喂给 gemini/gpt/claude 三个外部面板模型——脱敏晚一步就是脱敏前已外发。因此：
+原因：面板模型调用 = 内容上传外部聚合网关。一旦文件放进 `intake/local_sources/`，harvest.py 就会把它原文喂给 configured panel 的存活模型——脱敏晚一步就是脱敏前已外发。因此：
 
 - 凡进入 `local_sources/` 的内容，必须先完成 L1/L2 脱敏（豁免清单同上）或命中豁免清单，才允许落盘
 - `scripts/harvest.config.json` 需显式 `local_sources.enabled = true` 才启用本地材料链路，默认 `false`，防误传
@@ -143,7 +143,7 @@ Lead 的采集指令，必须包含：
 - 候选基数: N (selection 类型须 ≥ 3，否则 G1 强制补搜)
 - 饱和轮次记录: [最近 2 轮有无新候选类别；无则 "saturation reached after N rounds"]
 ## 多模型参与情况（仅 harvest.py 项目；legacy 链填 N/A）
-- 参与模型: [gemini/gpt/claude 存活列表]
+- 参与模型: [configured panel 存活列表]
 - 法定人数状态: quorum_met (true/false)，未达标时列出缺席模型及原因
 ## 引用校验统计（仅 harvest.py 项目；legacy 链填 N/A）
 - 校验总数: N
@@ -179,7 +179,7 @@ Lead 的采集指令，必须包含：
 | 7 | 检查 verify-local exit code：exit 0 → 继续；exit 1 → 上报 Lead | — |
 | 8 | 写 `harvest/local/findings.json`（覆写 placeholder，标准 schema）| `pipeline/1_raw/harvest/local/findings.json` |
 | 9 | 写 `merged-findings.json`（覆写 placeholder，单源 flat clusters）| `pipeline/1_raw/merged-findings.json` |
-| 10 | 执行 Sanitization（同标准流程） | `pipeline/2_cleaned/` |
+| 10 | 执行 Sanitization（同标准流程）。local / `--no-api` **不**走 v1 确定性交接 | `pipeline/2_cleaned/` |
 
 **claims.json schema**（verify-local 输入）：
 
@@ -221,6 +221,7 @@ Lead 的采集指令，必须包含：
 - 无多模型交叉验证（单源）；reviewer 的 G1 Sufficiency Gate 会看到 `mode: "local"` 标记
 - citation verification 由 `verify-local` 子命令执行（确定性代码，非 LLM）
 - 脱敏按标准 post-acquisition 流程（local mode 不外发内容到第三方 LLM，无前置脱敏需求）
+- 不写 `handoff_*` 字段，不跑 `finalize-handoff`。`check_project()` 对 `verdict=LOCAL` 返回 N/A
 
 ---
 

--- a/plugins/deep-research/agents/research-harvester.md
+++ b/plugins/deep-research/agents/research-harvester.md
@@ -49,7 +49,7 @@ Lead 的采集指令，必须包含：
 | 2 | 准备本地材料（可选）：PDF 等二进制先转文本，**前置完成 L1/L2 脱敏**后放入 `intake/local_sources/` | 见下「本地材料前置脱敏」 |
 | 3 | 执行 `python3 <harvest.py绝对路径> run --goal-file <goal-file> --out pipeline/1_raw/` | `pipeline/1_raw/harvest/<model>/findings.json`、`merged-findings.json`、`fetch-report.md`、`pipeline/verification/harvest-verify.json`（`verdict=OK`，`handoff_status=PENDING_SANITIZATION`） |
 | 4 | 读 merged 的 `coverage_gaps` / `blind_spots`，按需补采。不应解读 consensus 标签——标签由 `finalize-handoff` 写入 manifest，不是 raw merge 产物 | 补采裁判指出的 gaps（若有） |
-| 5 | 对 raw merged 做 L1/L2 脱敏，写 WIP，再 finalize | `pipeline/2_cleaned/harvest-handoff.wip.json`（supplementary：`track_<raw_dir.name>-harvest-handoff.wip.json`；unclustered 脱敏正文走 `unclustered_claims`），然后 `python3 harvest.py finalize-handoff --project-dir <proj> --out <raw_dir> --wip <wip>`。primary 正式产物：`harvest-manifest.json` + `harvest-evidence.jsonl`。verify 变为 `READY` 后才可请求 G1 |
+| 5 | 对 raw merged 做 L1/L2 脱敏，写 WIP，再 finalize | `pipeline/2_cleaned/harvest-handoff.wip.json`（supplementary：`track_<raw_dir.name>-harvest-handoff.wip.json`；unclustered 脱敏正文走 `unclustered_claims`；`coverage_gaps` / `blind_spots` 只核条数，正文以 WIP 脱敏文本为准），然后 `python3 harvest.py finalize-handoff --project-dir <proj> --out <raw_dir> --wip <wip>`。primary 正式产物：`harvest-manifest.json` + `harvest-evidence.jsonl`。verify 变为 `READY` 后才可请求 G1 |
 
 **单模型 step 预算耗尽 = 强制收尾，非该模型失败**：每个 panel 模型的 agentic loop 有 `max_steps_per_model` 轮工具预算。预算耗尽时 harvest.py **不丢弃该模型已 fetch 的证据**，而是强制发一次收尾 synthesis 调用（用 prompt 指令要求模型停止调工具、把已采证据收敛成 findings，tools 块保持不变以稳住 KV-cache 前缀），再走引用机械门校验；只有收尾仍无合法产出才判该模型 `step_limit_no_synthesis` 失败。因此单个模型跑到步数上限通常仍会贡献有效 claims，不必视为异常——真正影响整轮的是存活模型数是否达 quorum（见下 exit 3）。
 

--- a/plugins/deep-research/agents/research-reviewer.md
+++ b/plugins/deep-research/agents/research-reviewer.md
@@ -74,6 +74,7 @@ receipt。
 - **候选集完备性**（G1，仅选型类）：候选基数 < 3 未补搜、或未做饱和判定 → 不通过
 - **RECYCLE**：G3 假设审计发现双环学习（结论推翻原始问题假设）→ 裁决 RECYCLE，强制回退 G0 重校准（区别于 FAIL 的原阶段补充）
 - **前提/判据 FAIL**（G3）：假设审计有 Unsupported 前提撑核心结论、或证伪审计任一子项（反驳搜索/cite 回链/证伪不可省）不通过 → FAIL
+- **G1 引用校验机械门**：宣称 `GATE_VERDICT: G1 PASS` 前，应跑 `python3 <harvest.py 路径> check <project-dir>`。handoff-enabled 的 panel 路径须为 `READY`。`PENDING_SANITIZATION`、残缺 marker、hash mismatch 均为 FAIL，阻塞 PASS。旧记录三字段全缺走原表。local / exemption / 无 verify 仍为 N/A。细则见 deep-research skill 的 references/quality-gates.md。不复制 schema。
 - 未通过时**必须**指出：哪个维度不足、当前分数、达标所需的具体改进
 
 ### Gate 评分输出格式

--- a/plugins/deep-research/docs/main-session-isolation-contracts.md
+++ b/plugins/deep-research/docs/main-session-isolation-contracts.md
@@ -31,7 +31,8 @@
     `echo "$(<file)"`），且目标指向受管路径，则拦截。
 - **白名单放行**（小指针文件，主 session 可合法持有）：文件名匹配 `research-goal.md`、
   `*-manifest.*`、`*-receipt.*`、`INDEX.md`、`*.verdict`、`*-verdict.md`；或文件体积低于阈值
-  （建议 8KB，即指针与 receipt 的量级）。
+  （8KB，即指针与 receipt 的量级）。边界：`harvest-manifest.json` 命中既有 `*-manifest.*`，按白名单放行。
+  `harvest-evidence.jsonl` 与 `*-harvest-evidence.jsonl` 在体积阈值判定之前拒绝，即使远小于 8KiB。
 - **fail-open 硬约束**（任一条成立即放行，never break userspace）：非 deep-research 项目
   （查不到 `pipeline/`）；目标非受管路径；命中白名单；路径解析异常；Bash 命令解析不出明确的
   读大文件意图（不误伤 grep 检索、ls、find、git）。**fail-open 落在项目层、路径层与白名单层，

--- a/plugins/deep-research/hooks/read_guard.py
+++ b/plugins/deep-research/hooks/read_guard.py
@@ -77,6 +77,10 @@ def _locate_project_root(start: Path):
 def _is_whitelisted(abs_path: str) -> bool:
     """小指针文件放行判定：文件名匹配白名单，或体积低于阈值。"""
     base = os.path.basename(abs_path)
+    # Evidence ledger is line-addressable raw claims — never a Lead pointer,
+    # even when the file is far below the 8KiB receipt threshold.
+    if base == "harvest-evidence.jsonl" or base.endswith("-harvest-evidence.jsonl"):
+        return False
     if base in _WHITELIST_BASENAMES:
         return True
     for pat in _WHITELIST_PATTERNS:

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -121,6 +121,7 @@ def _emit(event, **kw):
         pass
 
 
+import harvest_handoff
 from harvest_safety import (  # re-export: safety layer moved to its own module
     RateLimiter,
     SSRFBlocked,
@@ -921,9 +922,11 @@ def merge_findings(worker_findings_by_alias, judge_data):
     # dedup_notes. The judge prompt asks for this too, but this invariant
     # must hold even if the judge ignores the instruction.
     all_claims = {}
+    source_of = {}
     for alias, data in worker_findings_by_alias.items():
         for c in data["claims"]:
             all_claims[c["_id"]] = c
+            source_of[c["_id"]] = alias
 
     clusters_out = []
     claimed_ids = set()
@@ -955,10 +958,29 @@ def merge_findings(worker_findings_by_alias, judge_data):
                 "url": c.get("url", ""),
                 "language": c.get("language", "unknown"),
                 "credibility": c.get("credibility", 3),
+                "source_model": source_of[cid],
             })
-        clusters_out.append({"summary": summary, "claims": assembled})
+        clusters_out.append({
+            "cluster_id": f"c{len(clusters_out) + 1:03d}",
+            "summary": summary,
+            "relation": relation,
+            "claims": assembled,
+        })
 
     unique_insights = [cid for cid in judge_data.get("unique_insights", []) if cid in all_claims]
+    unclustered_claim_ids = sorted(cid for cid in all_claims if cid not in claimed_ids)
+    unclustered_claims = []
+    for cid in unclustered_claim_ids:
+        c = all_claims[cid]
+        unclustered_claims.append({
+            "id": cid,
+            "claim": c.get("claim", ""),
+            "excerpt": c.get("excerpt", ""),
+            "url": c.get("url", ""),
+            "language": c.get("language", "unknown"),
+            "credibility": c.get("credibility", 3),
+            "source_model": source_of[cid],
+        })
     return {
         "clusters": clusters_out,
         "coverage_gaps": judge_data.get("coverage_gaps", []),
@@ -966,6 +988,8 @@ def merge_findings(worker_findings_by_alias, judge_data):
         "blind_spots": judge_data.get("blind_spots", []),
         "contradictions": contradictions,
         "dedup_notes": dedup_notes,
+        "unclustered_claim_ids": unclustered_claim_ids,
+        "unclustered_claims": unclustered_claims,
     }
 
 
@@ -1011,6 +1035,7 @@ def cleanup_stale_state(pipeline_dir, verify_dir, raw_dir):
     harvest_dir = raw_dir / HARVEST_SUBDIR
     if harvest_dir.exists():
         shutil.rmtree(harvest_dir)
+    _unlink_handoff_artifacts(pipeline_dir / "2_cleaned")
 
 
 def track_verify_filename(raw_dir):
@@ -1037,6 +1062,30 @@ def cleanup_stale_supplementary_state(verify_dir, raw_dir, verify_filename):
     harvest_dir = raw_dir / HARVEST_SUBDIR
     if harvest_dir.exists():
         shutil.rmtree(harvest_dir)
+    _unlink_handoff_artifacts(_cleaned_dir_from_raw(raw_dir), track_name=raw_dir.name)
+
+
+def _cleaned_dir_from_raw(raw_dir):
+    """pipeline/2_cleaned next to 1_raw, even when --out is nested under 1_raw."""
+    node = Path(raw_dir)
+    while node.name and node.name != "pipeline":
+        if node.parent == node:
+            return Path(raw_dir).parent / "2_cleaned"
+        node = node.parent
+    if node.name == "pipeline":
+        return node / "2_cleaned"
+    return Path(raw_dir).parent / "2_cleaned"
+
+
+def _unlink_handoff_artifacts(cleaned_dir, track_name=None):
+    if cleaned_dir is None:
+        return
+    target = Path(cleaned_dir)
+    names = harvest_handoff.artifact_names(track_name)
+    for name in names.values():
+        path = target / name
+        if path.is_file():
+            path.unlink()
 
 
 # ---------------------------------------------------------------------------
@@ -1072,6 +1121,16 @@ def check_project(project_dir):
     if verdict != "OK":
         return "FAIL", f"unknown or incomplete verdict: {verdict!r}"
 
+    # Handoff negotiation only runs on OK records, after exemption / missing
+    # / unreadable / UNAVAILABLE / LOCAL / not-OK. Three fields all absent
+    # keeps the historical path byte-for-byte.
+    negotiated = _negotiate_handoff(project_dir, data)
+    if negotiated is not None:
+        return negotiated
+    return _evaluate_ok_verify(project_dir, data)
+
+
+def _evaluate_ok_verify(project_dir, data):
     goal_note = None
     goal_file = resolve_goal_file(project_dir)
     if goal_file is not None:
@@ -1106,6 +1165,72 @@ def check_project(project_dir):
         return "FAIL", f"invalid_citation_rate {invalid_rate} exceeds 0.05 with {invalid_count} rejected claims"
 
     return "PASS", goal_note or "ok"
+
+
+_HANDOFF_KEYS = ("handoff_version", "handoff_required", "handoff_status")
+
+
+def _negotiate_handoff(project_dir, data):
+    present = [key for key in _HANDOFF_KEYS if key in data]
+    if not present:
+        return None
+    if len(present) != 3:
+        return "FAIL", "handoff marker incomplete"
+    if data.get("handoff_version") != 1:
+        return "FAIL", "handoff_version must be 1"
+    if data.get("handoff_required") is not True:
+        return "FAIL", "handoff_required must be true"
+    status = data.get("handoff_status")
+    if status == "PENDING_SANITIZATION":
+        return "FAIL", "handoff pending sanitization"
+    if status != "READY":
+        return "FAIL", f"handoff_status not READY: {status!r}"
+    legacy = _evaluate_ok_verify(project_dir, data)
+    if legacy[0] != "PASS":
+        return legacy
+    return _check_primary_handoff_ready(project_dir, data)
+
+
+def _check_primary_handoff_ready(project_dir, data):
+    """Primary artifacts only — never track_*. Delegates schema/hash to harvest_handoff."""
+    try:
+        return _check_primary_handoff_ready_inner(project_dir, data)
+    except harvest_handoff.HandoffError as exc:
+        return "FAIL", str(exc)
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
+        return "FAIL", f"handoff artifact unreadable: {exc}"
+
+
+def _check_primary_handoff_ready_inner(project_dir, data):
+    pipeline = Path(project_dir) / "pipeline"
+    raw_path = pipeline / "1_raw" / MERGED_FINDINGS_FILE
+    man_path = pipeline / "2_cleaned" / "harvest-manifest.json"
+    ev_path = pipeline / "2_cleaned" / "harvest-evidence.jsonl"
+    for path, label in ((raw_path, "merged-findings.json"),
+                        (man_path, "harvest-manifest.json"),
+                        (ev_path, "harvest-evidence.jsonl")):
+        if not path.is_file():
+            return "FAIL", f"handoff artifact missing: {label}"
+    try:
+        raw = json.loads(raw_path.read_text(encoding="utf-8"))
+        manifest = json.loads(man_path.read_text(encoding="utf-8"))
+        evidence_text = ev_path.read_text(encoding="utf-8")
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
+        return "FAIL", f"handoff artifact unreadable: {exc}"
+    goal_file = resolve_goal_file(project_dir)
+    goal_hash = hashlib.sha256(goal_file.read_bytes()).hexdigest() if goal_file is not None else data.get("goal_file_sha256", "")
+    harvest_handoff.check_ready_payloads(
+        verify=data,
+        raw=raw,
+        manifest=manifest,
+        evidence_text=evidence_text,
+        goal_sha256=goal_hash,
+        raw_sha256=harvest_handoff.file_sha256(raw_path),
+        manifest_sha256=harvest_handoff.file_sha256(man_path),
+        evidence_sha256=harvest_handoff.file_sha256(ev_path),
+    )
+    harvest_handoff.check_ready_invariants(raw, manifest, evidence_text)
+    return "PASS", "ok"
 
 
 # ---------------------------------------------------------------------------
@@ -1646,6 +1771,9 @@ def cmd_run(args):
             "invalid_claim_count": invalid_total,
             "total_claims": total_claims,
             "harvest_wall_s": harvest_wall_s,
+            "handoff_version": 1,
+            "handoff_required": True,
+            "handoff_status": "PENDING_SANITIZATION",
         }, verify_filename=verify_filename)
         _emit("run_done", verdict=verdict, total_claims=total_claims, invalid_rate=round(invalid_rate, 4))
         print(f"harvest run complete: verdict={verdict}")
@@ -1760,6 +1888,96 @@ def cmd_verify_local(args):
         sys.exit(1)
 
 
+def _resolve_handoff_paths(project_dir, raw_dir):
+    """Primary vs supplementary + verify filename, without goal-file matching."""
+    project_dir = Path(project_dir).resolve()
+    raw_dir = Path(raw_dir)
+    pipeline_dir = project_dir / "pipeline"
+    verify_dir = pipeline_dir / "verification"
+    is_supplementary = raw_dir.resolve() != (pipeline_dir / "1_raw").resolve()
+    verify_filename = track_verify_filename(raw_dir) if is_supplementary else VERIFY_FILE
+    return project_dir, pipeline_dir, verify_dir, is_supplementary, verify_filename
+
+
+def _assert_inside_project(path, project_dir, label):
+    resolved = Path(path).resolve()
+    if not _is_relative_to(resolved, project_dir):
+        raise harvest_handoff.HandoffError(f"{label} outside project: {resolved}")
+    return resolved
+
+
+def cmd_finalize_handoff(args):
+    """Publish WIP → evidence + manifest, then bind READY hashes on verify."""
+    try:
+        _finalize_handoff(args)
+    except harvest_handoff.HandoffError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _finalize_handoff(args):
+    project_dir, pipeline_dir, verify_dir, is_supplementary, verify_filename = (
+        _resolve_handoff_paths(args.project_dir, args.out)
+    )
+    raw_dir = Path(args.out)
+    cleaned_dir = pipeline_dir / "2_cleaned"
+    track_name = raw_dir.name if is_supplementary else None
+    names = harvest_handoff.artifact_names(track_name)
+
+    wip_path = _assert_inside_project(args.wip, project_dir, "wip")
+    cleaned_dir = _assert_inside_project(cleaned_dir, project_dir, "cleaned")
+    raw_merged = _assert_inside_project(raw_dir / MERGED_FINDINGS_FILE, project_dir, "raw")
+    verify_path = _assert_inside_project(verify_dir / verify_filename, project_dir, "verify")
+    manifest_path = cleaned_dir / names["manifest"]
+    evidence_path = cleaned_dir / names["evidence"]
+    _assert_inside_project(manifest_path, project_dir, "manifest")
+    _assert_inside_project(evidence_path, project_dir, "evidence")
+
+    raw = json.loads(raw_merged.read_text(encoding="utf-8"))
+    wip = json.loads(wip_path.read_text(encoding="utf-8"))
+    verify = json.loads(verify_path.read_text(encoding="utf-8"))
+    harvest_handoff.validate_wip(wip)
+    harvest_handoff.check_coverage(wip, raw)
+
+    goal_hash = verify.get("goal_file_sha256") or ""
+    goal_file = resolve_goal_file(project_dir)
+    if goal_file is not None:
+        goal_hash = hashlib.sha256(goal_file.read_bytes()).hexdigest()
+    raw_hash = harvest_handoff.file_sha256(raw_merged)
+    alive = list(verify.get("models_alive") or [])
+
+    harvest_handoff.publish_handoff(
+        cleaned_dir, wip, raw,
+        goal_file_sha256=goal_hash,
+        raw_merged_sha256=raw_hash,
+        alive_models=alive,
+        track_name=track_name,
+    )
+    evidence_hash = harvest_handoff.file_sha256(evidence_path)
+    manifest_hash = harvest_handoff.file_sha256(manifest_path)
+
+    extra = dict(verify)
+    extra.update({
+        "handoff_version": 1,
+        "handoff_required": True,
+        "handoff_status": "READY",
+        "manifest_sha256": manifest_hash,
+        "evidence_sha256": evidence_hash,
+        "raw_merged_sha256": raw_hash,
+    })
+    extra.pop("verdict", None)
+    extra.pop("goal_file_sha256", None)
+    extra.pop("run_timestamp", None)
+    write_verify_json(verify_dir, goal_hash, verify.get("verdict", "OK"), extra,
+                      verify_filename=verify_filename)
+    if wip_path.exists():
+        wip_path.unlink()
+    print(f"handoff finalized: {manifest_path.name}")
+
+
 def build_arg_parser():
     parser = argparse.ArgumentParser(prog="harvest.py")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -1793,6 +2011,13 @@ def build_arg_parser():
     verify_local_p.add_argument("--manifest", required=True)
     verify_local_p.add_argument("--out", required=True)
     verify_local_p.set_defaults(func=cmd_verify_local)
+
+    finalize_p = sub.add_parser("finalize-handoff")
+    finalize_p.add_argument("--project-dir", required=True)
+    finalize_p.add_argument("--out", required=True,
+                            help="raw_dir; same primary vs supplementary rule as run")
+    finalize_p.add_argument("--wip", required=True)
+    finalize_p.set_defaults(func=cmd_finalize_handoff)
 
     return parser
 

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -946,6 +946,8 @@ def merge_findings(worker_findings_by_alias, judge_data):
             continue
         claimed_ids.update(ids)
         relation = cluster.get("relation", "agree")
+        if relation not in ("agree", "contradict"):
+            relation = "contradict"
         if relation == "contradict":
             contradictions.append(summary)
         assembled = []
@@ -1081,7 +1083,11 @@ def _unlink_handoff_artifacts(cleaned_dir, track_name=None):
     if cleaned_dir is None:
         return
     target = Path(cleaned_dir)
-    names = harvest_handoff.artifact_names(track_name)
+    try:
+        names = harvest_handoff.artifact_names(track_name)
+    except harvest_handoff.HandoffError:
+        # Fail-open: skip handoff unlink rather than crash cmd_run cleanup.
+        return
     for name in names.values():
         path = target / name
         if path.is_file():

--- a/plugins/deep-research/scripts/harvest.py
+++ b/plugins/deep-research/scripts/harvest.py
@@ -1070,11 +1070,11 @@ def _cleaned_dir_from_raw(raw_dir):
     node = Path(raw_dir)
     while node.name and node.name != "pipeline":
         if node.parent == node:
-            return Path(raw_dir).parent / "2_cleaned"
+            return None
         node = node.parent
     if node.name == "pipeline":
         return node / "2_cleaned"
-    return Path(raw_dir).parent / "2_cleaned"
+    return None
 
 
 def _unlink_handoff_artifacts(cleaned_dir, track_name=None):
@@ -1906,6 +1906,25 @@ def _assert_inside_project(path, project_dir, label):
     return resolved
 
 
+def _assert_finalize_verify(verify):
+    """Refuse finalize unless this verify is an OK record awaiting or already READY."""
+    if not isinstance(verify, dict):
+        raise harvest_handoff.HandoffError("verify must be an object")
+    verdict = verify.get("verdict")
+    if verdict != "OK":
+        raise harvest_handoff.HandoffError(
+            f"finalize requires verdict OK, got {verdict!r}"
+        )
+    present = [key for key in _HANDOFF_KEYS if key in verify]
+    if len(present) != 3:
+        raise harvest_handoff.HandoffError("handoff marker incomplete")
+    status = verify.get("handoff_status")
+    if status not in ("PENDING_SANITIZATION", "READY"):
+        raise harvest_handoff.HandoffError(
+            f"finalize requires PENDING_SANITIZATION or READY, got {status!r}"
+        )
+
+
 def cmd_finalize_handoff(args):
     """Publish WIP → evidence + manifest, then bind READY hashes on verify."""
     try:
@@ -1925,6 +1944,8 @@ def _finalize_handoff(args):
     raw_dir = Path(args.out)
     cleaned_dir = pipeline_dir / "2_cleaned"
     track_name = raw_dir.name if is_supplementary else None
+    if is_supplementary and track_name in ("", ".", ".."):
+        raise harvest_handoff.HandoffError("invalid supplementary track_name")
     names = harvest_handoff.artifact_names(track_name)
 
     wip_path = _assert_inside_project(args.wip, project_dir, "wip")
@@ -1939,13 +1960,16 @@ def _finalize_handoff(args):
     raw = json.loads(raw_merged.read_text(encoding="utf-8"))
     wip = json.loads(wip_path.read_text(encoding="utf-8"))
     verify = json.loads(verify_path.read_text(encoding="utf-8"))
+    _assert_finalize_verify(verify)
     harvest_handoff.validate_wip(wip)
     harvest_handoff.check_coverage(wip, raw)
 
     goal_hash = verify.get("goal_file_sha256") or ""
     goal_file = resolve_goal_file(project_dir)
     if goal_file is not None:
-        goal_hash = hashlib.sha256(goal_file.read_bytes()).hexdigest()
+        current_hash = hashlib.sha256(goal_file.read_bytes()).hexdigest()
+        if current_hash != goal_hash:
+            raise harvest_handoff.HandoffError("goal_file_sha256 mismatch")
     raw_hash = harvest_handoff.file_sha256(raw_merged)
     alive = list(verify.get("models_alive") or [])
 

--- a/plugins/deep-research/scripts/harvest_handoff.py
+++ b/plugins/deep-research/scripts/harvest_handoff.py
@@ -179,8 +179,8 @@ def validate_wip(wip: Any) -> dict[str, Any]:
             raise HandoffError(f"{label}.cluster_id must be a non-empty string")
         if not isinstance(cluster["summary"], str):
             raise HandoffError(f"{label}.summary must be a string")
-        if not isinstance(cluster["relation"], str) or not cluster["relation"]:
-            raise HandoffError(f"{label}.relation must be a non-empty string")
+        if cluster["relation"] not in ("agree", "contradict"):
+            raise HandoffError(f"{label}.relation must be agree or contradict")
         if not isinstance(cluster["claims"], list) or not cluster["claims"]:
             raise HandoffError(f"{label}.claims must be a non-empty list")
         for cidx, claim in enumerate(cluster["claims"]):
@@ -295,10 +295,13 @@ def check_coverage(wip: Mapping[str, Any], raw: Mapping[str, Any]) -> None:
             raise HandoffError(f"unknown claim: {extra[0]}")
         raise HandoffError(f"missing claim: {missing[0]}")
 
-    for field in ("coverage_gaps", "blind_spots", "unique_insights"):
+    for field in ("coverage_gaps", "blind_spots"):
         raw_vals = _as_str_list(raw.get(field, []), f"raw.{field}")
-        if sorted(wip[field]) != sorted(raw_vals):
+        if len(wip[field]) != len(raw_vals):
             raise HandoffError(f"{field} coverage mismatch")
+    raw_insights = _as_str_list(raw.get("unique_insights", []), "raw.unique_insights")
+    if sorted(wip["unique_insights"]) != sorted(raw_insights):
+        raise HandoffError("unique_insights coverage mismatch")
 
 
 def supporting_models(claims: Iterable[Mapping[str, Any]]) -> list[str]:
@@ -307,7 +310,7 @@ def supporting_models(claims: Iterable[Mapping[str, Any]]) -> list[str]:
 
 def classify_consensus(relation: str, models: list[str]) -> str:
     """Navigation label only — not a truth claim."""
-    if relation == "contradict":
+    if relation != "agree":
         return "disputed"
     if len(models) >= 2:
         return "corroborated"
@@ -602,7 +605,9 @@ def atomic_write(path: Path, data: bytes) -> None:
 
 
 def artifact_names(track_name: str | None = None) -> dict[str, str]:
-    if track_name:
+    if track_name is not None:
+        if track_name in ("", ".", ".."):
+            raise HandoffError("invalid track_name")
         stem = f"track_{track_name}-"
     else:
         stem = ""
@@ -705,14 +710,11 @@ def check_published_against_raw(raw, manifest, evidence_text):
     raw_un = raw.get("unclustered_claim_ids", [])
     if sorted(raw_un) != sorted(manifest["unclustered_claim_ids"]):
         raise HandoffError("unclustered_claim_ids mismatch")
-    pairs = (
-        ("coverage_gaps", "coverage_gaps"),
-        ("blind_spots", "blind_spots"),
-        ("unique_insights", "unique_insight_ids"),
-    )
-    for raw_field, man_field in pairs:
-        if sorted(raw.get(raw_field, [])) != sorted(manifest.get(man_field, [])):
-            raise HandoffError(f"{raw_field} coverage mismatch")
+    for field in ("coverage_gaps", "blind_spots"):
+        if len(raw.get(field, [])) != len(manifest.get(field, [])):
+            raise HandoffError(f"{field} coverage mismatch")
+    if sorted(raw.get("unique_insights", [])) != sorted(manifest.get("unique_insight_ids", [])):
+        raise HandoffError("unique_insights coverage mismatch")
 
 
 def check_ready_invariants(raw, manifest, evidence_text):

--- a/plugins/deep-research/scripts/harvest_handoff.py
+++ b/plugins/deep-research/scripts/harvest_handoff.py
@@ -238,12 +238,14 @@ def check_coverage(wip: Mapping[str, Any], raw: Mapping[str, Any]) -> None:
     raw_clusters = raw.get("clusters") or []
     raw_cluster_ids = []
     raw_cluster_claim_ids: dict[str, list[str]] = {}
+    raw_cluster_relations: dict[str, str] = {}
     for cluster in raw_clusters:
         cid = cluster.get("cluster_id")
         if not isinstance(cid, str) or not cid:
             raise HandoffError("raw cluster missing cluster_id")
         raw_cluster_ids.append(cid)
         raw_cluster_claim_ids[cid] = [claim["id"] for claim in cluster.get("claims") or []]
+        raw_cluster_relations[cid] = cluster.get("relation", "agree")
 
     seen: dict[str, str] = {}
     wip_cluster_ids = []
@@ -252,6 +254,8 @@ def check_coverage(wip: Mapping[str, Any], raw: Mapping[str, Any]) -> None:
         wip_cluster_ids.append(cid)
         if cid not in raw_cluster_claim_ids:
             raise HandoffError(f"unknown cluster: {cid}")
+        if cluster["relation"] != raw_cluster_relations[cid]:
+            raise HandoffError(f"relation mismatch: {cid}")
         wip_ids = [claim["id"] for claim in cluster["claims"]]
         for claim_id in wip_ids:
             if claim_id in seen:
@@ -698,6 +702,10 @@ def check_published_against_raw(raw, manifest, evidence_text):
         cluster["cluster_id"]: [claim["id"] for claim in cluster.get("claims") or []]
         for cluster in raw.get("clusters") or []
     }
+    raw_cluster_relations = {
+        cluster["cluster_id"]: cluster.get("relation", "agree")
+        for cluster in raw.get("clusters") or []
+    }
     man_clusters = {
         cluster["cluster_id"]: list(cluster["claim_ids"])
         for cluster in manifest["clusters"]
@@ -707,6 +715,10 @@ def check_published_against_raw(raw, manifest, evidence_text):
     for cid, ids in raw_clusters.items():
         if sorted(ids) != sorted(man_clusters[cid]):
             raise HandoffError(f"cluster membership incomplete: {cid}")
+    for cluster in manifest["clusters"]:
+        cid = cluster["cluster_id"]
+        if cluster.get("relation") != raw_cluster_relations.get(cid, "agree"):
+            raise HandoffError(f"relation mismatch: {cid}")
     raw_un = raw.get("unclustered_claim_ids", [])
     if sorted(raw_un) != sorted(manifest["unclustered_claim_ids"]):
         raise HandoffError("unclustered_claim_ids mismatch")

--- a/plugins/deep-research/scripts/harvest_handoff.py
+++ b/plugins/deep-research/scripts/harvest_handoff.py
@@ -1,0 +1,720 @@
+"""Harvest handoff: closed-schema WIP → compact manifest + evidence ledger.
+
+stdlib-only. Does not import harvest. Callers pass already-loaded structures.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+class HandoffError(ValueError):
+    """Closed-schema / coverage / publish failure with a stable message."""
+
+
+SCHEMA_WIP = "harvest-handoff-wip"
+SCHEMA_MANIFEST = "harvest-handoff-manifest"
+HANDOFF_VERSION = 1
+EXCERPT_VERIFICATION = "url_fetched_only"
+
+WIP_TOP_KEYS = frozenset({
+    "schema",
+    "handoff_version",
+    "clusters",
+    "coverage_gaps",
+    "blind_spots",
+    "contradictions",
+    "unique_insights",
+    "unclustered_claim_ids",
+    "unclustered_claims",
+})
+WIP_CLUSTER_KEYS = frozenset({"cluster_id", "summary", "relation", "claims"})
+CLAIM_KEYS = frozenset({
+    "id", "claim", "excerpt", "url", "language", "credibility", "source_model",
+})
+MANIFEST_TOP_KEYS = frozenset({
+    "schema",
+    "handoff_version",
+    "goal_file_sha256",
+    "raw_merged_sha256",
+    "evidence_sha256",
+    "alive_models",
+    "claim_count",
+    "cluster_count",
+    "clusters",
+    "coverage_gaps",
+    "blind_spots",
+    "contradictions",
+    "unique_insight_ids",
+    "unclustered_claim_ids",
+})
+MANIFEST_CLUSTER_KEYS = frozenset({
+    "cluster_id",
+    "summary",
+    "relation",
+    "supporting_models",
+    "consensus",
+    "presentation",
+    "expansion_reasons",
+    "representative_claim_id",
+    "claim_ids",
+    "evidence_offset",
+    "evidence_limit",
+})
+EVIDENCE_KEYS = frozenset({
+    "cluster_id",
+    "id",
+    "claim",
+    "excerpt",
+    "url",
+    "language",
+    "credibility",
+    "source_model",
+    "excerpt_verification",
+})
+REQUIRED_WIP_LISTS = (
+    "coverage_gaps",
+    "blind_spots",
+    "contradictions",
+    "unique_insights",
+    "unclustered_claim_ids",
+)
+
+
+def canonical_dumps(obj: Any) -> str:
+    """UTF-8 JSON with frozen key order so hashes do not depend on dict insert order."""
+    return json.dumps(
+        obj,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def canonical_bytes(obj: Any) -> bytes:
+    return canonical_dumps(obj).encode("utf-8")
+
+
+def semantic_hash(obj: Any) -> str:
+    """sha256 hex of canonical JSON bytes."""
+    return hashlib.sha256(canonical_bytes(obj)).hexdigest()
+
+
+def file_sha256(path: str | os.PathLike[str]) -> str:
+    """sha256 hex of the file's on-disk bytes."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _closed(obj: Mapping[str, Any], allowed: frozenset[str], label: str) -> None:
+    extra = sorted(set(obj) - allowed)
+    if extra:
+        raise HandoffError(f"{label}: unknown keys {extra}")
+
+
+def _require_keys(obj: Mapping[str, Any], required: Iterable[str], label: str) -> None:
+    missing = sorted(set(required) - set(obj))
+    if missing:
+        raise HandoffError(f"{label}: missing keys {missing}")
+
+
+def _as_str_list(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise HandoffError(f"{label} must be a list of strings")
+    return list(value)
+
+
+def _as_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise HandoffError(f"{label} must be an int")
+    return value
+
+
+def validate_claim(claim: Any, label: str) -> dict[str, Any]:
+    if not isinstance(claim, dict):
+        raise HandoffError(f"{label} must be an object")
+    _require_keys(claim, CLAIM_KEYS, label)
+    _closed(claim, CLAIM_KEYS, label)
+    for key in ("id", "claim", "excerpt", "url", "language", "source_model"):
+        if not isinstance(claim[key], str) or not claim[key] and key == "id":
+            raise HandoffError(f"{label}.{key} must be a non-empty string" if key == "id"
+                               else f"{label}.{key} must be a string")
+        if key != "id" and not isinstance(claim[key], str):
+            raise HandoffError(f"{label}.{key} must be a string")
+    if not claim["id"]:
+        raise HandoffError(f"{label}.id must be a non-empty string")
+    _as_int(claim["credibility"], f"{label}.credibility")
+    return claim
+
+
+def validate_wip(wip: Any) -> dict[str, Any]:
+    if not isinstance(wip, dict):
+        raise HandoffError("wip must be an object")
+    _require_keys(wip, WIP_TOP_KEYS, "wip")
+    _closed(wip, WIP_TOP_KEYS, "wip")
+    if wip.get("schema") != SCHEMA_WIP:
+        raise HandoffError(f"wip.schema must be {SCHEMA_WIP}")
+    if wip.get("handoff_version") != HANDOFF_VERSION:
+        raise HandoffError("wip.handoff_version must be 1")
+    if not isinstance(wip.get("clusters"), list):
+        raise HandoffError("wip.clusters must be a list")
+    for name in REQUIRED_WIP_LISTS:
+        _as_str_list(wip[name], f"wip.{name}")
+    for index, cluster in enumerate(wip["clusters"]):
+        label = f"wip.clusters[{index}]"
+        if not isinstance(cluster, dict):
+            raise HandoffError(f"{label} must be an object")
+        _require_keys(cluster, WIP_CLUSTER_KEYS, label)
+        _closed(cluster, WIP_CLUSTER_KEYS, label)
+        if not isinstance(cluster["cluster_id"], str) or not cluster["cluster_id"]:
+            raise HandoffError(f"{label}.cluster_id must be a non-empty string")
+        if not isinstance(cluster["summary"], str):
+            raise HandoffError(f"{label}.summary must be a string")
+        if not isinstance(cluster["relation"], str) or not cluster["relation"]:
+            raise HandoffError(f"{label}.relation must be a non-empty string")
+        if not isinstance(cluster["claims"], list) or not cluster["claims"]:
+            raise HandoffError(f"{label}.claims must be a non-empty list")
+        for cidx, claim in enumerate(cluster["claims"]):
+            validate_claim(claim, f"{label}.claims[{cidx}]")
+    extras = wip["unclustered_claims"]
+    if not isinstance(extras, list):
+        raise HandoffError("wip.unclustered_claims must be a list")
+    for cidx, claim in enumerate(extras):
+        validate_claim(claim, f"wip.unclustered_claims[{cidx}]")
+    return wip
+
+
+def _raw_claim_index(raw: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+
+    def _add(claim: Mapping[str, Any], label: str) -> None:
+        validated = validate_claim(claim, label)
+        cid = validated["id"]
+        if cid in index:
+            raise HandoffError(f"duplicate claim: {cid}")
+        index[cid] = validated
+
+    clusters = raw.get("clusters")
+    if not isinstance(clusters, list):
+        raise HandoffError("raw.clusters must be a list")
+    for index_i, cluster in enumerate(clusters):
+        if not isinstance(cluster, dict):
+            raise HandoffError(f"raw.clusters[{index_i}] must be an object")
+        claims = cluster.get("claims")
+        if not isinstance(claims, list):
+            raise HandoffError(f"raw.clusters[{index_i}].claims must be a list")
+        for cidx, claim in enumerate(claims):
+            if not isinstance(claim, dict):
+                raise HandoffError(f"raw.clusters[{index_i}].claims[{cidx}] must be an object")
+            _add(claim, f"raw.clusters[{index_i}].claims[{cidx}]")
+    extras = raw.get("unclustered_claims", [])
+    if extras:
+        if not isinstance(extras, list):
+            raise HandoffError("raw.unclustered_claims must be a list")
+        for cidx, claim in enumerate(extras):
+            if not isinstance(claim, dict):
+                raise HandoffError(f"raw.unclustered_claims[{cidx}] must be an object")
+            _add(claim, f"raw.unclustered_claims[{cidx}]")
+    return index
+
+
+def _norm_str_list(values: Iterable[str]) -> list[str]:
+    return sorted(values)
+
+
+def check_coverage(wip: Mapping[str, Any], raw: Mapping[str, Any]) -> None:
+    """WIP must cover each accepted raw claim exactly once; cluster ids must match."""
+    validate_wip(wip)
+    raw_index = _raw_claim_index(raw)
+    raw_clusters = raw.get("clusters") or []
+    raw_cluster_ids = []
+    raw_cluster_claim_ids: dict[str, list[str]] = {}
+    for cluster in raw_clusters:
+        cid = cluster.get("cluster_id")
+        if not isinstance(cid, str) or not cid:
+            raise HandoffError("raw cluster missing cluster_id")
+        raw_cluster_ids.append(cid)
+        raw_cluster_claim_ids[cid] = [claim["id"] for claim in cluster.get("claims") or []]
+
+    seen: dict[str, str] = {}
+    wip_cluster_ids = []
+    for cluster in wip["clusters"]:
+        cid = cluster["cluster_id"]
+        wip_cluster_ids.append(cid)
+        if cid not in raw_cluster_claim_ids:
+            raise HandoffError(f"unknown cluster: {cid}")
+        wip_ids = [claim["id"] for claim in cluster["claims"]]
+        for claim_id in wip_ids:
+            if claim_id in seen:
+                raise HandoffError(f"duplicate claim: {claim_id}")
+            if claim_id not in raw_index:
+                raise HandoffError(f"unknown claim: {claim_id}")
+            seen[claim_id] = cid
+        if sorted(wip_ids) != sorted(raw_cluster_claim_ids[cid]):
+            raise HandoffError(f"cluster membership incomplete: {cid}")
+
+    if sorted(wip_cluster_ids) != sorted(raw_cluster_ids):
+        raise HandoffError("cluster membership incomplete: missing raw cluster")
+
+    raw_unclustered = _as_str_list(
+        raw.get("unclustered_claim_ids", []), "raw.unclustered_claim_ids",
+    )
+    wip_unclustered = list(wip["unclustered_claim_ids"])
+    if len(wip_unclustered) != len(set(wip_unclustered)):
+        dup = next(cid for cid in wip_unclustered if wip_unclustered.count(cid) > 1)
+        raise HandoffError(f"duplicate claim: {dup}")
+    if sorted(wip_unclustered) != sorted(raw_unclustered):
+        raise HandoffError("unclustered_claim_ids mismatch")
+    body_ids = [claim["id"] for claim in wip["unclustered_claims"]]
+    if len(body_ids) != len(set(body_ids)):
+        dup = next(cid for cid in body_ids if body_ids.count(cid) > 1)
+        raise HandoffError(f"duplicate claim: {dup}")
+    if sorted(body_ids) != sorted(wip_unclustered):
+        raise HandoffError("unclustered_claims id mismatch")
+    for claim_id in wip_unclustered:
+        if claim_id in seen:
+            raise HandoffError(f"duplicate claim: {claim_id}")
+        if claim_id not in raw_index:
+            raise HandoffError(f"unknown claim: {claim_id}")
+        seen[claim_id] = ""
+
+    expected = set(raw_index)
+    if set(seen) != expected:
+        missing = sorted(expected - set(seen))
+        extra = sorted(set(seen) - expected)
+        if extra:
+            raise HandoffError(f"unknown claim: {extra[0]}")
+        raise HandoffError(f"missing claim: {missing[0]}")
+
+    for field in ("coverage_gaps", "blind_spots", "unique_insights"):
+        raw_vals = _as_str_list(raw.get(field, []), f"raw.{field}")
+        if sorted(wip[field]) != sorted(raw_vals):
+            raise HandoffError(f"{field} coverage mismatch")
+
+
+def supporting_models(claims: Iterable[Mapping[str, Any]]) -> list[str]:
+    return sorted({claim["source_model"] for claim in claims})
+
+
+def classify_consensus(relation: str, models: list[str]) -> str:
+    """Navigation label only — not a truth claim."""
+    if relation == "contradict":
+        return "disputed"
+    if len(models) >= 2:
+        return "corroborated"
+    return "single-model"
+
+
+def expansion_reasons(
+    *,
+    consensus: str,
+    claim_ids: list[str],
+    claims: list[Mapping[str, Any]],
+    unique_insight_ids: set[str],
+    unclustered: bool,
+) -> list[str]:
+    reasons: list[str] = []
+    if consensus == "disputed":
+        reasons.append("disputed")
+    if consensus == "single-model":
+        reasons.append("single-model")
+    if any(cid in unique_insight_ids for cid in claim_ids):
+        reasons.append("unique-insight")
+    if any(int(claim["credibility"]) < 3 for claim in claims):
+        reasons.append("low-credibility")
+    if unclustered:
+        reasons.append("unclustered")
+    return sorted(reasons)
+
+
+def pick_representative(claims: list[Mapping[str, Any]]) -> str:
+    """Highest credibility; ties broken by claim id ascending."""
+    ordered = sorted(claims, key=lambda c: (-int(c["credibility"]), c["id"]))
+    return ordered[0]["id"]
+
+
+def _evidence_sort_key(row: Mapping[str, Any]) -> tuple[bool, str, str]:
+    # Empty cluster_id (unclustered) sorts after named clusters.
+    cid = row["cluster_id"]
+    return (cid == "", cid, row["id"])
+
+
+def _evidence_row(cluster_id: str, claim: Mapping[str, Any]) -> dict[str, Any]:
+    """Ledger line from a validated WIP claim. cluster_id is navigation only."""
+    return {
+        "cluster_id": cluster_id,
+        "id": claim["id"],
+        "claim": claim["claim"],
+        "excerpt": claim["excerpt"],
+        "url": claim["url"],
+        "language": claim["language"],
+        "credibility": claim["credibility"],
+        "source_model": claim["source_model"],
+        "excerpt_verification": EXCERPT_VERIFICATION,
+    }
+
+
+def build_evidence_rows(wip: Mapping[str, Any], raw: Mapping[str, Any]) -> list[dict[str, Any]]:
+    # Coverage is ID-aligned against raw; sanitized bodies come from WIP.
+    raw_index = _raw_claim_index(raw)
+    rows: list[dict[str, Any]] = []
+    for cluster in wip["clusters"]:
+        for claim in cluster["claims"]:
+            if claim["id"] not in raw_index:
+                raise HandoffError(f"unknown claim: {claim['id']}")
+            rows.append(_evidence_row(cluster["cluster_id"], claim))
+    for claim in wip["unclustered_claims"]:
+        if claim["id"] not in raw_index:
+            raise HandoffError(f"unknown claim: {claim['id']}")
+        rows.append(_evidence_row("", claim))
+    rows.sort(key=_evidence_sort_key)
+    return rows
+
+
+def evidence_jsonl(rows: list[Mapping[str, Any]]) -> str:
+    lines = []
+    for row in rows:
+        _closed(row, EVIDENCE_KEYS, "evidence")
+        if row.get("excerpt_verification") != EXCERPT_VERIFICATION:
+            raise HandoffError("excerpt_verification must be url_fetched_only")
+        lines.append(canonical_dumps(row))
+    return "".join(line + "\n" for line in lines)
+
+
+def _cluster_window(rows: list[Mapping[str, Any]], cluster_id: str) -> tuple[int, int]:
+    indices = [i for i, row in enumerate(rows) if row["cluster_id"] == cluster_id]
+    if not indices:
+        return 0, 0
+    start = indices[0]
+    return start, len(indices)
+
+
+def build_manifest(
+    wip: Mapping[str, Any],
+    raw: Mapping[str, Any],
+    *,
+    goal_file_sha256: str,
+    raw_merged_sha256: str,
+    evidence_sha256: str,
+    alive_models: list[str],
+) -> dict[str, Any]:
+    check_coverage(wip, raw)
+    rows = build_evidence_rows(wip, raw)
+    unique_ids = set(wip["unique_insights"])
+    clusters_out: list[dict[str, Any]] = []
+    for cluster in wip["clusters"]:
+        claims = list(cluster["claims"])
+        models = supporting_models(claims)
+        consensus = classify_consensus(cluster["relation"], models)
+        reasons = expansion_reasons(
+            consensus=consensus,
+            claim_ids=[c["id"] for c in claims],
+            claims=claims,
+            unique_insight_ids=unique_ids,
+            unclustered=False,
+        )
+        presentation = "compressed" if (consensus == "corroborated" and not reasons) else "expanded"
+        offset, limit = _cluster_window(rows, cluster["cluster_id"])
+        clusters_out.append({
+            "cluster_id": cluster["cluster_id"],
+            "summary": cluster["summary"],
+            "relation": cluster["relation"],
+            "supporting_models": models,
+            "consensus": consensus,
+            "presentation": presentation,
+            "expansion_reasons": reasons,
+            "representative_claim_id": pick_representative(claims),
+            "claim_ids": [c["id"] for c in claims],
+            "evidence_offset": offset,
+            "evidence_limit": limit,
+        })
+
+    unclustered_ids = list(wip["unclustered_claim_ids"])
+    if unclustered_ids:
+        claims = list(wip["unclustered_claims"])
+        models = supporting_models(claims)
+        consensus = classify_consensus("agree", models)
+        reasons = expansion_reasons(
+            consensus=consensus,
+            claim_ids=unclustered_ids,
+            claims=claims,
+            unique_insight_ids=unique_ids,
+            unclustered=True,
+        )
+        # Unclustered rows are addressable but stay out of clusters[];
+        # R5 requires them fully expanded at the id list, not as compressed clusters.
+        if "unclustered" not in reasons:
+            reasons = sorted(reasons + ["unclustered"])
+
+    manifest = {
+        "schema": SCHEMA_MANIFEST,
+        "handoff_version": HANDOFF_VERSION,
+        "goal_file_sha256": goal_file_sha256,
+        "raw_merged_sha256": raw_merged_sha256,
+        "evidence_sha256": evidence_sha256,
+        "alive_models": sorted(alive_models),
+        "claim_count": len(rows),
+        "cluster_count": len(clusters_out),
+        "clusters": clusters_out,
+        "coverage_gaps": list(wip["coverage_gaps"]),
+        "blind_spots": list(wip["blind_spots"]),
+        "contradictions": list(wip["contradictions"]),
+        "unique_insight_ids": list(wip["unique_insights"]),
+        "unclustered_claim_ids": unclustered_ids,
+    }
+    validate_manifest(manifest)
+    return manifest
+
+
+def validate_manifest(manifest: Any) -> dict[str, Any]:
+    if not isinstance(manifest, dict):
+        raise HandoffError("manifest must be an object")
+    _require_keys(manifest, MANIFEST_TOP_KEYS, "manifest")
+    _closed(manifest, MANIFEST_TOP_KEYS, "manifest")
+    if manifest.get("schema") != SCHEMA_MANIFEST:
+        raise HandoffError(f"manifest.schema must be {SCHEMA_MANIFEST}")
+    if manifest.get("handoff_version") != HANDOFF_VERSION:
+        raise HandoffError("manifest.handoff_version must be 1")
+    for key in ("goal_file_sha256", "raw_merged_sha256", "evidence_sha256"):
+        if not isinstance(manifest[key], str) or len(manifest[key]) != 64:
+            raise HandoffError(f"manifest.{key} must be a sha256 hex")
+    if not isinstance(manifest["alive_models"], list):
+        raise HandoffError("manifest.alive_models must be a list")
+    _as_int(manifest["claim_count"], "manifest.claim_count")
+    _as_int(manifest["cluster_count"], "manifest.cluster_count")
+    if not isinstance(manifest["clusters"], list):
+        raise HandoffError("manifest.clusters must be a list")
+    for index, cluster in enumerate(manifest["clusters"]):
+        label = f"manifest.clusters[{index}]"
+        if not isinstance(cluster, dict):
+            raise HandoffError(f"{label} must be an object")
+        _require_keys(cluster, MANIFEST_CLUSTER_KEYS, label)
+        _closed(cluster, MANIFEST_CLUSTER_KEYS, label)
+        if cluster["presentation"] not in ("expanded", "compressed"):
+            raise HandoffError(f"{label}.presentation invalid")
+        if cluster["consensus"] not in ("disputed", "corroborated", "single-model"):
+            raise HandoffError(f"{label}.consensus invalid")
+        if not isinstance(cluster["expansion_reasons"], list):
+            raise HandoffError(f"{label}.expansion_reasons must be a list")
+        if cluster["expansion_reasons"] != sorted(cluster["expansion_reasons"]):
+            raise HandoffError(f"{label}.expansion_reasons must be sorted")
+        _as_int(cluster["evidence_offset"], f"{label}.evidence_offset")
+        _as_int(cluster["evidence_limit"], f"{label}.evidence_limit")
+    for name in ("coverage_gaps", "blind_spots", "contradictions",
+                 "unique_insight_ids", "unclustered_claim_ids"):
+        _as_str_list(manifest[name], f"manifest.{name}")
+    return manifest
+
+
+def validate_evidence_line(row: Any) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        raise HandoffError("evidence line must be an object")
+    _require_keys(row, EVIDENCE_KEYS, "evidence")
+    _closed(row, EVIDENCE_KEYS, "evidence")
+    if row.get("excerpt_verification") != EXCERPT_VERIFICATION:
+        raise HandoffError("excerpt_verification must be url_fetched_only")
+    if "verified" in str(row.get("excerpt_verification", "")).lower() and \
+            row["excerpt_verification"] != EXCERPT_VERIFICATION:
+        raise HandoffError("verified-excerpt claim forbidden")
+    return row
+
+
+def parse_evidence_jsonl(text: str) -> list[dict[str, Any]]:
+    rows = []
+    for line_no, line in enumerate(text.splitlines()):
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise HandoffError(f"evidence line {line_no} is not JSON") from exc
+        rows.append(validate_evidence_line(row))
+    return rows
+
+
+def validate_published(
+    manifest: Mapping[str, Any],
+    evidence_text: str,
+    raw: Mapping[str, Any],
+    wip: Mapping[str, Any] | None = None,
+) -> None:
+    validate_manifest(manifest)
+    rows = parse_evidence_jsonl(evidence_text)
+    expected_hash = hashlib.sha256(evidence_text.encode("utf-8")).hexdigest()
+    if manifest["evidence_sha256"] != expected_hash:
+        raise HandoffError("evidence_sha256 mismatch")
+    if any(row["excerpt_verification"] != EXCERPT_VERIFICATION for row in rows):
+        raise HandoffError("excerpt_verification must be url_fetched_only")
+    if "verified-excerpt" in evidence_text:
+        raise HandoffError("verified-excerpt claim forbidden")
+    if len(rows) != manifest["claim_count"]:
+        raise HandoffError("claim_count mismatch")
+    if wip is not None:
+        check_coverage(wip, raw)
+        rebuilt = build_evidence_rows(wip, raw)
+        if [semantic_hash(r) for r in rebuilt] != [semantic_hash(r) for r in rows]:
+            raise HandoffError("evidence rows do not match wip/raw")
+
+
+def atomic_write(path: Path, data: bytes) -> None:
+    """Write via a unique same-dir temp file, then replace.
+
+    A pre-existing sibling `{name}.tmp` (including a symlink planted
+    there) must not be opened or truncated. mkstemp creates a new
+    exclusive name; os.replace then swaps onto the target.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent),
+    )
+    tmp = Path(tmp_name)
+    try:
+        try:
+            view = memoryview(data)
+            written = 0
+            while written < len(data):
+                n = os.write(fd, view[written:])
+                if n <= 0:
+                    raise OSError("short write produced no progress")
+                written += n
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+            fd = -1
+        os.replace(tmp, path)
+    except Exception:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def artifact_names(track_name: str | None = None) -> dict[str, str]:
+    if track_name:
+        stem = f"track_{track_name}-"
+    else:
+        stem = ""
+    return {
+        "manifest": f"{stem}harvest-manifest.json",
+        "evidence": f"{stem}harvest-evidence.jsonl",
+        "wip": f"{stem}harvest-handoff.wip.json",
+    }
+
+
+def publish_handoff(
+    cleaned_dir: str | os.PathLike[str],
+    wip: Mapping[str, Any],
+    raw: Mapping[str, Any],
+    *,
+    goal_file_sha256: str,
+    raw_merged_sha256: str,
+    alive_models: list[str],
+    track_name: str | None = None,
+) -> dict[str, Any]:
+    """Validate in memory, then replace evidence first and manifest second."""
+    check_coverage(wip, raw)
+    rows = build_evidence_rows(wip, raw)
+    evidence_text = evidence_jsonl(rows)
+    evidence_hash = hashlib.sha256(evidence_text.encode("utf-8")).hexdigest()
+    manifest = build_manifest(
+        wip,
+        raw,
+        goal_file_sha256=goal_file_sha256,
+        raw_merged_sha256=raw_merged_sha256,
+        evidence_sha256=evidence_hash,
+        alive_models=alive_models,
+    )
+    names = artifact_names(track_name)
+    cleaned = Path(cleaned_dir)
+    evidence_path = cleaned / names["evidence"]
+    manifest_path = cleaned / names["manifest"]
+    atomic_write(evidence_path, evidence_text.encode("utf-8"))
+    atomic_write(manifest_path, canonical_bytes(manifest))
+    validate_published(manifest, evidence_text, raw, wip)
+    return manifest
+
+
+def check_ready_payloads(
+    *,
+    verify: Mapping[str, Any],
+    raw: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+    evidence_text: str,
+    goal_sha256: str,
+    raw_sha256: str,
+    manifest_sha256: str,
+    evidence_sha256: str,
+) -> None:
+    """Invariants for a READY verify record. Raises HandoffError on any mismatch."""
+    if verify.get("handoff_version") != HANDOFF_VERSION:
+        raise HandoffError("handoff_version must be 1")
+    if verify.get("handoff_required") is not True:
+        raise HandoffError("handoff_required must be true")
+    if verify.get("handoff_status") != "READY":
+        raise HandoffError("handoff_status must be READY")
+    validate_published(manifest, evidence_text, raw)
+    if verify.get("manifest_sha256") != manifest_sha256:
+        raise HandoffError("manifest_sha256 mismatch")
+    if verify.get("evidence_sha256") != evidence_sha256:
+        raise HandoffError("evidence_sha256 mismatch")
+    if verify.get("raw_merged_sha256") != raw_sha256:
+        raise HandoffError("raw_merged_sha256 mismatch")
+    if verify.get("goal_file_sha256") and verify["goal_file_sha256"] != goal_sha256:
+        raise HandoffError("goal_file_sha256 mismatch")
+    if manifest.get("raw_merged_sha256") != raw_sha256:
+        raise HandoffError("manifest raw_merged_sha256 mismatch")
+    if manifest.get("evidence_sha256") != evidence_sha256:
+        raise HandoffError("manifest evidence_sha256 mismatch")
+    if manifest.get("goal_file_sha256") != goal_sha256:
+        raise HandoffError("manifest goal_file_sha256 mismatch")
+
+
+def check_published_against_raw(raw, manifest, evidence_text):
+    """READY-path invariants: published set must still cover raw merged claims."""
+    validate_published(manifest, evidence_text, raw)
+    rows = parse_evidence_jsonl(evidence_text)
+    raw_index = _raw_claim_index(raw)
+    ev_ids = [row["id"] for row in rows]
+    if sorted(ev_ids) != sorted(raw_index):
+        raise HandoffError("evidence claim set mismatch")
+    raw_clusters = {
+        cluster["cluster_id"]: [claim["id"] for claim in cluster.get("claims") or []]
+        for cluster in raw.get("clusters") or []
+    }
+    man_clusters = {
+        cluster["cluster_id"]: list(cluster["claim_ids"])
+        for cluster in manifest["clusters"]
+    }
+    if sorted(raw_clusters) != sorted(man_clusters):
+        raise HandoffError("cluster membership incomplete: missing raw cluster")
+    for cid, ids in raw_clusters.items():
+        if sorted(ids) != sorted(man_clusters[cid]):
+            raise HandoffError(f"cluster membership incomplete: {cid}")
+    raw_un = raw.get("unclustered_claim_ids", [])
+    if sorted(raw_un) != sorted(manifest["unclustered_claim_ids"]):
+        raise HandoffError("unclustered_claim_ids mismatch")
+    pairs = (
+        ("coverage_gaps", "coverage_gaps"),
+        ("blind_spots", "blind_spots"),
+        ("unique_insights", "unique_insight_ids"),
+    )
+    for raw_field, man_field in pairs:
+        if sorted(raw.get(raw_field, [])) != sorted(manifest.get(man_field, [])):
+            raise HandoffError(f"{raw_field} coverage mismatch")
+
+
+def check_ready_invariants(raw, manifest, evidence_text):
+    """Published-artifact invariants used by check_project READY path."""
+    check_published_against_raw(raw, manifest, evidence_text)

--- a/plugins/deep-research/skills/deep-research/SKILL.md
+++ b/plugins/deep-research/skills/deep-research/SKILL.md
@@ -49,7 +49,7 @@ G0 与用户完成 primary_job / Non-Goals 对齐后、进入 Acquisition 前，
 
 1. **检测 `GATEWAY_API_KEY`**（或 config 中声明的 `gateway.api_key_env`）是否已配置
 2. 结果分支：
-   - **已配置** → 默认走 panel mode（三模型并行），不问用户
+   - **已配置** → 默认走 panel mode（configured panel，quorum 由 config），不问用户
    - **未配置** → 主动询问用户：
      > "当前未检测到聚合网关 API key。你可以：
      > 1. 提供 key（我来帮你配好环境变量）
@@ -92,7 +92,7 @@ python3 <路径> run --no-api --queries-json <queries.json> --goal-file <goal-fi
 - **exit 3**（`UNAVAILABLE`）：采集不可用（panel mode 法定人数未达标 / local mode 搜索全失败），须停止并上报用户裁决，**不自行降级到 legacy 链**
 - **exit 4**：curl_cffi 依赖未装，须 `pip install curl_cffi` 后重跑
 
-`harvest.py check <project-dir>` 用于 G1 的引用校验机械门（三态 exit code 0=PASS / 1=FAIL / 2=N/A），细则见 `references/quality-gates.md`。
+`harvest.py check <project-dir>` 用于 G1 的引用校验机械门（三态 exit code 0=PASS / 1=FAIL / 2=N/A），细则见 `references/quality-gates.md`。panel `run` 成功后须 `finalize-handoff` 使交接进入 `READY`，生命周期见 `references/pipeline.md`。
 
 ## 新建研究项目
 
@@ -118,9 +118,9 @@ Gate 评分细则：`assets/review-rubric.md`（审阅 5 评分维度 + 维度6 
 
 ## 依赖前置
 
-harvest.py 主路径依赖：网关 API key（`GATEWAY_API_KEY` 等，用于聚合网关调用 gemini/gpt/claude 三面板，以及主搜索后端 gemini-grounding 经网关直连）、`curl_cffi`（TLS 模拟搜索 + 直连 fetch，未装则 exit 4 阻塞）。搜索后端按序降级 gemini-grounding → tavily → duckduckgo，无本机检索 CLI 依赖。详见插件 README。
+harvest.py 主路径依赖：网关 API key（`GATEWAY_API_KEY` 等，用于聚合网关调用 configured panel，以及主搜索后端 gemini-grounding 经网关直连）、`curl_cffi`（TLS 模拟搜索 + 直连 fetch，未装则 exit 4 阻塞）。搜索后端按序降级 gemini-grounding → tavily → duckduckgo，无本机检索 CLI 依赖。详见插件 README。
 
 三种采集模式：
-- **panel mode**（默认）：有 gateway key → 三模型并行 + judge 聚类 + 机械引用校验
+- **panel mode**（默认）：有 gateway key → configured panel + quorum + judge merge + 机械引用校验；成功后须 finalize-handoff
 - **`--no-api` local mode**：无 gateway key 或用户选择 → harvest.py 只搜索+抓取，harvester subagent 做推理 + `verify-local` 做确定性引用校验
 - **legacy 手工链**：经用户显式豁免（`pipeline/verification/legacy-exemption.md`）或项目未启用 harvest.py → Gemini CLI / WebSearch / WebFetch

--- a/plugins/deep-research/skills/deep-research/references/pipeline.md
+++ b/plugins/deep-research/skills/deep-research/references/pipeline.md
@@ -48,13 +48,13 @@ Lead 确定信息源策略：学术 / Web / API / 代码 / 文献。playbook 提
 
 | 项 | 说明 |
 |---|---|
-| 执行者 | research-harvester（Task subagent），主路径经 `harvest.py` 多模型采集（gemini/gpt/claude 三面板并行 + 裁判 merge，harvest.py 路径见 SKILL.md 的路径发现约定），未启用/经豁免项目走 legacy 手工采集 |
+| 执行者 | research-harvester（Task subagent），主路径经 `harvest.py` 的 configured panel + quorum + judge merge（`panel_models` 与 `quorum` 来自 `harvest.config.json`；harvest.py 路径见 SKILL.md 的路径发现约定），未启用/经豁免项目走 legacy 手工采集 |
 | 输入 | Lead 的采集指令 |
 | 输出目录 | `pipeline/1_raw/`（含 `harvest/<model>/findings.json`）+ `pipeline/verification/`（harvest.py 项目） |
-| 产物 | 原始数据文件 + fetch-report + `merged-findings.json`（harvest.py 项目，带共识标签）+ `harvest-verify.json`（机械门校验记录） |
+| 产物 | 原始数据文件 + fetch-report + `merged-findings.json`（harvest.py 项目，judge merge 后的 raw clusters）+ `harvest-verify.json`（机械门校验记录。panel `run` 成功时仍为 `verdict=OK`，并带 `handoff_version=1`、`handoff_required=true`、`handoff_status=PENDING_SANITIZATION`） |
 | 命名 | `YYYYMMDD_HHMMSS_{source}_{description}` |
 
-fetch-report 必填字段：tier 分层（T1/T2/T3）、翻页统计、错误汇总、中英文搜索覆盖率；harvest.py 项目另加多模型共识统计、引用校验统计、本地材料清单（见 deep-research 插件的 research-harvester subagent）。
+fetch-report 必填字段：tier 分层（T1/T2/T3）、翻页统计、错误汇总、中英文搜索覆盖率；harvest.py 项目另加 configured panel 参与统计、引用校验统计、本地材料清单（见 deep-research 插件的 research-harvester subagent）。
 
 ### Stage 3: Sanitization（harvester 执行）
 
@@ -63,13 +63,13 @@ fetch-report 必填字段：tier 分层（T1/T2/T3）、翻页统计、错误汇
 | 执行者 | research-harvester（同一 Task，与 Acquisition 串行） |
 | 输入目录 | `pipeline/1_raw/` |
 | 输出目录 | `pipeline/2_cleaned/` |
-| 产物 | 脱敏后数据文件 |
+| 产物 | 脱敏后数据文件。handoff-enabled 的 panel 路径另产确定性交接：从 raw merged 做 L1/L2 脱敏，写入 `pipeline/2_cleaned/harvest-handoff.wip.json`（supplementary 为 `track_<raw_dir.name>-harvest-handoff.wip.json`；unclustered 脱敏正文走 `unclustered_claims`），再执行 `python3 harvest.py finalize-handoff --project-dir <proj> --out <raw_dir> --wip <wip>`。primary 正式产物为 `pipeline/2_cleaned/harvest-manifest.json`（compact，Lead 可读）与 `pipeline/2_cleaned/harvest-evidence.jsonl`（行寻址完整证据；Lead 禁读，即使远小于 8KiB）。finalize 成功后，verify 才变为 `READY` 并绑定 hashes。local / `--no-api` 不走 v1 确定性交接 |
 
-脱敏协议见 deep-research 插件的 research-harvester subagent。
+脱敏协议见 deep-research 插件的 research-harvester subagent。Acquisition 与 Sanitization 仍在同一 Task。
 
 ### ❰G1❱ Sufficiency Gate: 采集充分性
 
-- 触发点：Acquisition + Sanitization 完成后
+- 触发点：Acquisition + Sanitization 完成后。handoff-enabled 路径应在交接 `READY` 之后再请求 G1
 - 执行者：research-reviewer（mode=sufficiency）
 - 适用维度：覆盖度、时效性、可信度、双语平衡
 - 通过条件：见 [quality-gates.md](./quality-gates.md)
@@ -83,6 +83,8 @@ fetch-report 必填字段：tier 分层（T1/T2/T3）、翻页统计、错误汇
 | 输入目录 | `pipeline/2_cleaned/`（只读） |
 | 输出目录 | `pipeline/3_structured/` |
 | 产物 | 域拆解文件（每域独立） |
+
+handoff-enabled track 应先读 `harvest-manifest.json`。应无条件展开 manifest 标出的 anomaly ranges。再按目标选其余 ledger ranges。仍可读其他 `2_cleaned` 文件。仍禁读 `1_raw`。旧项目 / local / legacy 继续全量读 cleaned。
 
 ### ❰G2❱ Sufficiency Gate: 拆解充分性
 
@@ -197,6 +199,7 @@ fetch-report 必填字段：tier 分层（T1/T2/T3）、翻页统计、错误汇
 6. **Gate 阻塞**：G0/G1/G2/G3 未通过时，后续 Stage 禁止启动
 7. **回退权限**：只有 Lead 可以决定 Stage 回退。G3 裁决 RECYCLE 时强制回退到 G0 重校准问题定义（区别于 FAIL 的原阶段补充）
 8. **主 session 只持指针**：Lead（主 session，`agent_id` 为空）对 `pipeline/**` 和 `deliverables/**` 下的文件只允许持有路径指针，禁止读取其内容（Read 工具 + Bash cat 类读取）。所有内容读取/生成/审阅由 subagent 在隔离上下文完成，回传 Lead 的只有 manifest/receipt/spec/delta-receipt（路径 + 结构化裁决摘要），永不含全文。物理焊死靠 PreToolUse `read_guard` hook。详见 [main-session-isolation-contracts.md](../../../docs/main-session-isolation-contracts.md)。
+9. **确定性交接（handoff-enabled panel）**：panel 成功后应先完成脱敏与 `finalize-handoff`，使 verify 进入 `READY`，再请求 G1。analyst 应先读 `harvest-manifest.json`，并展开 anomaly ranges。schema 权威在 `scripts/harvest_handoff.py`，本文不复制字段表。旧项目 / local / legacy 无此交接，继续全量读 cleaned。`check_project()` 只看 primary 文件名，不看 `track_*`。
 
 ### manifest / receipt / spec / delta-receipt 产物定义
 

--- a/plugins/deep-research/skills/deep-research/references/pipeline.md
+++ b/plugins/deep-research/skills/deep-research/references/pipeline.md
@@ -63,7 +63,7 @@ fetch-report 必填字段：tier 分层（T1/T2/T3）、翻页统计、错误汇
 | 执行者 | research-harvester（同一 Task，与 Acquisition 串行） |
 | 输入目录 | `pipeline/1_raw/` |
 | 输出目录 | `pipeline/2_cleaned/` |
-| 产物 | 脱敏后数据文件。handoff-enabled 的 panel 路径另产确定性交接：从 raw merged 做 L1/L2 脱敏，写入 `pipeline/2_cleaned/harvest-handoff.wip.json`（supplementary 为 `track_<raw_dir.name>-harvest-handoff.wip.json`；unclustered 脱敏正文走 `unclustered_claims`），再执行 `python3 harvest.py finalize-handoff --project-dir <proj> --out <raw_dir> --wip <wip>`。primary 正式产物为 `pipeline/2_cleaned/harvest-manifest.json`（compact，Lead 可读）与 `pipeline/2_cleaned/harvest-evidence.jsonl`（行寻址完整证据；Lead 禁读，即使远小于 8KiB）。finalize 成功后，verify 才变为 `READY` 并绑定 hashes。local / `--no-api` 不走 v1 确定性交接 |
+| 产物 | 脱敏后数据文件。handoff-enabled 的 panel 路径另产确定性交接：从 raw merged 做 L1/L2 脱敏，写入 `pipeline/2_cleaned/harvest-handoff.wip.json`（supplementary 为 `track_<raw_dir.name>-harvest-handoff.wip.json`；unclustered 脱敏正文走 `unclustered_claims`；`coverage_gaps` / `blind_spots` 只核条数，正文以 WIP 脱敏文本为准），再执行 `python3 harvest.py finalize-handoff --project-dir <proj> --out <raw_dir> --wip <wip>`。primary 正式产物为 `pipeline/2_cleaned/harvest-manifest.json`（compact，Lead 可读）与 `pipeline/2_cleaned/harvest-evidence.jsonl`（行寻址完整证据；Lead 禁读，即使远小于 8KiB）。finalize 成功后，verify 才变为 `READY` 并绑定 hashes。local / `--no-api` 不走 v1 确定性交接 |
 
 脱敏协议见 deep-research 插件的 research-harvester subagent。Acquisition 与 Sanitization 仍在同一 Task。
 

--- a/plugins/deep-research/skills/deep-research/references/principles.md
+++ b/plugins/deep-research/skills/deep-research/references/principles.md
@@ -54,6 +54,12 @@ deliverables/          → 最终交付物（draft/ + final/）
 - 修正机制走 **Correction Record**（见原则 5）：追加补偿文档而非覆盖原文。修正流是 deliverables 层的独立合法路径，**不算「反向」**——它不回写 pipeline，只在派生层叠加新视图。
 - analyst 禁止直接读 `1_raw/`，必须读 `2_cleaned/`；下游角色对 pipeline 上游只有读权限。
 
+**确定性交接**（handoff-enabled 的 panel 路径）：
+
+- 完整记录应落在 evidence ledger（`pipeline/2_cleaned/harvest-evidence.jsonl`）。压缩只改默认读取集合，不应删除 ledger 行。
+- 异常优先展开：manifest 标出的 anomaly ranges 应先读。无异常的 `corroborated` 簇可走 compressed 默认集。
+- 字段 schema 的权威在 `scripts/harvest_handoff.py`。本文只定职责，不复制 schema。生命周期见 [pipeline.md](./pipeline.md)。
+
 > **为何不是「禁止反向」**：旧铁律把 pipeline 与 deliverables 混为一条单向链，导致落地回填看似违规。分层后矛盾消解：pipeline 冻结是铁律，deliverables 可重算是常态，回填是正常重算而非违规。详见「框架演进调研」结论 1。
 
 ## 3. 可追溯性原则
@@ -94,7 +100,7 @@ deliverables/          → 最终交付物（draft/ + final/）
 - 关键事实**必须**通过至少 2 个独立源验证
 - 中英文双语搜索是强制要求，不是可选项
 - 每个核心概念必须用中英文分别搜索，建立术语对照表
-- 交叉验证记录格式（`excerpt` 为逐字摘录，保证可比对溯源）：
+- 交叉验证记录格式（人工记录用 `excerpt` 摘录原文，便于对照）。harvest 引用门只证明 URL 已 fetch（`url_fetched_only`），不应把摘录当成已做子串验证：
 
 ```
 事实: {具体事实描述}
@@ -103,7 +109,7 @@ deliverables/          → 最终交付物（draft/ + final/）
 一致性: 一致 / 有差异（说明差异点）
 ```
 
-> **共识 ≠ 正确**：多源重合度是参考信号，不是真值判据——三源一致可能共享同一上游谣言，单源观点也可能是唯一说对的。[quality-gates.md](./quality-gates.md) G3 证伪审计不因多源重合而放松审查。
+> **共识 ≠ 正确**：确定性交接里的 consensus 是导航信号，不等于 truth。三个标签为 `disputed`（`relation=contradict`）、`corroborated`（不少于 2 个不同 `source_model`）、`single-model`。`corroborated` 只说明多模型重合，不应当作已证实。`disputed` 与 `single-model` 应强制展开。三源一致仍可能共享同一上游谣言。单源观点仍可能是唯一说对的。[quality-gates.md](./quality-gates.md) G3 证伪审计不因多源重合而放松审查。
 
 - 中英文信息出现矛盾时，必须在分析中标注并说明可能原因（地域差异、时间差异、翻译失真）
 - 单一信息源引用不得超过 3 次（防止单源偏见）

--- a/plugins/deep-research/skills/deep-research/references/quality-gates.md
+++ b/plugins/deep-research/skills/deep-research/references/quality-gates.md
@@ -155,19 +155,31 @@ GATE_VERDICT: G<N> PASS|FAIL|RECYCLE
 
 ### 引用校验机械门（G1，harvest.py 项目）
 
-项目启用 `harvest.py` 采集时（通过 deep-research skill 说明的 harvest.py 路径发现约定获取，见 SKILL.md），G1 追加一道**确定性代码门**（非 LLM 判断），由 `python3 <harvest.py 路径> check <project-dir>` 执行，三态 exit code：
+项目启用 `harvest.py` 采集时（通过 deep-research skill 说明的 harvest.py 路径发现约定获取，见 SKILL.md），G1 追加一道**确定性代码门**（非 LLM 判断），由 `python3 <harvest.py 路径> check <project-dir>` 执行。`hooks/gate_check.py` 仍只调 `check_project()`，无新 hook。三态 exit code：
 
 | exit code | 含义 | G1 处置 |
 |-----------|------|---------|
-| 0 | PASS：引用校验通过、法定人数达标、claims > 0、（被拒 claim 数 < 2 或 INVALID 引用率 ≤ 5%） | 机械门通过，继续走上方 Sufficiency 评分 |
-| 1 | FAIL（含 `verdict: UNAVAILABLE`，即多模型采集全挂） | **G1 自动 FAIL 阻塞**，须上报用户裁决；**禁止静默转 legacy 继续采集**——不完整调研冒充完整调研比失败更糟。恢复路径：修复后重跑 `harvest.py run`，或经用户显式同意写入 `pipeline/verification/legacy-exemption.md` 后转 N/A |
-| 2 | N/A：项目从未启用 harvest.py（现行人工采集流程不受影响），或存在用户豁免记录 `legacy-exemption.md` | 机械门不适用，走现行人工 Sufficiency 审查 |
+| 0 | PASS：引用校验通过、法定人数达标、claims > 0、（被拒 claim 数 < 2 或 INVALID 引用率 ≤ 5%）；handoff-enabled 且 `READY` 时另加重算 primary hashes 与不变量 | 机械门通过，继续走上方 Sufficiency 评分 |
+| 1 | FAIL（含 `verdict: UNAVAILABLE`，即多模型采集全挂；也含交接未就绪，见下） | **G1 自动 FAIL 阻塞**，须上报用户裁决；**禁止静默转 legacy 继续采集**——不完整调研冒充完整调研比失败更糟。恢复路径：修复后重跑 `harvest.py run`（handoff-enabled 还须完成 `finalize-handoff`），或经用户显式同意写入 `pipeline/verification/legacy-exemption.md` 后转 N/A |
+| 2 | N/A：项目从未启用 harvest.py（无 verify）、存在用户豁免记录 `legacy-exemption.md`，或 `verdict=LOCAL`（`--no-api`） | 机械门不适用，走现行人工 Sufficiency 审查。local / exemption / 无 verify 仍为 N/A，不走 v1 确定性交接 |
+
+**v1 确定性交接协商**（只在 `verdict=OK` 记录上运行；`check_project()` 只看 primary 文件名，不看 `track_*`）：
+
+- 三个字段 `handoff_version` / `handoff_required` / `handoff_status` 全缺 → 旧路径（旧项目 / 手写 OK 测例），继续走上表既有 OK 检查。
+- 任一字段出现但不完整、`handoff_version` ≠ 1、或 `handoff_required` 不是 true → FAIL，不降级。
+- `handoff_status=PENDING_SANITIZATION` → FAIL。
+- `handoff_status=READY` → 先跑旧 OK 检查，再重算 primary `harvest-manifest.json` / `harvest-evidence.jsonl` / raw merged / goal hash 与不变量。
+- 字段 schema 的权威在 `scripts/harvest_handoff.py`。本文不复制字段表。
 
 引用率门槛是**双条件与**：被拒 claim 数 ≥ 2 **且** INVALID 引用率 > 5% 才判 FAIL——真实冒烟中出现过小样本下单条孤立被拒（已过一次重试、已被剔除出最终产物）把整锅判 FAIL 的假阳性，门槛本意是拦系统性造假，不是拦单条噪声。被拒 claim 的具体内容和拒绝原因见 `harvest/<alias>/rejected_claims.json`。
+
+citation 只证明 URL 已 fetch。产物标 `url_fetched_only`。不应把 citation 门写成 excerpt 子串门。
 
 法定人数达标但存在缺席模型（quorum_met = true，非全员存活）不算 FAIL，但 reviewer 须在报告中标注哪一路模型缺席及原因。
 
 机械门与 Sufficiency 评分是**与**关系：机械门 FAIL 直接阻塞，不进入评分；机械门 PASS/N/A 后仍须过既有覆盖度/时效性/可信度/双语平衡评分。
+
+hook 仍是技术 fail-open（拿不到项目路径、脚本异常时不拦）。业务 FAIL（`check_project()` 返回 FAIL，含交接未就绪）仍 fail-closed，阻塞 `GATE_VERDICT: G1 PASS`。
 
 ## 审阅 6 维度（mode=review）
 

--- a/plugins/deep-research/skills/deep-research/references/web-research.md
+++ b/plugins/deep-research/skills/deep-research/references/web-research.md
@@ -22,7 +22,7 @@ Lead 确定信息源策略，输出采集指令。
 
 ### 搜索关键词矩阵
 
-**harvest.py 项目（主路径）**：关键词矩阵不再由 Lead 预生成——由各面板模型（`panel_models` 配置，当前 gemini/gpt/claude）在 Acquisition 阶段自主分解研究目标、自定关键词，记录于各自 `findings.json` 的 `keywords_used: {zh: [], en: []}` 字段。三模型异构检索策略的并集由架构保证覆盖广度（消除单模型盲区）。Lead 在 Stage 1 只需定义研究目标/范围/约束，写入 goal-file，**不预生成关键词**。
+**harvest.py 项目（主路径）**：关键词矩阵不再由 Lead 预生成——由 configured panel（`harvest.config.json` 的 `panel_models`）在 Acquisition 阶段自主分解研究目标、自定关键词，记录于各自 `findings.json` 的 `keywords_used: {zh: [], en: []}` 字段。异构检索策略的并集由架构保证覆盖广度（消除单模型盲区）。Lead 在 Stage 1 只需定义研究目标/范围/约束，写入 goal-file，**不预生成关键词**。
 
 **legacy 链（未启用 harvest.py 或经用户豁免）**：仍需 Lead 建立中英文关键词矩阵：
 
@@ -63,7 +63,7 @@ harvester（Task subagent）执行采集。**禁止**在主上下文直接搜索
 python3 <harvest.py 路径> run --goal-file intake/requirements/research-goal.md --out pipeline/1_raw/ [--config <harvest.config.json 路径>] [--local-dir intake/local_sources]
 ```
 
-三个异构面板模型（由 `harvest.config.json` 的 `panel_models` 配置，当前为 gemini/gpt/claude 三家族）并行各跑独立 agentic loop 自主检索，内部 search 后端链按优先级降级（gemini-grounding → tavily → DuckDuckGo 兜底，见 [context-economics.md](./context-economics.md)）；merge 阶段裁判模型产出共识标签与 Fusion 五元组分析，落盘 `merged-findings.json` + 带机械门数据的 `fetch-report.md`。exit 3（`UNAVAILABLE`）时 harvester 停止并上报 Lead，**不自行转 fallback**（见 deep-research 插件的 research-harvester subagent 工具链）。
+configured panel（`harvest.config.json` 的 `panel_models` + `quorum`）并行各跑独立 agentic loop 自主检索，内部 search 后端链按优先级降级（gemini-grounding → tavily → DuckDuckGo 兜底，见 [context-economics.md](./context-economics.md)）；merge 阶段裁判模型产出 raw clusters（含 `relation`、`coverage_gaps`、`blind_spots`），落盘 `merged-findings.json` + 带机械门数据的 `fetch-report.md`。共识导航标签不在 raw merge 产物上，而由后续 `finalize-handoff` 写入 `harvest-manifest.json`。exit 3（`UNAVAILABLE`）时 harvester 停止并上报 Lead，**不自行转 fallback**（见 deep-research 插件的 research-harvester subagent 工具链）。
 
 **agentic loop 收敛语义（强制收尾兜底）**：每个 panel worker 的 loop 有 `max_steps_per_model` 轮工具预算（LLM 回合数，非工具调用数），system prompt 会告知该预算并引导「先双语搜索摸清源 → fetch 最相关几篇 → 主动停下吐 findings JSON」。**预算耗尽不再直接丢弃已采证据**：loop 结束后强制发一次收尾 synthesis 调用，让 worker 把已 fetch 的证据收敛成 findings，再走同一套引用机械门校验（追不到已 fetch 内容的 claim 照剔）。收尾仍无合法产出才判 `step_limit_no_synthesis` 失败。此设计避免「worker 采足证据却因未主动收尾被整个作废、进而拖垮 quorum」。`wall_clock_s` 超时是另一条独立硬停路径（濒临墙钟死线不再追加调用），不走强制收尾。
 

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -3338,6 +3338,108 @@ class TestHarvestHandoffGate(unittest.TestCase):
         data = json.loads(before)
         self.assertEqual(data["handoff_status"], "PENDING_SANITIZATION")
 
+    def test_finalize_rejects_goal_change_and_keeps_pending(self):
+        raw, wip = self._sample()
+        (self.raw_dir / harvest.MERGED_FINDINGS_FILE).write_text(
+            json.dumps(raw), encoding="utf-8")
+        harvest.write_verify_json(self.verify_dir, self.goal_hash, "OK", {
+            "quorum_met": True, "total_claims": 2, "invalid_citation_rate": 0.0,
+            "models_alive": ["m1", "m2"],
+            "handoff_version": 1, "handoff_required": True,
+            "handoff_status": "PENDING_SANITIZATION",
+        })
+        verify_path = self.verify_dir / harvest.VERIFY_FILE
+        before = verify_path.read_bytes()
+        wip_path = self.cleaned / "harvest-handoff.wip.json"
+        wip_path.write_text(json.dumps(wip), encoding="utf-8")
+        self.goal.write_text("goal changed before finalize", encoding="utf-8")
+        with self.assertRaises(SystemExit) as ctx:
+            harvest.cmd_finalize_handoff(argparse_ns(
+                project_dir=str(self.project_dir), out=str(self.raw_dir), wip=str(wip_path)))
+        self.assertNotEqual(ctx.exception.code, 0)
+        self.assertEqual(verify_path.read_bytes(), before)
+        data = json.loads(before)
+        self.assertEqual(data["handoff_status"], "PENDING_SANITIZATION")
+        self.assertEqual(data["goal_file_sha256"], self.goal_hash)
+        self.assertFalse((self.cleaned / "harvest-manifest.json").exists())
+
+    def test_finalize_rejects_local_verify_without_writing(self):
+        raw, wip = self._sample()
+        (self.raw_dir / harvest.MERGED_FINDINGS_FILE).write_text(
+            json.dumps(raw), encoding="utf-8")
+        harvest.write_verify_json(self.verify_dir, self.goal_hash, "LOCAL", {
+            "reason": "no-api",
+        })
+        verify_path = self.verify_dir / harvest.VERIFY_FILE
+        before = verify_path.read_bytes()
+        wip_path = self.cleaned / "harvest-handoff.wip.json"
+        wip_path.write_text(json.dumps(wip), encoding="utf-8")
+        with self.assertRaises(SystemExit) as ctx:
+            harvest.cmd_finalize_handoff(argparse_ns(
+                project_dir=str(self.project_dir), out=str(self.raw_dir), wip=str(wip_path)))
+        self.assertNotEqual(ctx.exception.code, 0)
+        self.assertEqual(verify_path.read_bytes(), before)
+        self.assertEqual(json.loads(before)["verdict"], "LOCAL")
+        self.assertFalse((self.cleaned / "harvest-manifest.json").exists())
+
+    def test_finalize_ready_rerun_is_byte_identical(self):
+        raw, wip = self._publish_ready()
+        wip_path = self.cleaned / "harvest-handoff.wip.json"
+        wip_path.write_text(json.dumps(wip), encoding="utf-8")
+        man_path = self.cleaned / "harvest-manifest.json"
+        ev_path = self.cleaned / "harvest-evidence.jsonl"
+        before_man = man_path.read_bytes()
+        before_ev = ev_path.read_bytes()
+        harvest.cmd_finalize_handoff(argparse_ns(
+            project_dir=str(self.project_dir), out=str(self.raw_dir), wip=str(wip_path)))
+        self.assertEqual(man_path.read_bytes(), before_man)
+        self.assertEqual(ev_path.read_bytes(), before_ev)
+        data = json.loads((self.verify_dir / harvest.VERIFY_FILE).read_text(encoding="utf-8"))
+        self.assertEqual(data["handoff_status"], "READY")
+        self.assertEqual(data["verdict"], "OK")
+        self.assertEqual(data["goal_file_sha256"], self.goal_hash)
+
+    def test_supplementary_invalid_track_name_leaves_primary(self):
+        raw, wip = self._sample()
+        (self.raw_dir / harvest.MERGED_FINDINGS_FILE).write_text(
+            json.dumps(raw), encoding="utf-8")
+        harvest.write_verify_json(self.verify_dir, self.goal_hash, "OK", {
+            "quorum_met": True, "total_claims": 2, "invalid_citation_rate": 0.0,
+            "handoff_version": 1, "handoff_required": True,
+            "handoff_status": "PENDING_SANITIZATION",
+        })
+        primary_verify = (self.verify_dir / harvest.VERIFY_FILE).read_bytes()
+        primary_manifest = self.cleaned / "harvest-manifest.json"
+        primary_manifest.write_text("primary-keep", encoding="utf-8")
+        supp_raw_dir = self.raw_dir / "gap_A"
+        supp_raw_dir.mkdir()
+        (supp_raw_dir / harvest.MERGED_FINDINGS_FILE).write_text(
+            json.dumps(raw), encoding="utf-8")
+        harvest.write_verify_json(self.verify_dir, self.goal_hash, "OK", {
+            "quorum_met": True, "total_claims": 2, "invalid_citation_rate": 0.0,
+            "models_alive": ["m1", "m2"],
+            "handoff_version": 1, "handoff_required": True,
+            "handoff_status": "PENDING_SANITIZATION",
+        }, verify_filename=harvest.track_verify_filename(supp_raw_dir))
+        track_verify = (self.verify_dir / harvest.track_verify_filename(supp_raw_dir)).read_bytes()
+        wip_path = self.cleaned / "harvest-handoff.wip.json"
+        wip_path.write_text(json.dumps(wip), encoding="utf-8")
+        # Path('gap_A/nested/..').name is '..' while resolve() stays supplementary.
+        with self.assertRaises(SystemExit) as ctx:
+            harvest.cmd_finalize_handoff(argparse_ns(
+                project_dir=str(self.project_dir),
+                out=str(supp_raw_dir / "nested" / ".."),
+                wip=str(wip_path)))
+        self.assertNotEqual(ctx.exception.code, 0)
+        self.assertEqual((self.verify_dir / harvest.VERIFY_FILE).read_bytes(), primary_verify)
+        self.assertEqual(primary_manifest.read_text(encoding="utf-8"), "primary-keep")
+        self.assertEqual(
+            (self.verify_dir / harvest.track_verify_filename(supp_raw_dir)).read_bytes(),
+            track_verify,
+        )
+        self.assertFalse((self.cleaned / "track_gap_A-harvest-manifest.json").exists())
+        self.assertFalse((self.cleaned / "track_..-harvest-manifest.json").exists())
+
     def test_t1_supplementary_finalize_does_not_touch_primary(self):
         primary_raw, primary_wip = self._sample()
         (self.raw_dir / harvest.MERGED_FINDINGS_FILE).write_text(
@@ -3443,6 +3545,18 @@ class TestStateCleanup(unittest.TestCase):
         for name in ("harvest-manifest.json", "harvest-evidence.jsonl", "harvest-handoff.wip.json"):
             self.assertFalse((cleaned / name).exists())
         self.assertTrue((cleaned / "keep-me.md").exists())
+
+    def test_cleaned_dir_from_raw_without_pipeline_returns_none(self):
+        stray = Path(self.tmpdir.name) / "outside" / "1_raw"
+        stray.mkdir(parents=True)
+        victim = Path(self.tmpdir.name) / "outside" / "2_cleaned"
+        victim.mkdir()
+        keep = victim / "keep.txt"
+        keep.write_text("stay", encoding="utf-8")
+        self.assertIsNone(harvest._cleaned_dir_from_raw(stray))
+        harvest._unlink_handoff_artifacts(harvest._cleaned_dir_from_raw(stray))
+        self.assertTrue(keep.exists())
+        self.assertEqual(keep.read_text(encoding="utf-8"), "stay")
 
     def test_cleanup_no_op_when_nothing_present(self):
         harvest.cleanup_stale_state(self.pipeline_dir, self.verify_dir, self.raw_dir)  # must not raise
@@ -4048,6 +4162,10 @@ class TestSupplementaryRunIsolation(unittest.TestCase):
         # Primary state never touched.
         self.assertTrue(primary_verify_file.exists())
         self.assertTrue(primary_exemption_file.exists())
+        self.assertTrue(primary_merged.exists())
+        self.assertEqual(primary_merged.read_text(encoding="utf-8"), "{}")
+        self.assertTrue((primary_harvest_dir / "marker.txt").exists())
+        self.assertEqual((primary_harvest_dir / "marker.txt").read_text(encoding="utf-8"), "keep me")
 
     def test_supplementary_cleanup_removes_only_track_handoff_files(self):
         verify_dir = self.project_dir / "pipeline" / "verification"

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -1,3 +1,4 @@
+import hashlib
 import io
 import json
 import os
@@ -15,6 +16,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 import harvest  # noqa: E402
 import harvest_fetch  # noqa: E402
+import harvest_handoff  # noqa: E402
 import harvest_journal  # noqa: E402
 import harvest_safety  # noqa: E402
 import harvest_search  # noqa: E402
@@ -90,6 +92,29 @@ def assistant_final(content):
 def findings_block(claims, zh=None, en=None):
     payload = {"claims": claims, "keywords_used": {"zh": zh or [], "en": en or []}, "term_map": []}
     return "```json\n" + json.dumps(payload, ensure_ascii=False) + "\n```"
+
+
+def _wip_from_merged(merged):
+    """Build a closed-schema WIP from merge_findings output. Tests load harvest, not a copy."""
+    return {
+        "schema": "harvest-handoff-wip",
+        "handoff_version": 1,
+        "clusters": [
+            {
+                "cluster_id": cluster["cluster_id"],
+                "summary": cluster["summary"],
+                "relation": cluster["relation"],
+                "claims": list(cluster["claims"]),
+            }
+            for cluster in merged["clusters"]
+        ],
+        "coverage_gaps": list(merged.get("coverage_gaps") or []),
+        "blind_spots": list(merged.get("blind_spots") or []),
+        "contradictions": list(merged.get("contradictions") or []),
+        "unique_insights": list(merged.get("unique_insights") or []),
+        "unclustered_claim_ids": list(merged.get("unclustered_claim_ids") or []),
+        "unclustered_claims": [dict(c) for c in (merged.get("unclustered_claims") or [])],
+    }
 
 
 class FakeHTTPResponse:
@@ -2869,6 +2894,19 @@ class TestMergeFindings(unittest.TestCase):
         self.assertEqual(len(merged["clusters"]), 1)
         self.assertEqual(merged["clusters"][0]["summary"], "first")
 
+    def test_merge_attaches_cluster_id_relation_source_and_unclustered(self):
+        judge = {"clusters": [{"summary": "s", "source_claim_ids": ["m1-1", "m2-1"], "relation": "agree"}],
+                 "coverage_gaps": [], "unique_insights": [], "blind_spots": []}
+        merged = harvest.merge_findings(self.worker_findings, judge)
+        self.assertEqual(merged["clusters"][0]["cluster_id"], "c001")
+        self.assertEqual(merged["clusters"][0]["relation"], "agree")
+        by_id = {c["id"]: c["source_model"] for c in merged["clusters"][0]["claims"]}
+        self.assertEqual(by_id["m1-1"], "m1")
+        self.assertEqual(by_id["m2-1"], "m2")
+        self.assertEqual(merged["unclustered_claim_ids"], ["m3-1"])
+        self.assertEqual(merged["unclustered_claims"][0]["id"], "m3-1")
+        self.assertEqual(merged["unclustered_claims"][0]["source_model"], "m3")
+
 
 class TestJudgeFallback(unittest.TestCase):
     def test_judge_falls_back_to_next_panel_model_on_failure(self):
@@ -3128,10 +3166,242 @@ class TestCheckProject(unittest.TestCase):
         root_file.write_text("y", encoding="utf-8")
         self.assertEqual(harvest.resolve_goal_file(self.project_dir), root_file)
 
+    def test_h1_pending_fields_fail_even_when_quorum_ok(self):
+        self._write_verify(handoff_version=1, handoff_required=True,
+                           handoff_status="PENDING_SANITIZATION")
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "FAIL")
+        self.assertIn("pending", reason.lower())
+
 
 class TestCmdCheckExitCodes(unittest.TestCase):
     def test_verdict_exit_code_mapping(self):
         self.assertEqual(harvest._VERDICT_EXIT_CODES, {"PASS": 0, "FAIL": 1, "N_A": 2})
+
+
+class TestHarvestHandoffGate(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.project_dir = Path(self.tmpdir.name)
+        self.pipeline = self.project_dir / "pipeline"
+        self.raw_dir = self.pipeline / "1_raw"
+        self.cleaned = self.pipeline / "2_cleaned"
+        self.verify_dir = self.pipeline / "verification"
+        self.raw_dir.mkdir(parents=True)
+        self.cleaned.mkdir(parents=True)
+        self.verify_dir.mkdir(parents=True)
+        self.goal = self.project_dir / harvest.GOAL_FILE_NAME
+        self.goal.write_text("goal", encoding="utf-8")
+        self.goal_hash = hashlib.sha256(self.goal.read_bytes()).hexdigest()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _sample(self):
+        claim_a = {
+            "id": "m1-1", "claim": "A", "excerpt": "eA", "url": "https://ex.test/a",
+            "language": "en", "credibility": 4, "source_model": "m1",
+        }
+        claim_b = {
+            "id": "m2-1", "claim": "B", "excerpt": "eB", "url": "https://ex.test/b",
+            "language": "en", "credibility": 4, "source_model": "m2",
+        }
+        raw = {
+            "clusters": [{
+                "cluster_id": "c001", "summary": "s", "relation": "agree",
+                "claims": [claim_a, claim_b],
+            }],
+            "coverage_gaps": [],
+            "blind_spots": [],
+            "contradictions": [],
+            "unique_insights": [],
+            "unclustered_claim_ids": [],
+            "unclustered_claims": [],
+        }
+        return raw, _wip_from_merged(raw)
+
+    def _publish_ready(self):
+        raw, wip = self._sample()
+        raw_path = self.raw_dir / harvest.MERGED_FINDINGS_FILE
+        raw_path.write_text(json.dumps(raw, ensure_ascii=False, indent=2), encoding="utf-8")
+        harvest_handoff.publish_handoff(
+            self.cleaned, wip, raw,
+            goal_file_sha256=self.goal_hash,
+            raw_merged_sha256=harvest_handoff.file_sha256(raw_path),
+            alive_models=["m1", "m2"],
+        )
+        extra = {
+            "quorum_met": True,
+            "total_claims": 2,
+            "invalid_citation_rate": 0.0,
+            "invalid_claim_count": 0,
+            "models_alive": ["m1", "m2"],
+            "handoff_version": 1,
+            "handoff_required": True,
+            "handoff_status": "READY",
+            "manifest_sha256": harvest_handoff.file_sha256(self.cleaned / "harvest-manifest.json"),
+            "evidence_sha256": harvest_handoff.file_sha256(self.cleaned / "harvest-evidence.jsonl"),
+            "raw_merged_sha256": harvest_handoff.file_sha256(raw_path),
+        }
+        harvest.write_verify_json(self.verify_dir, self.goal_hash, "OK", extra)
+        return raw, wip
+
+    def test_h3_missing_manifest_fails(self):
+        self._publish_ready()
+        (self.cleaned / "harvest-manifest.json").unlink()
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "FAIL")
+        self.assertIn("harvest-manifest.json", reason)
+
+    def test_h3_missing_evidence_fails(self):
+        self._publish_ready()
+        (self.cleaned / "harvest-evidence.jsonl").unlink()
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "FAIL")
+        self.assertIn("harvest-evidence.jsonl", reason)
+
+    def test_h3_bad_json_fails(self):
+        self._publish_ready()
+        (self.cleaned / "harvest-manifest.json").write_text("not-json", encoding="utf-8")
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "FAIL")
+
+    def test_h3_hash_mismatch_fails(self):
+        self._publish_ready()
+        payload = json.loads((self.verify_dir / harvest.VERIFY_FILE).read_text(encoding="utf-8"))
+        payload["manifest_sha256"] = "0" * 64
+        (self.verify_dir / harvest.VERIFY_FILE).write_text(json.dumps(payload), encoding="utf-8")
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "FAIL")
+        self.assertIn("manifest_sha256", reason)
+
+    def test_h3_goal_change_fails(self):
+        self._publish_ready()
+        self.goal.write_text("goal changed", encoding="utf-8")
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "FAIL")
+
+    def test_h3_raw_change_fails(self):
+        self._publish_ready()
+        raw_path = self.raw_dir / harvest.MERGED_FINDINGS_FILE
+        raw = json.loads(raw_path.read_text(encoding="utf-8"))
+        raw["coverage_gaps"] = ["new gap"]
+        raw_path.write_text(json.dumps(raw), encoding="utf-8")
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "FAIL")
+
+    def test_h3_incomplete_marker_fails(self):
+        harvest.write_verify_json(self.verify_dir, self.goal_hash, "OK", {
+            "quorum_met": True, "total_claims": 2, "invalid_citation_rate": 0.0,
+            "handoff_status": "READY",
+        })
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "FAIL")
+        self.assertIn("incomplete", reason)
+
+    def test_h4_evidence_only_stays_pending(self):
+        raw, wip = self._sample()
+        (self.raw_dir / harvest.MERGED_FINDINGS_FILE).write_text(
+            json.dumps(raw), encoding="utf-8")
+        harvest.write_verify_json(self.verify_dir, self.goal_hash, "OK", {
+            "quorum_met": True, "total_claims": 2, "invalid_citation_rate": 0.0,
+            "handoff_version": 1, "handoff_required": True,
+            "handoff_status": "PENDING_SANITIZATION",
+        })
+        (self.cleaned / "harvest-evidence.jsonl").write_text("{}\n", encoding="utf-8")
+        data = json.loads((self.verify_dir / harvest.VERIFY_FILE).read_text(encoding="utf-8"))
+        self.assertNotEqual(data.get("handoff_status"), "READY")
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "FAIL")
+        self.assertIn("pending", reason.lower())
+
+    def test_h4_failed_finalize_leaves_verify_bytes(self):
+        raw, wip = self._sample()
+        (self.raw_dir / harvest.MERGED_FINDINGS_FILE).write_text(
+            json.dumps(raw), encoding="utf-8")
+        harvest.write_verify_json(self.verify_dir, self.goal_hash, "OK", {
+            "quorum_met": True, "total_claims": 2, "invalid_citation_rate": 0.0,
+            "models_alive": ["m1", "m2"],
+            "handoff_version": 1, "handoff_required": True,
+            "handoff_status": "PENDING_SANITIZATION",
+        })
+        verify_path = self.verify_dir / harvest.VERIFY_FILE
+        before = verify_path.read_bytes()
+        wip["clusters"][0]["claims"] = [wip["clusters"][0]["claims"][0]]
+        wip_path = self.cleaned / "harvest-handoff.wip.json"
+        wip_path.write_text(json.dumps(wip), encoding="utf-8")
+        with self.assertRaises(SystemExit) as ctx:
+            harvest.cmd_finalize_handoff(argparse_ns(
+                project_dir=str(self.project_dir), out=str(self.raw_dir), wip=str(wip_path)))
+        self.assertNotEqual(ctx.exception.code, 0)
+        self.assertEqual(verify_path.read_bytes(), before)
+        data = json.loads(before)
+        self.assertEqual(data["handoff_status"], "PENDING_SANITIZATION")
+
+    def test_t1_supplementary_finalize_does_not_touch_primary(self):
+        primary_raw, primary_wip = self._sample()
+        (self.raw_dir / harvest.MERGED_FINDINGS_FILE).write_text(
+            json.dumps(primary_raw), encoding="utf-8")
+        harvest.write_verify_json(self.verify_dir, self.goal_hash, "OK", {
+            "quorum_met": True, "total_claims": 2, "invalid_citation_rate": 0.0,
+            "handoff_version": 1, "handoff_required": True,
+            "handoff_status": "PENDING_SANITIZATION",
+        })
+        primary_verify = (self.verify_dir / harvest.VERIFY_FILE).read_bytes()
+        primary_manifest = self.cleaned / "harvest-manifest.json"
+        primary_manifest.write_text("primary-keep", encoding="utf-8")
+
+        supp_raw_dir = self.raw_dir / "gap_A"
+        supp_raw_dir.mkdir()
+        (supp_raw_dir / harvest.MERGED_FINDINGS_FILE).write_text(
+            json.dumps(primary_raw), encoding="utf-8")
+        track_name = harvest.track_verify_filename(supp_raw_dir)
+        harvest.write_verify_json(self.verify_dir, self.goal_hash, "OK", {
+            "quorum_met": True, "total_claims": 2, "invalid_citation_rate": 0.0,
+            "models_alive": ["m1", "m2"],
+            "handoff_version": 1, "handoff_required": True,
+            "handoff_status": "PENDING_SANITIZATION",
+        }, verify_filename=track_name)
+        wip_path = self.cleaned / f"track_{supp_raw_dir.name}-harvest-handoff.wip.json"
+        wip_path.write_text(json.dumps(primary_wip), encoding="utf-8")
+        harvest.cmd_finalize_handoff(argparse_ns(
+            project_dir=str(self.project_dir), out=str(supp_raw_dir), wip=str(wip_path)))
+
+        self.assertEqual((self.verify_dir / harvest.VERIFY_FILE).read_bytes(), primary_verify)
+        self.assertEqual(primary_manifest.read_text(encoding="utf-8"), "primary-keep")
+        self.assertTrue((self.cleaned / f"track_{supp_raw_dir.name}-harvest-manifest.json").is_file())
+        self.assertTrue((self.cleaned / f"track_{supp_raw_dir.name}-harvest-evidence.jsonl").is_file())
+        track = json.loads((self.verify_dir / track_name).read_text(encoding="utf-8"))
+        self.assertEqual(track["handoff_status"], "READY")
+        self.assertFalse(wip_path.exists())
+
+    def test_h3_unreadable_evidence_encoding_fails_without_raising(self):
+        self._publish_ready()
+        ev_path = self.cleaned / "harvest-evidence.jsonl"
+        ev_path.write_bytes(b"\xff\xfe not-utf8 \x80\x81")
+        try:
+            verdict, reason = harvest.check_project(self.project_dir)
+        except Exception as exc:  # noqa: BLE001 — gate must not leak
+            self.fail(f"check_project raised {type(exc).__name__}: {exc}")
+        self.assertEqual(verdict, "FAIL")
+        self.assertIn("unreadable", reason.lower())
+
+    def test_h3_unreadable_evidence_permission_fails_without_raising(self):
+        self._publish_ready()
+        ev_path = self.cleaned / "harvest-evidence.jsonl"
+        original_mode = ev_path.stat().st_mode
+        os.chmod(ev_path, 0)
+        try:
+            if os.access(ev_path, os.R_OK):
+                self.skipTest("environment still allows reading chmod-0 evidence")
+            try:
+                verdict, reason = harvest.check_project(self.project_dir)
+            except Exception as exc:  # noqa: BLE001 — gate must not leak
+                self.fail(f"check_project raised {type(exc).__name__}: {exc}")
+            self.assertEqual(verdict, "FAIL")
+            self.assertIn("unreadable", reason.lower())
+        finally:
+            os.chmod(ev_path, original_mode)
 
 
 # ---------------------------------------------------------------------------
@@ -3158,12 +3428,21 @@ class TestStateCleanup(unittest.TestCase):
         (self.raw_dir / harvest.HARVEST_SUBDIR).mkdir()
         (self.raw_dir / harvest.HARVEST_SUBDIR / "leftover.txt").write_text("x", encoding="utf-8")
 
+        cleaned = self.pipeline_dir / "2_cleaned"
+        cleaned.mkdir()
+        for name in ("harvest-manifest.json", "harvest-evidence.jsonl", "harvest-handoff.wip.json"):
+            (cleaned / name).write_text("stale", encoding="utf-8")
+        (cleaned / "keep-me.md").write_text("keep", encoding="utf-8")
+
         harvest.cleanup_stale_state(self.pipeline_dir, self.verify_dir, self.raw_dir)
 
         self.assertFalse((self.verify_dir / harvest.VERIFY_FILE).exists())
         self.assertFalse((self.verify_dir / harvest.LEGACY_EXEMPTION_FILE).exists())
         self.assertFalse((self.raw_dir / harvest.MERGED_FINDINGS_FILE).exists())
         self.assertFalse((self.raw_dir / harvest.HARVEST_SUBDIR).exists())
+        for name in ("harvest-manifest.json", "harvest-evidence.jsonl", "harvest-handoff.wip.json"):
+            self.assertFalse((cleaned / name).exists())
+        self.assertTrue((cleaned / "keep-me.md").exists())
 
     def test_cleanup_no_op_when_nothing_present(self):
         harvest.cleanup_stale_state(self.pipeline_dir, self.verify_dir, self.raw_dir)  # must not raise
@@ -3273,6 +3552,9 @@ class TestCmdRunEndToEnd(unittest.TestCase):
         self.assertEqual(data["invalid_citation_rate"], 0.0)
         self.assertIn("harvest_wall_s", data)
         self.assertGreaterEqual(data["harvest_wall_s"], 0)
+        self.assertEqual(data["handoff_version"], 1)
+        self.assertIs(data["handoff_required"], True)
+        self.assertEqual(data["handoff_status"], "PENDING_SANITIZATION")
 
         merged_file = self.raw_dir / harvest.MERGED_FINDINGS_FILE
         self.assertTrue(merged_file.exists())
@@ -3288,7 +3570,8 @@ class TestCmdRunEndToEnd(unittest.TestCase):
             self.assertEqual(json.loads(rejected_file.read_text(encoding="utf-8")), [])
 
         verdict, reason = harvest.check_project(self.project_dir)
-        self.assertEqual(verdict, "PASS", reason)
+        self.assertEqual(verdict, "FAIL", reason)
+        self.assertIn("pending", reason.lower())
 
     def test_zero_valid_claims_aborts_unavailable(self):
         # Quorum is met (all three workers return status OK) but every
@@ -3374,9 +3657,13 @@ class TestCmdRunEndToEnd(unittest.TestCase):
         self.assertTrue(data["quorum_met"])
         self.assertEqual(set(data["models_alive"]), {"m1", "m2"})
         self.assertEqual(data["total_claims"], 2)
+        self.assertEqual(data["handoff_version"], 1)
+        self.assertIs(data["handoff_required"], True)
+        self.assertEqual(data["handoff_status"], "PENDING_SANITIZATION")
 
         verdict, reason = harvest.check_project(self.project_dir)
-        self.assertEqual(verdict, "PASS", reason)
+        self.assertEqual(verdict, "FAIL", reason)
+        self.assertIn("pending", reason.lower())
 
     def test_local_dir_falls_back_to_config_when_cli_flag_omitted(self):
         # local_sources.enabled=True + a configured relative dir, but the
@@ -3507,6 +3794,50 @@ class TestCmdRunEndToEnd(unittest.TestCase):
                 harvest.cmd_run(args)
 
         self.assertFalse((verify_dir / harvest.LEGACY_EXEMPTION_FILE).exists())
+
+    def test_h2_int_finalize_after_run_makes_check_pass(self):
+        fact = "Rayleigh scattering explains why the sky looks blue."
+        panel_scripts = {
+            model_id: ScriptedClient([
+                assistant_tool_call("c1", "fetch", {"url": "https://example.com/page1"}),
+                assistant_final(findings_block([
+                    {"claim": f"claim from {model_id}", "excerpt": fact, "url": "https://example.com/page1",
+                     "credibility": 4, "language": "en"}])),
+            ])
+            for model_id in ["model-a", "model-b", "model-c"]
+        }
+        judge_text = ('```json\n{"clusters": [{"summary": "blue sky consensus", '
+                      '"source_claim_ids": ["m1-1", "m2-1", "m3-1"], "relation": "agree"}], '
+                      '"coverage_gaps": [], "unique_insights": [], "blind_spots": []}\n```')
+        judge_client = ScriptedClient([assistant_final(judge_text)])
+
+        def factory(model_id):
+            if model_id == "model-judge":
+                return judge_client
+            return panel_scripts[model_id]
+
+        args = argparse_ns(goal_file=str(self.goal_file), out=str(self.raw_dir), config="unused", local_dir=None)
+        with mock.patch("harvest.load_config", return_value=base_config()), \
+             mock.patch("harvest.make_client_factory", return_value=factory), \
+             mock.patch("harvest_fetch.call_fetch_backend", return_value=fact):
+            harvest.cmd_run(args)
+
+        merged = json.loads((self.raw_dir / harvest.MERGED_FINDINGS_FILE).read_text(encoding="utf-8"))
+        cleaned = self.pipeline_dir / "2_cleaned"
+        cleaned.mkdir(parents=True, exist_ok=True)
+        wip_path = cleaned / "harvest-handoff.wip.json"
+        wip_path.write_text(json.dumps(_wip_from_merged(merged), ensure_ascii=False), encoding="utf-8")
+        harvest.cmd_finalize_handoff(argparse_ns(
+            project_dir=str(self.project_dir), out=str(self.raw_dir), wip=str(wip_path)))
+
+        data = json.loads((self.pipeline_dir / "verification" / harvest.VERIFY_FILE).read_text(encoding="utf-8"))
+        self.assertEqual(data["verdict"], "OK")
+        self.assertEqual(data["handoff_status"], "READY")
+        self.assertTrue((cleaned / "harvest-manifest.json").is_file())
+        self.assertTrue((cleaned / "harvest-evidence.jsonl").is_file())
+        self.assertFalse(wip_path.exists())
+        verdict, reason = harvest.check_project(self.project_dir)
+        self.assertEqual(verdict, "PASS", reason)
 
 
 class TestCmdRunGoalFileResolution(unittest.TestCase):
@@ -3717,8 +4048,24 @@ class TestSupplementaryRunIsolation(unittest.TestCase):
         # Primary state never touched.
         self.assertTrue(primary_verify_file.exists())
         self.assertTrue(primary_exemption_file.exists())
-        self.assertTrue(primary_merged.exists())
-        self.assertTrue((primary_harvest_dir / "marker.txt").exists())
+
+    def test_supplementary_cleanup_removes_only_track_handoff_files(self):
+        verify_dir = self.project_dir / "pipeline" / "verification"
+        verify_dir.mkdir(parents=True)
+        cleaned = self.project_dir / "pipeline" / "2_cleaned"
+        cleaned.mkdir(parents=True)
+        (cleaned / "harvest-manifest.json").write_text("primary", encoding="utf-8")
+        (cleaned / "track_gap_A-harvest-manifest.json").write_text("t", encoding="utf-8")
+        (cleaned / "track_gap_A-harvest-evidence.jsonl").write_text("t", encoding="utf-8")
+        (cleaned / "track_gap_A-harvest-handoff.wip.json").write_text("t", encoding="utf-8")
+        supplementary_raw_dir = self.project_dir / "pipeline" / "1_raw" / "gap_A"
+        supplementary_raw_dir.mkdir(parents=True)
+        harvest.cleanup_stale_supplementary_state(
+            verify_dir, supplementary_raw_dir, harvest.track_verify_filename(supplementary_raw_dir))
+        self.assertTrue((cleaned / "harvest-manifest.json").exists())
+        self.assertFalse((cleaned / "track_gap_A-harvest-manifest.json").exists())
+        self.assertFalse((cleaned / "track_gap_A-harvest-evidence.jsonl").exists())
+        self.assertFalse((cleaned / "track_gap_A-harvest-handoff.wip.json").exists())
 
     def test_no_project_dir_preserves_legacy_reverse_derivation(self):
         # No --project-dir at all (attribute absent from the args namespace,

--- a/plugins/deep-research/tests/test_harvest.py
+++ b/plugins/deep-research/tests/test_harvest.py
@@ -2907,6 +2907,14 @@ class TestMergeFindings(unittest.TestCase):
         self.assertEqual(merged["unclustered_claims"][0]["id"], "m3-1")
         self.assertEqual(merged["unclustered_claims"][0]["source_model"], "m3")
 
+    def test_unknown_judge_relation_normalizes_to_contradict(self):
+        judge = {"clusters": [{"summary": "maybe-s", "source_claim_ids": ["m1-1", "m2-1"],
+                               "relation": "maybe"}],
+                 "coverage_gaps": [], "unique_insights": [], "blind_spots": []}
+        merged = harvest.merge_findings(self.worker_findings, judge)
+        self.assertEqual(merged["clusters"][0]["relation"], "contradict")
+        self.assertIn("maybe-s", merged["contradictions"])
+
 
 class TestJudgeFallback(unittest.TestCase):
     def test_judge_falls_back_to_next_panel_model_on_failure(self):
@@ -4184,6 +4192,19 @@ class TestSupplementaryRunIsolation(unittest.TestCase):
         self.assertFalse((cleaned / "track_gap_A-harvest-manifest.json").exists())
         self.assertFalse((cleaned / "track_gap_A-harvest-evidence.jsonl").exists())
         self.assertFalse((cleaned / "track_gap_A-harvest-handoff.wip.json").exists())
+
+    def test_cleanup_illegal_track_name_does_not_raise(self):
+        verify_dir = self.project_dir / "pipeline" / "verification"
+        verify_dir.mkdir(parents=True)
+        cleaned = self.project_dir / "pipeline" / "2_cleaned"
+        cleaned.mkdir(parents=True)
+        primary = cleaned / "harvest-manifest.json"
+        primary.write_text("primary-keep", encoding="utf-8")
+        raw_dir = self.project_dir / "pipeline" / "1_raw" / "gap" / ".."
+        harvest.cleanup_stale_supplementary_state(verify_dir, raw_dir, "track_x.json")
+        harvest._unlink_handoff_artifacts(cleaned, track_name="..")
+        self.assertTrue(primary.exists())
+        self.assertEqual(primary.read_text(encoding="utf-8"), "primary-keep")
 
     def test_no_project_dir_preserves_legacy_reverse_derivation(self):
         # No --project-dir at all (attribute absent from the args namespace,

--- a/plugins/deep-research/tests/test_harvest_handoff.py
+++ b/plugins/deep-research/tests/test_harvest_handoff.py
@@ -1,0 +1,513 @@
+"""Harvest handoff closed-schema / publish / consensus tests.
+
+Imports harvest_handoff only — never harvest.py — so CLI side effects stay out.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+HANDOFF_PATH = Path(__file__).resolve().parents[1] / "scripts" / "harvest_handoff.py"
+
+
+def _load_handoff():
+    spec = importlib.util.spec_from_file_location("harvest_handoff", HANDOFF_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["harvest_handoff"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+hh = _load_handoff()
+
+
+def _claim(cid, model="gpt", cred=4, claim="c", excerpt="e", url="https://ex.test/a"):
+    return {
+        "id": cid,
+        "claim": claim,
+        "excerpt": excerpt,
+        "url": url,
+        "language": "en",
+        "credibility": cred,
+        "source_model": model,
+    }
+
+
+def _cluster(cid, claims, relation="agree", summary="s"):
+    return {
+        "cluster_id": cid,
+        "summary": summary,
+        "relation": relation,
+        "claims": claims,
+    }
+
+
+def _raw_and_wip(clusters, *, gaps=None, blinds=None, insights=None,
+                 unclustered=None, contradictions=None):
+    unclustered = unclustered or []
+    raw = {
+        "clusters": [
+            {
+                "cluster_id": c["cluster_id"],
+                "summary": c["summary"],
+                "relation": c["relation"],
+                "claims": list(c["claims"]),
+            }
+            for c in clusters
+        ],
+        "coverage_gaps": list(gaps or []),
+        "blind_spots": list(blinds or []),
+        "contradictions": list(contradictions or []),
+        "unique_insights": list(insights or []),
+        "unclustered_claim_ids": [c["id"] for c in unclustered],
+        "unclustered_claims": list(unclustered),
+    }
+    wip = {
+        "schema": "harvest-handoff-wip",
+        "handoff_version": 1,
+        "clusters": [
+            {
+                "cluster_id": c["cluster_id"],
+                "summary": c["summary"],
+                "relation": c["relation"],
+                "claims": list(c["claims"]),
+            }
+            for c in clusters
+        ],
+        "coverage_gaps": list(gaps or []),
+        "blind_spots": list(blinds or []),
+        "contradictions": list(contradictions or []),
+        "unique_insights": list(insights or []),
+        "unclustered_claim_ids": [c["id"] for c in unclustered],
+        "unclustered_claims": list(unclustered),
+    }
+    return raw, wip
+
+
+def _goal_hash():
+    return hashlib.sha256(b"goal").hexdigest()
+
+
+def _raw_hash(raw):
+    return hh.semantic_hash(raw)
+
+
+class TestH2PublishAndHash(unittest.TestCase):
+    def test_h2_valid_wip_publishes_manifest_and_ledger_with_recomputable_hash(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1", "gpt"), _claim("gem-1", "gemini")]),
+        ])
+        with tempfile.TemporaryDirectory() as tmp:
+            cleaned = Path(tmp)
+            manifest = hh.publish_handoff(
+                cleaned, wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt", "gemini"],
+            )
+            man_path = cleaned / "harvest-manifest.json"
+            ev_path = cleaned / "harvest-evidence.jsonl"
+            self.assertTrue(man_path.is_file())
+            self.assertTrue(ev_path.is_file())
+            on_disk = json.loads(man_path.read_text(encoding="utf-8"))
+            self.assertEqual(on_disk, manifest)
+            evidence_text = ev_path.read_text(encoding="utf-8")
+            self.assertEqual(
+                hashlib.sha256(evidence_text.encode("utf-8")).hexdigest(),
+                manifest["evidence_sha256"],
+            )
+            self.assertEqual(hh.file_sha256(ev_path), manifest["evidence_sha256"])
+            self.assertEqual(hh.semantic_hash(on_disk), hh.semantic_hash(manifest))
+            hh.validate_published(on_disk, evidence_text, raw, wip)
+
+
+class TestH5CanonicalStability(unittest.TestCase):
+    def test_h5_key_order_and_republish_are_byte_identical(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1", "gpt"), _claim("gem-1", "gemini")]),
+        ])
+        shuffled_wip = json.loads(json.dumps(wip))
+        shuffled_wip["clusters"][0] = {
+            "relation": shuffled_wip["clusters"][0]["relation"],
+            "summary": shuffled_wip["clusters"][0]["summary"],
+            "cluster_id": shuffled_wip["clusters"][0]["cluster_id"],
+            "claims": shuffled_wip["clusters"][0]["claims"],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            cleaned = Path(tmp)
+            kwargs = dict(
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt", "gemini"],
+            )
+            hh.publish_handoff(cleaned, wip, raw, **kwargs)
+            first_man = (cleaned / "harvest-manifest.json").read_bytes()
+            first_ev = (cleaned / "harvest-evidence.jsonl").read_bytes()
+            hh.publish_handoff(cleaned, shuffled_wip, raw, **kwargs)
+            self.assertEqual((cleaned / "harvest-manifest.json").read_bytes(), first_man)
+            self.assertEqual((cleaned / "harvest-evidence.jsonl").read_bytes(), first_ev)
+            self.assertEqual(hh.file_sha256(cleaned / "harvest-manifest.json"),
+                             hashlib.sha256(first_man).hexdigest())
+
+
+class TestS1CoverageRejects(unittest.TestCase):
+    def test_s1_missing_claim_rejected(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1"), _claim("gem-1", "gemini")]),
+        ])
+        wip["clusters"][0]["claims"] = [wip["clusters"][0]["claims"][0]]
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.check_coverage(wip, raw)
+        self.assertIn("cluster membership incomplete", str(ctx.exception))
+
+    def test_s1_duplicate_claim_rejected(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1"), _claim("gem-1", "gemini")]),
+            _cluster("c002", [_claim("gpt-2")]),
+        ])
+        wip["clusters"][1]["claims"] = [dict(wip["clusters"][0]["claims"][0])]
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.check_coverage(wip, raw)
+        self.assertIn("duplicate claim", str(ctx.exception))
+
+    def test_s1_unknown_claim_rejected(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1"), _claim("gem-1", "gemini")]),
+        ])
+        wip["clusters"][0]["claims"][1] = _claim("stranger")
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.check_coverage(wip, raw)
+        self.assertRegex(str(ctx.exception), r"unknown claim|cluster membership")
+
+    def test_s1_missing_raw_cluster_rejected(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1")]),
+            _cluster("c002", [_claim("gem-1", "gemini")]),
+        ])
+        wip["clusters"] = [wip["clusters"][0]]
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.check_coverage(wip, raw)
+        self.assertIn("cluster membership incomplete", str(ctx.exception))
+
+
+class TestR1CorroboratedCompressed(unittest.TestCase):
+    def test_r1_agree_two_models_no_anomaly_is_corroborated_compressed(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [
+                _claim("b-1", "gpt", cred=4),
+                _claim("a-1", "gemini", cred=4),
+            ]),
+        ])
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = hh.publish_handoff(
+                Path(tmp), wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt", "gemini"],
+            )
+        cluster = manifest["clusters"][0]
+        self.assertEqual(cluster["consensus"], "corroborated")
+        self.assertEqual(cluster["presentation"], "compressed")
+        self.assertEqual(cluster["expansion_reasons"], [])
+        # credibility tie → claim id ascending
+        self.assertEqual(cluster["representative_claim_id"], "a-1")
+        self.assertEqual(cluster["evidence_offset"], 0)
+        self.assertEqual(cluster["evidence_limit"], 2)
+
+
+class TestR2DisputedExpanded(unittest.TestCase):
+    def test_r2_contradict_is_disputed_expanded(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [
+                _claim("gpt-1", "gpt"),
+                _claim("gem-1", "gemini"),
+            ], relation="contradict"),
+        ], contradictions=["gpt-1 vs gem-1"])
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = hh.publish_handoff(
+                Path(tmp), wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt", "gemini"],
+            )
+        cluster = manifest["clusters"][0]
+        self.assertEqual(cluster["consensus"], "disputed")
+        self.assertEqual(cluster["presentation"], "expanded")
+        self.assertIn("disputed", cluster["expansion_reasons"])
+
+
+class TestR3SingleModelExpanded(unittest.TestCase):
+    def test_r3_single_model_is_expanded(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1", "gpt"), _claim("gpt-2", "gpt")]),
+        ])
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = hh.publish_handoff(
+                Path(tmp), wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt"],
+            )
+        cluster = manifest["clusters"][0]
+        self.assertEqual(cluster["consensus"], "single-model")
+        self.assertEqual(cluster["presentation"], "expanded")
+        self.assertIn("single-model", cluster["expansion_reasons"])
+
+
+class TestR4UniqueOrLowCredExpanded(unittest.TestCase):
+    def test_r4_unique_insight_expands_and_keeps_claim_id(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [
+                _claim("gpt-1", "gpt", cred=5),
+                _claim("gem-1", "gemini", cred=5),
+            ]),
+        ], insights=["gem-1"])
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = hh.publish_handoff(
+                Path(tmp), wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt", "gemini"],
+            )
+        cluster = manifest["clusters"][0]
+        self.assertEqual(cluster["presentation"], "expanded")
+        self.assertIn("unique-insight", cluster["expansion_reasons"])
+        self.assertIn("gem-1", cluster["claim_ids"])
+        self.assertEqual(manifest["unique_insight_ids"], ["gem-1"])
+
+    def test_r4_low_credibility_expands(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [
+                _claim("gpt-1", "gpt", cred=2),
+                _claim("gem-1", "gemini", cred=5),
+            ]),
+        ])
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = hh.publish_handoff(
+                Path(tmp), wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt", "gemini"],
+            )
+        cluster = manifest["clusters"][0]
+        self.assertEqual(cluster["presentation"], "expanded")
+        self.assertIn("low-credibility", cluster["expansion_reasons"])
+        self.assertIn("gpt-1", cluster["claim_ids"])
+
+
+class TestR5TopLevelAndUnclustered(unittest.TestCase):
+    def test_r5_gaps_and_blind_spots_kept_at_top_level_unclustered_expanded(self):
+        unclustered = [_claim("solo-1", "claude", cred=4)]
+        raw, wip = _raw_and_wip(
+            [_cluster("c001", [_claim("gpt-1", "gpt"), _claim("gem-1", "gemini")])],
+            gaps=["missing market share"],
+            blinds=["no primary source"],
+            unclustered=unclustered,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            cleaned = Path(tmp)
+            manifest = hh.publish_handoff(
+                cleaned, wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt", "gemini", "claude"],
+            )
+            rows = hh.parse_evidence_jsonl(
+                (cleaned / "harvest-evidence.jsonl").read_text(encoding="utf-8")
+            )
+        self.assertEqual(manifest["coverage_gaps"], ["missing market share"])
+        self.assertEqual(manifest["blind_spots"], ["no primary source"])
+        self.assertEqual(manifest["unclustered_claim_ids"], ["solo-1"])
+        # clustered rows first, unclustered last with empty cluster_id
+        self.assertEqual(rows[-1]["id"], "solo-1")
+        self.assertEqual(rows[-1]["cluster_id"], "")
+        # unclustered is not a compressed cluster
+        self.assertTrue(all(c["cluster_id"] != "" for c in manifest["clusters"]))
+
+
+class TestE1ExcerptVerification(unittest.TestCase):
+    def test_e1_every_line_is_url_fetched_only_never_verified_excerpt(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1"), _claim("gem-1", "gemini")]),
+        ])
+        with tempfile.TemporaryDirectory() as tmp:
+            hh.publish_handoff(
+                Path(tmp), wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt", "gemini"],
+            )
+            text = (Path(tmp) / "harvest-evidence.jsonl").read_text(encoding="utf-8")
+        self.assertNotIn("verified-excerpt", text)
+        self.assertNotIn("verified_excerpt", text)
+        for row in hh.parse_evidence_jsonl(text):
+            self.assertEqual(row["excerpt_verification"], "url_fetched_only")
+
+    def test_e1_validate_rejects_verified_excerpt_token(self):
+        with self.assertRaises(hh.HandoffError):
+            hh.validate_evidence_line({
+                **_claim("gpt-1"),
+                "cluster_id": "c001",
+                "excerpt_verification": "verified-excerpt",
+            })
+
+
+class TestLedgerUsesWipBodies(unittest.TestCase):
+    def test_clustered_evidence_uses_wip_text_not_raw(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1", claim="RAW_CLAIM", excerpt="RAW_EX")]),
+        ])
+        wip["clusters"][0]["claims"][0] = _claim(
+            "gpt-1", claim="WIP_CLAIM", excerpt="WIP_EX",
+        )
+        rows = hh.build_evidence_rows(wip, raw)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["claim"], "WIP_CLAIM")
+        self.assertEqual(rows[0]["excerpt"], "WIP_EX")
+        self.assertNotEqual(rows[0]["claim"], raw["clusters"][0]["claims"][0]["claim"])
+        self.assertNotEqual(rows[0]["excerpt"], raw["clusters"][0]["claims"][0]["excerpt"])
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = hh.publish_handoff(
+                Path(tmp), wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt"],
+            )
+            evidence_text = (Path(tmp) / "harvest-evidence.jsonl").read_text(encoding="utf-8")
+        hh.validate_published(manifest, evidence_text, raw, wip)
+        self.assertIn("WIP_CLAIM", evidence_text)
+        self.assertNotIn("RAW_CLAIM", evidence_text)
+
+    def test_unclustered_evidence_uses_wip_text_not_raw(self):
+        raw, wip = _raw_and_wip(
+            [_cluster("c001", [_claim("gpt-1")])],
+            unclustered=[_claim("solo-1", "claude", claim="RAW_SOLO", excerpt="RAW_SOLO_EX")],
+        )
+        wip["unclustered_claims"] = [
+            _claim("solo-1", "claude", claim="WIP_SOLO", excerpt="WIP_SOLO_EX"),
+        ]
+        rows = hh.build_evidence_rows(wip, raw)
+        solo = next(row for row in rows if row["id"] == "solo-1")
+        self.assertEqual(solo["claim"], "WIP_SOLO")
+        self.assertEqual(solo["excerpt"], "WIP_SOLO_EX")
+        self.assertNotEqual(solo["claim"], raw["unclustered_claims"][0]["claim"])
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = hh.publish_handoff(
+                Path(tmp), wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt", "claude"],
+            )
+            evidence_text = (Path(tmp) / "harvest-evidence.jsonl").read_text(encoding="utf-8")
+        hh.validate_published(manifest, evidence_text, raw, wip)
+        self.assertIn("WIP_SOLO", evidence_text)
+        self.assertNotIn("RAW_SOLO", evidence_text)
+
+    def test_missing_unclustered_claims_rejected(self):
+        raw, wip = _raw_and_wip([_cluster("c001", [_claim("gpt-1")])])
+        del wip["unclustered_claims"]
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.validate_wip(wip)
+        self.assertIn("unclustered_claims", str(ctx.exception))
+        with self.assertRaises(hh.HandoffError):
+            hh.check_coverage(wip, raw)
+
+    def test_unclustered_claims_id_set_must_match_ids(self):
+        raw, wip = _raw_and_wip(
+            [_cluster("c001", [_claim("gpt-1")])],
+            unclustered=[_claim("solo-1", "claude")],
+        )
+        wip["unclustered_claims"] = []
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.check_coverage(wip, raw)
+        self.assertIn("unclustered_claims", str(ctx.exception))
+        wip["unclustered_claims"] = [_claim("solo-1", "claude"), _claim("extra-1", "claude")]
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.check_coverage(wip, raw)
+        self.assertIn("unclustered_claims", str(ctx.exception))
+        wip["unclustered_claims"] = [
+            _claim("solo-1", "claude"),
+            _claim("solo-1", "claude", claim="dup"),
+        ]
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.check_coverage(wip, raw)
+        self.assertRegex(str(ctx.exception), r"duplicate claim|unclustered_claims")
+
+
+class TestAtomicWriteRetriesShortWrite(unittest.TestCase):
+    def test_short_write_retries_until_full_payload_lands(self):
+        payload = b"ABCDEFGH" * 32
+        real_write = os.write
+        calls = {"n": 0}
+
+        def short_then_full(fd, buf):
+            calls["n"] += 1
+            view = memoryview(buf)
+            if calls["n"] == 1:
+                half = max(1, len(view) // 2)
+                return real_write(fd, view[:half])
+            return real_write(fd, view)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "out.bin"
+            with patch.object(hh.os, "write", side_effect=short_then_full):
+                hh.atomic_write(dest, payload)
+            self.assertEqual(dest.read_bytes(), payload)
+            self.assertGreaterEqual(calls["n"], 2)
+
+    def test_zero_progress_raises_and_does_not_replace(self):
+        payload = b"NEW-CONTENT"
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "out.bin"
+            with patch.object(hh.os, "write", return_value=0):
+                with self.assertRaises(OSError):
+                    hh.atomic_write(dest, payload)
+            self.assertFalse(dest.exists())
+
+            dest.write_bytes(b"OLD")
+            with patch.object(hh.os, "write", return_value=0):
+                with self.assertRaises(OSError):
+                    hh.atomic_write(dest, payload)
+            self.assertEqual(dest.read_bytes(), b"OLD")
+
+
+class TestAtomicWriteIgnoresSiblingTmpSymlink(unittest.TestCase):
+    def test_preexisting_evidence_tmp_symlink_is_not_followed(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1", "gpt"), _claim("gem-1", "gemini")]),
+        ])
+        with tempfile.TemporaryDirectory() as outside_dir, tempfile.TemporaryDirectory() as cleaned_dir:
+            victim = Path(outside_dir) / "outside-victim.bin"
+            original = b"DO-NOT-TOUCH"
+            victim.write_bytes(original)
+            planted = Path(cleaned_dir) / "harvest-evidence.jsonl.tmp"
+            os.symlink(victim, planted)
+            hh.publish_handoff(
+                Path(cleaned_dir), wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt", "gemini"],
+            )
+            self.assertEqual(victim.read_bytes(), original)
+            self.assertTrue(planted.is_symlink())
+            evidence = Path(cleaned_dir) / "harvest-evidence.jsonl"
+            self.assertTrue(evidence.is_file())
+            self.assertFalse(evidence.is_symlink())
+            text = evidence.read_text(encoding="utf-8")
+            self.assertIn("gpt-1", text)
+            rows = hh.parse_evidence_jsonl(text)
+            self.assertEqual({row["id"] for row in rows}, {"gpt-1", "gem-1"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/deep-research/tests/test_harvest_handoff.py
+++ b/plugins/deep-research/tests/test_harvest_handoff.py
@@ -200,6 +200,81 @@ class TestS1CoverageRejects(unittest.TestCase):
         self.assertIn("cluster membership incomplete", str(ctx.exception))
 
 
+class TestGapBlindCountOnly(unittest.TestCase):
+    def test_sanitized_gap_text_same_count_publishes_wip_text(self):
+        raw, wip = _raw_and_wip(
+            [_cluster("c001", [_claim("gpt-1"), _claim("gem-1", "gemini")])],
+            gaps=["email alice@example.com missing share"],
+            blinds=["phone 13800138000 no primary"],
+        )
+        wip["coverage_gaps"] = ["email [REDACTED] missing share"]
+        wip["blind_spots"] = ["phone [REDACTED] no primary"]
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = hh.publish_handoff(
+                Path(tmp), wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt", "gemini"],
+            )
+            evidence_text = (Path(tmp) / "harvest-evidence.jsonl").read_text(encoding="utf-8")
+        self.assertEqual(manifest["coverage_gaps"], ["email [REDACTED] missing share"])
+        self.assertEqual(manifest["blind_spots"], ["phone [REDACTED] no primary"])
+        hh.check_published_against_raw(raw, manifest, evidence_text)
+        hh.check_ready_invariants(raw, manifest, evidence_text)
+
+    def test_gap_count_mismatch_rejected(self):
+        raw, wip = _raw_and_wip(
+            [_cluster("c001", [_claim("gpt-1")])],
+            gaps=["one", "two"],
+        )
+        wip["coverage_gaps"] = ["only-one"]
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.check_coverage(wip, raw)
+        self.assertIn("coverage_gaps coverage mismatch", str(ctx.exception))
+
+    def test_insight_set_mismatch_still_rejected(self):
+        raw, wip = _raw_and_wip(
+            [_cluster("c001", [_claim("gpt-1"), _claim("gem-1", "gemini")])],
+            insights=["gpt-1"],
+        )
+        wip["unique_insights"] = ["gem-1"]
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.check_coverage(wip, raw)
+        self.assertIn("unique_insights coverage mismatch", str(ctx.exception))
+
+
+class TestRelationClosedSet(unittest.TestCase):
+    def test_unknown_relation_wip_rejected(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1")], relation="maybe"),
+        ])
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.validate_wip(wip)
+        self.assertIn("relation", str(ctx.exception))
+        with self.assertRaises(hh.HandoffError):
+            hh.check_coverage(wip, raw)
+
+    def test_classify_consensus_unknown_relation_is_disputed(self):
+        self.assertEqual(hh.classify_consensus("weird", ["a", "b"]), "disputed")
+        self.assertEqual(hh.classify_consensus("contradict", ["a", "b"]), "disputed")
+        self.assertEqual(hh.classify_consensus("agree", ["a", "b"]), "corroborated")
+
+
+class TestArtifactNamesTrack(unittest.TestCase):
+    def test_empty_track_name_rejected(self):
+        with self.assertRaises(hh.HandoffError):
+            hh.artifact_names("")
+        with self.assertRaises(hh.HandoffError):
+            hh.artifact_names(".")
+        with self.assertRaises(hh.HandoffError):
+            hh.artifact_names("..")
+        self.assertEqual(hh.artifact_names(None)["manifest"], "harvest-manifest.json")
+        self.assertEqual(
+            hh.artifact_names("gap_A")["manifest"],
+            "track_gap_A-harvest-manifest.json",
+        )
+
+
 class TestR1CorroboratedCompressed(unittest.TestCase):
     def test_r1_agree_two_models_no_anomaly_is_corroborated_compressed(self):
         raw, wip = _raw_and_wip([

--- a/plugins/deep-research/tests/test_harvest_handoff.py
+++ b/plugins/deep-research/tests/test_harvest_handoff.py
@@ -254,6 +254,50 @@ class TestRelationClosedSet(unittest.TestCase):
         with self.assertRaises(hh.HandoffError):
             hh.check_coverage(wip, raw)
 
+    def test_wip_flipping_raw_contradict_to_agree_is_rejected(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1"), _claim("gem-1", "gemini")], relation="contradict"),
+        ])
+        wip["clusters"][0]["relation"] = "agree"
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.check_coverage(wip, raw)
+        self.assertIn("relation", str(ctx.exception))
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(hh.HandoffError) as pub_ctx:
+                hh.publish_handoff(
+                    Path(tmp), wip, raw,
+                    goal_file_sha256=_goal_hash(),
+                    raw_merged_sha256=_raw_hash(raw),
+                    alive_models=["gpt", "gemini"],
+                )
+            self.assertIn("relation", str(pub_ctx.exception))
+
+    def test_published_manifest_relation_flip_fails_raw_check(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1"), _claim("gem-1", "gemini")], relation="contradict"),
+        ], contradictions=["c001"])
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = hh.publish_handoff(
+                Path(tmp), wip, raw,
+                goal_file_sha256=_goal_hash(),
+                raw_merged_sha256=_raw_hash(raw),
+                alive_models=["gpt", "gemini"],
+            )
+            evidence_text = (Path(tmp) / "harvest-evidence.jsonl").read_text(encoding="utf-8")
+        hh.check_published_against_raw(raw, manifest, evidence_text)
+        flipped = json.loads(json.dumps(manifest))
+        flipped["clusters"][0]["relation"] = "agree"
+        with self.assertRaises(hh.HandoffError) as ctx:
+            hh.check_published_against_raw(raw, flipped, evidence_text)
+        self.assertIn("relation", str(ctx.exception))
+
+    def test_raw_missing_relation_defaults_to_agree(self):
+        raw, wip = _raw_and_wip([
+            _cluster("c001", [_claim("gpt-1")]),
+        ])
+        del raw["clusters"][0]["relation"]
+        hh.check_coverage(wip, raw)
+
     def test_classify_consensus_unknown_relation_is_disputed(self):
         self.assertEqual(hh.classify_consensus("weird", ["a", "b"]), "disputed")
         self.assertEqual(hh.classify_consensus("contradict", ["a", "b"]), "disputed")

--- a/plugins/deep-research/tests/test_read_guard.py
+++ b/plugins/deep-research/tests/test_read_guard.py
@@ -96,6 +96,38 @@ class TestWhitelist(_ProjectFixture):
         )
 
 
+class TestHarvestHandoffReadGuard(_ProjectFixture):
+    def test_i1_lead_reads_small_harvest_manifest(self):
+        path = self.proj / "pipeline" / "2_cleaned" / "harvest-manifest.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"schema":"harvest-handoff-manifest"}')
+        self.assertFalse(self._block("", "Read", {"file_path": str(path)}))
+
+    def test_i1_lead_reads_large_manifest_named_file(self):
+        path = self.proj / "pipeline" / "2_cleaned" / "harvest-manifest.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("m" * 20000)
+        self.assertFalse(self._block("", "Read", {"file_path": str(path)}))
+
+    def test_i2_lead_blocked_from_tiny_harvest_evidence(self):
+        path = self.proj / "pipeline" / "2_cleaned" / "harvest-evidence.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n")
+        self.assertTrue(self._block("", "Read", {"file_path": str(path)}))
+
+    def test_i2_lead_blocked_from_track_evidence_even_if_tiny(self):
+        path = self.proj / "pipeline" / "2_cleaned" / "track_gap-harvest-evidence.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n")
+        self.assertTrue(self._block("", "Read", {"file_path": str(path)}))
+
+    def test_i2_subagent_can_read_harvest_evidence(self):
+        path = self.proj / "pipeline" / "2_cleaned" / "harvest-evidence.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n")
+        self.assertFalse(self._block("harvester-1", "Read", {"file_path": str(path)}))
+
+
 class TestFailOpen(_ProjectFixture):
     def test_non_research_project_passes(self):
         # cwd 下无 pipeline/ → 非研究项目 → fail-open


### PR DESCRIPTION
## Summary

deep-research v1.17.0 adds a deterministic sanitized harvest handoff so the main session never has to ingest raw panel output.

### v1 contract

- Panel `run` writes `PENDING_SANITIZATION` and keeps raw evidence off the Lead path.
- `finalize-handoff` publishes compact `harvest-manifest.json` plus `harvest-evidence.jsonl`, then binds `READY`.
- `check_project` fails closed until `READY`.
- Legacy verify records stay on the old path.
- Evidence ledger remains Lead-blocked.

### Compatibility

- Existing verify-record projects are unchanged.
- Marketplace bump is only `deep-research` 1.16.1 → 1.17.0.

### Tests

- Ran 716 plugin tests (harvest handoff + harvest + read_guard coverage included).

close #190
