### PR TITLE
fix(pr-review): 删四处不一致，配方补路径先验

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,7 +63,7 @@
     {
       "name": "pr-review",
       "description": "AI review for open GitHub PRs — grok/claude/copilot backends, grok and claude auto-routed via a unified entry point, both with adversarial multi-round follow-up over a persisted session; copilot optional and async",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/pr-review/.claude-plugin/plugin.json
+++ b/plugins/pr-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pr-review",
   "description": "AI review for open GitHub PRs — grok/claude CLI local synchronous review (auto-routed via pr-review.sh, both with adversarial multi-round follow-up over a persisted session) + GitHub Copilot bot asynchronous review (optional)",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/pr-review"]
 }

--- a/plugins/pr-review/README.md
+++ b/plugins/pr-review/README.md
@@ -34,6 +34,7 @@ Normally you don't invoke anything by hand — say "评审 PR 123" / "grok revie
 
 ```bash
 REVIEW="${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh"   # auto-routes grok/claude
+[ -x "$REVIEW" ] || { echo "pr-review script path did not resolve" >&2; exit 1; }
 
 gh pr checkout 123        # cwd must be the PR's own repo worktree
 "$REVIEW" 123             # round 1: full review, opens a session

--- a/plugins/pr-review/skills/pr-review/SKILL.md
+++ b/plugins/pr-review/skills/pr-review/SKILL.md
@@ -39,7 +39,7 @@ gh pr checkout <PR>                                                    # 首轮�
 
 **两流必须分文件，不得 `2>&1` 合并**：脚本有意把评审正文放 stdout、诊断放 stderr，而首轮的引擎调用不做 stderr 隔离，`2>&1` 会让进度与告警插进评审正文中间。脚本非零退出时读 `.err` 拿原文，不自行重试、不改用其他评审方式。
 
-**路径用 `${CLAUDE_PLUGIN_ROOT}`，不要 `find … | head -1`**：本文件经 skill 加载时该变量已展开成绝对路径；被当**文件**读取时它是字面量（主线 shell 环境里并没有这个变量），故配方带 `[ -x "$REVIEW" ]` 先验——路径解析不出来就当场停，不往下跑。`find` 有两个实测失败模式——它解析到的是 marketplace 源码副本而非已安装的 cache（cache 路径含版本段，`*/pr-review/skills/…` 匹配不到），而远程安装无本地 clone 时零命中。
+**路径用 `${CLAUDE_PLUGIN_ROOT}`，不要 `find … | head -1`**：本文件经 skill 加载时该变量已展开成绝对路径；被当**文件**读取时它是字面量（主线 shell 环境里并没有这个变量），故配方带 `[ -x "$REVIEW" ]` 先验——路径解析不出来就当场停，不往下跑。**每处 `REVIEW=` 赋值后面都紧跟这行先验**，本仓文档无例外：配方要能独立照抄，就不能靠「上一节已经写过」。`find` 有两个实测失败模式——它解析到的是 marketplace 源码副本而非已安装的 cache（cache 路径含版本段，`*/pr-review/skills/…` 匹配不到），而远程安装无本地 clone 时零命中。
 
 **跑不完时等它跑完，不要重开一轮**：评审耗时随 PR 体量与 `--effort` 增长，前台调用应给足超时。命令若被中断，两条路径的补救不同——首轮的 `state_write` 在引擎成功返回之后才执行，此时 session 未建立，应丢弃残日志整轮重跑；复核轮 session 已在，应丢弃残日志**只重跑这一轮 `--followup`**，不要回头重开首轮（那会覆写 SID）。两种情况下半截日志都不得拿来裁决。
 
@@ -103,16 +103,17 @@ PR 极小、单文件、diff 一屏内可尽收——主线直接跑、直接改
 
 **强制指定后端**：设 `PR_REVIEW_BACKEND=grok` 或 `PR_REVIEW_BACKEND=claude` 后再调 `pr-review.sh`，或直接调用对应的 `grok-review.sh`/`claude-review.sh`。两个后端 CLI 参数形态完全一致（`<PR> [--repo] [--model] [--effort] [--followup] [--since] [--session] [--allow-divergent-base]`），仅 `--effort` 合法集合不同：grok 严格为 `none/minimal/low/medium/high`（默认 `high`，`GROK_EFFORT` 覆盖），claude 严格为 `low/medium/high/xhigh/max`（默认 `medium`，`CLAUDE_REVIEW_EFFORT` 覆盖，`CLAUDE_REVIEW_MODEL` 覆盖 model，默认 `claude-opus-5`）。grok 复核轮读到旧持久 state 的 `EFFORT=xhigh` 时会在调用前一次性迁移为 `high`（claude 无此历史包袱）。参数细节、工作原理、故障排查见 `references/grok-review.md`（grok）/ `references/claude-review.md`（claude）。
 
-**脚本路径发现**：主线用 `${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh`——该变量在本文件正文里展开。下发工单时把它**展开成字面绝对路径**写进去：子任务 prompt 里 `${CLAUDE_PLUGIN_ROOT}` 不展开，而 `find … | head -1` 有实测失败模式（见「执行分工」§1）。只需认识 `pr-review.sh` 这一个命令，不必先跑 `resolve-backend.sh` 再自行选脚本。
+**脚本路径发现**：主线用 `${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh`——展开时机与配套先验见「执行分工」§1。下发工单时把它**展开成字面绝对路径**写进去：子任务 prompt 里 `${CLAUDE_PLUGIN_ROOT}` 不展开，而 `find … | head -1` 有实测失败模式（见「执行分工」§1）。只需认识 `pr-review.sh` 这一个命令，不必先跑 `resolve-backend.sh` 再自行选脚本。
 
 **对抗式多轮复评**：首轮 `pr-review.sh <PR>` 全量评审建 session；复核轮 `--followup "<复核指令>"` 续接同一 session、只发复核指令 + 本轮增量 diff（不重发首轮全量）。每轮的正文与诊断各自落盘为 `<PR>-r<N>.log` / `<PR>-r<N>.err`。**轮次由主线驱动**，分工与收敛判据见上文「执行分工」；本段只讲脚本侧的 session 机制。
 
 ```bash
 REVIEW="${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh"
+[ -x "$REVIEW" ] || { echo "pr-review 脚本路径解析失败" >&2; exit 1; }
 LOG="$(git rev-parse --git-dir)/pr-review"; mkdir -p "$LOG"
 
 gh pr checkout 123                                                # 必须：先切到 PR 分支再跑首轮（本地 HEAD≠PR head 时首轮默认 Fail Fast，除非 --allow-divergent-base）
-"$REVIEW" 123 > "$LOG/123-r1.log" 2> "$LOG/123-r1.err"            # 第 1 轮：主线跑，全量评审
+"$REVIEW" 123 > "$LOG/123-r1.log" 2> "$LOG/123-r1.err"; echo "exit=$?"   # 第 1 轮：主线跑，全量评审
 
 # 之后每轮的 --followup 由修复子任务按 §3 执行（形如下行），主线只 Read 它回传的路径：
 #   "$REVIEW" 123 --followup "<复核指令 + 驳回清单>" > "$LOG/123-r2.log" 2> "$LOG/123-r2.err"

--- a/plugins/pr-review/skills/pr-review/SKILL.md
+++ b/plugins/pr-review/skills/pr-review/SKILL.md
@@ -26,6 +26,7 @@ description: |
 
 ```bash
 REVIEW="${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh"
+[ -x "$REVIEW" ] || { echo "pr-review 脚本路径解析失败" >&2; exit 1; }
 LOG="$(git rev-parse --git-dir)/pr-review"; mkdir -p "$LOG"
 
 gh pr checkout <PR>                                                    # 首轮前必须切到 PR 分支
@@ -38,7 +39,7 @@ gh pr checkout <PR>                                                    # 首轮�
 
 **两流必须分文件，不得 `2>&1` 合并**：脚本有意把评审正文放 stdout、诊断放 stderr，而首轮的引擎调用不做 stderr 隔离，`2>&1` 会让进度与告警插进评审正文中间。脚本非零退出时读 `.err` 拿原文，不自行重试、不改用其他评审方式。
 
-**路径用 `${CLAUDE_PLUGIN_ROOT}`，不要 `find … | head -1`**：本文件由主线读入，该变量在此展开。`find` 有两个实测失败模式——它解析到的是 marketplace 源码副本而非已安装的 cache（cache 路径含版本段，`*/pr-review/skills/…` 匹配不到），而远程安装无本地 clone 时零命中，`REVIEW=""` 会让 `"$REVIEW" <PR>` 变成执行 `<PR>` 本身。
+**路径用 `${CLAUDE_PLUGIN_ROOT}`，不要 `find … | head -1`**：本文件经 skill 加载时该变量已展开成绝对路径；被当**文件**读取时它是字面量（主线 shell 环境里并没有这个变量），故配方带 `[ -x "$REVIEW" ]` 先验——路径解析不出来就当场停，不往下跑。`find` 有两个实测失败模式——它解析到的是 marketplace 源码副本而非已安装的 cache（cache 路径含版本段，`*/pr-review/skills/…` 匹配不到），而远程安装无本地 clone 时零命中。
 
 **跑不完时等它跑完，不要重开一轮**：评审耗时随 PR 体量与 `--effort` 增长，前台调用应给足超时。命令若被中断，两条路径的补救不同——首轮的 `state_write` 在引擎成功返回之后才执行，此时 session 未建立，应丢弃残日志整轮重跑；复核轮 session 已在，应丢弃残日志**只重跑这一轮 `--followup`**，不要回头重开首轮（那会覆写 SID）。两种情况下半截日志都不得拿来裁决。
 
@@ -80,7 +81,7 @@ gh pr checkout <PR>                                                    # 首轮�
 
 ### 例外
 
-PR 极小、单文件、diff 一屏内可尽收——主线直接跑、直接改，不必落盘也不必派发。
+PR 极小、单文件、diff 一屏内可尽收——主线直接跑、直接改，**不必派修复子任务**。落盘不在豁免之列：两流重定向对一屏 diff 的代价也接近零，而免掉它就是把正文灌回主线，旧失败模式原地复活。
 
 ## 后端选择
 

--- a/plugins/pr-review/skills/pr-review/references/claude-review.md
+++ b/plugins/pr-review/skills/pr-review/references/claude-review.md
@@ -19,6 +19,8 @@ scripts/claude-review.sh <PR> --followup "<复核指令>" [--since <ref>] [--ses
 
 不带 `--repo` 时自动用当前仓库。首轮与复核轮是两条独立路径，机制与 grok 后端一致（见 [grok-review.md](grok-review.md)「多轮 session 复用」）。
 
+上面两行是**参数形态说明**，不是可直接照抄的调用式——agent 调用一律按 [grok-review.md](grok-review.md)「调用形态」两流分文件重定向。
+
 ## 与 grok 后端的两处不同
 
 CLI 参数形态（`<PR> [--repo] [--model] [--effort] [--followup] [--since] [--session] [--allow-divergent-base]`）与 grok-review.sh 完全一致，只有 MODEL/EFFORT 默认值与合法集合不同：

--- a/plugins/pr-review/skills/pr-review/references/grok-review.md
+++ b/plugins/pr-review/skills/pr-review/references/grok-review.md
@@ -25,6 +25,7 @@ scripts/grok-review.sh <PR> --followup "<复核指令>" [--since <ref>] [--sessi
 
 ```bash
 REVIEW="${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh"
+[ -x "$REVIEW" ] || { echo "pr-review 脚本路径解析失败" >&2; exit 1; }
 LOG="$(git rev-parse --git-dir)/pr-review"; mkdir -p "$LOG"
 "$REVIEW" <PR> > "$LOG/<PR>-r1.log" 2> "$LOG/<PR>-r1.err"; echo "exit=$?"
 ```
@@ -67,15 +68,17 @@ LOG="$(git rev-parse --git-dir)/pr-review"; mkdir -p "$LOG"
 典型两轮命令：
 
 ```bash
-LOG="$(git rev-parse --git-dir)/pr-review"; mkdir -p "$LOG"   # 与上节「调用形态」同一定义，本块可独立照抄
+REVIEW="${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh"   # 与上节「调用形态」同一定义，本块可独立照抄
+[ -x "$REVIEW" ] || { echo "pr-review 脚本路径解析失败" >&2; exit 1; }
+LOG="$(git rev-parse --git-dir)/pr-review"; mkdir -p "$LOG"
 
 # 第 1 轮：全量评审
-scripts/grok-review.sh 123 > "$LOG/123-r1.log" 2> "$LOG/123-r1.err"
+"$REVIEW" 123 > "$LOG/123-r1.log" 2> "$LOG/123-r1.err"
 
 # ...主线 Read 123-r1.log 逐条裁决，派修复子任务改代码 + git commit...
 
 # 第 2 轮：复核，只发复核指令 + 本轮增量 diff
-scripts/grok-review.sh 123 --followup "已按你的意见修复 file.go:42 的空指针解引用，请复核。以下维持驳回、无新证据不要重开：<驳回清单>" \
+"$REVIEW" 123 --followup "已按你的意见修复 file.go:42 的空指针解引用，请复核。以下维持驳回、无新证据不要重开：<驳回清单>" \
   > "$LOG/123-r2.log" 2> "$LOG/123-r2.err"
 ```
 


### PR DESCRIPTION
## 来源

#194 合并、插件更新到 1.2.0 之后，用**新协议**对 #194 自己跑了一轮全新会话评审（无前四轮 session 记忆）。它给 APPROVED，但提了 1 Major + 4 Minor。逐条裁决后采纳 4 条。

## 一条被实证驳回的误报

评审的 Major 是「`${CLAUDE_PLUGIN_ROOT}` 不会插值，配方空变量会执行 `194`」，**核心事实断言是反的**：

- 主线 Bash 里 `CLAUDE_PLUGIN_ROOT` 确实 **UNSET**（这半句对）
- 但**经 skill 加载时 CC 会展开**——实测调用一次，正文里全是绝对路径，一处字面量都没有

评审方读的是磁盘上的文件，没走过 skill 加载路径，把自己环境的观察外推了。

**但它建议的动作采纳**，理由换掉：不是「变量不展开」，而是正文被当**文件**读时确实不展开，且守卫成本一行、team-ops 侧已有同形守卫，两边不该不对称。

## 四处改动

**1. `SKILL.md:42` 一句假话 → 换成守卫的理由（Major）**

原文：`REVIEW=""` 会让 `"$REVIEW" <PR>` 变成执行 `<PR>` 本身。

带引号的空值是 `bash: : command not found`，**不会**执行 PR 号；会执行的是未引用形式。同一句错误已在 claude-config #340 的 team-ops 侧修过，本仓漏了。

三处代码块统一补 `[ -x "$REVIEW" ] || { echo …; exit 1; }`，散文改为说明「skill 加载时已展开 / 当文件读时是字面量，故带先验」。**一行进、一句错的出，净更简单。**

**2. `SKILL.md` 例外豁免了落盘（Minor）**

「不必落盘也不必派发」——免掉落盘就是把正文灌回主线，正是本 skill 要消灭的失败模式。收窄为只免派修复子任务，落盘不在豁免之列。

**3. `references/claude-review.md` 快速用法可被直接照抄（Minor）**

grok 侧已有「上面两行是参数形态说明，不是可直接照抄的调用式」，claude 侧漏了。补同一句，不发明新说法。

**4. `references/grok-review.md` 多轮示例用相对路径（Minor）**

示例是 `scripts/grok-review.sh 123 > …`。相对路径在「cwd 必须是被评审仓库」的前提下**解析不到**，同文件上文又要求「只需认识 `pr-review.sh`」。

改法不是按评审建议加一句「仅在钉死 grok 后端时用本路径」，而是**复用同文件「调用形态」节已有的 `$REVIEW` 形态、删掉这个变体**——一次修掉路径解析和绕过路由两件事，且少一种写法要维护。

## 明确不修

- 「主线前台跑大 PR 会顶工具超时」：已有「跑不完时等它跑完」覆盖，评审方自己也承认；`tee` 下沉是正交后续。
- `claude-review.md` 开头「评审结果直接打印到终端」：脚本行为的如实描述，也正是必须重定向的原因，不误导。

## 验证

- **守卫双向实测**：`CLAUDE_PLUGIN_ROOT` 未设 → 拦停 `exit=1`；设对 → 放行到 1.2.0 脚本
- **残留扫描**：「变成执行」0、「不必落盘」0；三处代码块都带守卫；`scripts/grok-review.sh` 仅存于已标注「不可照抄」的快速用法两行
- **bats 100/100**
- **版本双写** 1.2.0 → 1.2.1。`marketplace.json` 里 brain-route 同为 1.2.0，按 `name` 归属定位后只改 pr-review 那一行（`--numstat` 确认 1+/1-），brain-route 仍 1.2.0

close #196
