### PR TITLE
fix(pr-review): 评审调用改走后台通道，不再撞 Bash 工具超时硬顶 (v1.2.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,7 +63,7 @@
     {
       "name": "pr-review",
       "description": "AI review for open GitHub PRs — grok/claude/copilot backends, grok and claude auto-routed via a unified entry point, both with adversarial multi-round follow-up over a persisted session; copilot optional and async",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/pr-review/.claude-plugin/plugin.json
+++ b/plugins/pr-review/.claude-plugin/plugin.json
@@ -1,7 +1,11 @@
 {
   "name": "pr-review",
   "description": "AI review for open GitHub PRs — grok/claude CLI local synchronous review (auto-routed via pr-review.sh, both with adversarial multi-round follow-up over a persisted session) + GitHub Copilot bot asynchronous review (optional)",
-  "version": "1.2.1",
-  "author": { "name": "WooDragon" },
-  "skills": ["./skills/pr-review"]
+  "version": "1.2.2",
+  "author": {
+    "name": "WooDragon"
+  },
+  "skills": [
+    "./skills/pr-review"
+  ]
 }

--- a/plugins/pr-review/skills/pr-review/SKILL.md
+++ b/plugins/pr-review/skills/pr-review/SKILL.md
@@ -22,18 +22,29 @@ description: |
 
 **一轮只派一次**：主线裁决 → 派修复子任务改一遍并跑一次复核 → 主线读新一轮日志再裁决。循环由主线驱动，子任务不自行收敛。
 
-### 1. 取评审：主线自跑，两流分文件
+### 1. 取评审：主线自跑，后台执行，两流分文件
+
+第 1 步 · 前台，切到 PR 分支并建日志目录：
+
+```bash
+gh pr checkout <PR>                                    # 首轮前必须切到 PR 分支
+mkdir -p "$(git rev-parse --git-dir)/pr-review"
+```
+
+第 2 步 · **后台**（Bash 工具参数 `run_in_background: true`），跑评审：
 
 ```bash
 REVIEW="${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh"
 [ -x "$REVIEW" ] || { echo "pr-review 脚本路径解析失败" >&2; exit 1; }
-LOG="$(git rev-parse --git-dir)/pr-review"; mkdir -p "$LOG"
-
-gh pr checkout <PR>                                                    # 首轮前必须切到 PR 分支
-"$REVIEW" <PR> > "$LOG/<PR>-r1.log" 2> "$LOG/<PR>-r1.err"; echo "exit=$?"
+LOG="$(git rev-parse --git-dir)/pr-review"
+"$REVIEW" <PR> > "$LOG/<PR>-r1.log" 2> "$LOG/<PR>-r1.err"
 ```
 
-预期结果：主线上下文里只出现 `exit=0` 一行，评审正文进 `.log`，诊断与告警进 `.err`。「dump 不进主线」由重定向达成。相比派一个子任务去跑，这条路径少一个实例的 system prompt 与 skill 加载开销。**漏掉重定向就是错的**——正文会直接灌进主线上下文，旧失败模式原地复活。
+预期结果：第 2 步的 tool_result 只有一行受理回执（`Command running in background with ID: …`），评审正文进 `.log`，诊断与告警进 `.err`。评审跑完后完成通知自动送达主线，其中带 `<status>` 与 exit code。「dump 不进主线」由重定向达成。相比派一个子任务去跑，这条路径少一个实例的 system prompt 与 skill 加载开销。**漏掉重定向就是错的**——正文会直接灌进主线上下文，旧失败模式原地复活。
+
+**评审调用应走后台，`run_in_background` 是 Bash 工具参数、不是命令的一部分**——它写在工具调用的 `run_in_background` 字段里，照抄上面的命令文本抄不到它。理由是通道容量：前台 Bash 调用的 `timeout` 上限 600000ms 是硬顶，而评审时长随 PR 体量与 `--effort` 增长、无上限，撞顶即被 SIGTERM 杀（`Exit code 143`）或被静默移入后台；后台通道无此上限。正文与诊断既已全部落盘，前台阻塞也换不回任何多余信息。
+
+两步分开跑，是因为 shell 变量不跨 Bash 调用保留——第 2 步须自带 `REVIEW` / `LOG` 赋值，不能指望第 1 步的赋值还在。
 
 `$(git rev-parse --git-dir)` 在 worktree 里返回该 worktree 自己的 gitdir——评审日志随工作区走，不入版本库。
 
@@ -41,7 +52,12 @@ gh pr checkout <PR>                                                    # 首轮�
 
 **路径用 `${CLAUDE_PLUGIN_ROOT}`，不要 `find … | head -1`**：本文件经 skill 加载时该变量已展开成绝对路径；被当**文件**读取时它是字面量（主线 shell 环境里并没有这个变量），故配方带 `[ -x "$REVIEW" ]` 先验——路径解析不出来就当场停，不往下跑。**每处 `REVIEW=` 赋值后面都紧跟这行先验**，本仓文档无例外：配方要能独立照抄，就不能靠「上一节已经写过」。`find` 有两个实测失败模式——它解析到的是 marketplace 源码副本而非已安装的 cache（cache 路径含版本段，`*/pr-review/skills/…` 匹配不到），而远程安装无本地 clone 时零命中。
 
-**跑不完时等它跑完，不要重开一轮**：评审耗时随 PR 体量与 `--effort` 增长，前台调用应给足超时。命令若被中断，两条路径的补救不同——首轮的 `state_write` 在引擎成功返回之后才执行，此时 session 未建立，应丢弃残日志整轮重跑；复核轮 session 已在，应丢弃残日志**只重跑这一轮 `--followup`**，不要回头重开首轮（那会覆写 SID）。两种情况下半截日志都不得拿来裁决。
+**等完成通知，不要轮询**：后台评审跑完时通知会自动送达，主线**不应**用 `sleep` + `tail` 反复探日志——那每探一次烧一个 turn，且拿到的是半截正文。派完后台调用就结束本轮、交还主循环。想看中途进度时读一次后台任务的 output 文件即可，不要为此起轮询循环。
+
+**被中断时不要重开一轮**：后台通道无超时，剩余的中断来源只有用户主动中断与 session 结束。此时残日志**不得**拿来裁决，两条路径的补救不同：
+
+- **首轮**——SID 在 `.err` 的 `session=` 行里（脚本在调引擎**之前**就打了它），应丢弃残日志，用 `--session <SID> --followup "<继续评审的指令>"` 续接，不重发全量 diff。续接失败时脚本会明确报 session 已失效并要求重开首轮，故这条路径**宜**先试——试错成本低于无条件重发全量 diff。
+- **复核轮**——session 已在 state 文件里，应丢弃残日志**只重跑这一轮 `--followup`**，不要回头重开首轮（那会覆写 SID）。
 
 ### 2. 裁决：主线 Read 评审日志（每轮都回到这一步）
 
@@ -73,6 +89,7 @@ gh pr checkout <PR>                                                    # 首轮�
 - **cwd 钉死为首轮的仓库 toplevel，禁用 worktree 隔离**——脚本按 `git rev-parse --show-toplevel` 钉 session 身份，换路径直接 Fail Fast
 - 改完 `git commit` 新 commit（勿 `git amend` 首轮 tip），然后跑**一次**复核：
   `<REVIEW 绝对路径> <PR> --followup "<复核指令 + 驳回清单>" > <日志目录>/<PR>-r<N>.log 2> <日志目录>/<PR>-r<N>.err`
+- **该复核调用与首轮同样走后台**（`run_in_background: true`），等完成通知，不轮询——超时上限对子任务一样是硬顶，理由见 §1
 - **回传 exit code 与两个日志路径，到此为止**——不判定收敛、不循环、不自行裁决
 
 脚本路径与日志目录在工单里**应展开成字面绝对路径**：子任务不继承主线的 shell 变量，`${CLAUDE_PLUGIN_ROOT}` 在子任务 prompt 里也不展开。
@@ -107,15 +124,22 @@ PR 极小、单文件、diff 一屏内可尽收——主线直接跑、直接改
 
 **对抗式多轮复评**：首轮 `pr-review.sh <PR>` 全量评审建 session；复核轮 `--followup "<复核指令>"` 续接同一 session、只发复核指令 + 本轮增量 diff（不重发首轮全量）。每轮的正文与诊断各自落盘为 `<PR>-r<N>.log` / `<PR>-r<N>.err`。**轮次由主线驱动**，分工与收敛判据见上文「执行分工」；本段只讲脚本侧的 session 机制。
 
+前台，切分支 + 建日志目录（本地 HEAD≠PR head 时首轮默认 Fail Fast，除非 `--allow-divergent-base`）：
+
+```bash
+gh pr checkout 123
+mkdir -p "$(git rev-parse --git-dir)/pr-review"
+```
+
+后台（`run_in_background: true`），第 1 轮全量评审：
+
 ```bash
 REVIEW="${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh"
 [ -x "$REVIEW" ] || { echo "pr-review 脚本路径解析失败" >&2; exit 1; }
-LOG="$(git rev-parse --git-dir)/pr-review"; mkdir -p "$LOG"
+LOG="$(git rev-parse --git-dir)/pr-review"
+"$REVIEW" 123 > "$LOG/123-r1.log" 2> "$LOG/123-r1.err"
 
-gh pr checkout 123                                                # 必须：先切到 PR 分支再跑首轮（本地 HEAD≠PR head 时首轮默认 Fail Fast，除非 --allow-divergent-base）
-"$REVIEW" 123 > "$LOG/123-r1.log" 2> "$LOG/123-r1.err"; echo "exit=$?"   # 第 1 轮：主线跑，全量评审
-
-# 之后每轮的 --followup 由修复子任务按 §3 执行（形如下行），主线只 Read 它回传的路径：
+# 之后每轮的 --followup 由修复子任务按 §3 执行（同样走后台，形如下行），主线只 Read 它回传的路径：
 #   "$REVIEW" 123 --followup "<复核指令 + 驳回清单>" > "$LOG/123-r2.log" 2> "$LOG/123-r2.err"
 # 修复请 git commit 新 commit，勿 git amend 首轮 tip
 # （amend 会让首轮 BASE_SHA 不再是 HEAD 祖先 → 复核轮 Fail Fast，须重开首轮或 --since）

--- a/plugins/pr-review/skills/pr-review/SKILL.md
+++ b/plugins/pr-review/skills/pr-review/SKILL.md
@@ -57,16 +57,16 @@ LOG="$(git rev-parse --git-dir)/pr-review"
 **被中断时不要重开一轮**：后台通道无超时，剩余的中断来源只有用户主动中断与 session 结束。此时残日志**不得**拿来裁决，两条路径的补救不同：
 
 - **首轮**——SID 在 `.err` 的 `session=` 行里（脚本在调引擎**之前**就打了它），应丢弃残日志按下方命令续接，不重发全量 diff。续接失败时脚本会明确报 session 已失效并要求重开首轮，故这条路径**宜**先试——试错成本低于无条件重发全量 diff。
-- **复核轮**——session 已在 state 文件里，应丢弃残日志**只重跑这一轮 `--followup`**（形态同下方命令，去掉 `--session`），不要回头重开首轮（那会覆写 SID）。
+- **复核轮**——session 已在 state 文件里，应丢弃残日志**只重跑这一轮 `--followup`**，用下方同一条命令**去掉 `--session <SID>`** 即可（SID 由脚本自己从 state 读回），不要回头重开首轮（那会覆写 SID）。
 
-首轮续接命令，同样走**后台**（`run_in_background: true`）：
+续接命令，同样走**后台**（`run_in_background: true`）。`<N>` 填被中断的那一轮轮次，输出**覆写**该轮被丢弃的残日志——一轮一个文件，不另起变体后缀，主线仍按 `<PR>-r<N>.log` 找本轮结果：
 
 ```bash
 REVIEW="${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh"
 [ -x "$REVIEW" ] || { echo "pr-review 脚本路径解析失败" >&2; exit 1; }
 LOG="$(git rev-parse --git-dir)/pr-review"
 "$REVIEW" <PR> --session <SID> --followup "<继续评审的指令>" \
-  > "$LOG/<PR>-r1b.log" 2> "$LOG/<PR>-r1b.err"
+  > "$LOG/<PR>-r<N>.log" 2> "$LOG/<PR>-r<N>.err"
 ```
 
 `--session` 只在配 `--followup` 时合法，且 `<PR>` 不可省——脚本对二者都会 Fail Fast。

--- a/plugins/pr-review/skills/pr-review/SKILL.md
+++ b/plugins/pr-review/skills/pr-review/SKILL.md
@@ -42,7 +42,7 @@ LOG="$(git rev-parse --git-dir)/pr-review"
 
 预期结果：第 2 步的 tool_result 只有一行受理回执（`Command running in background with ID: …`），评审正文进 `.log`，诊断与告警进 `.err`。评审跑完后完成通知自动送达主线，其中带 `<status>` 与 exit code。「dump 不进主线」由重定向达成。相比派一个子任务去跑，这条路径少一个实例的 system prompt 与 skill 加载开销。**漏掉重定向就是错的**——正文会直接灌进主线上下文，旧失败模式原地复活。
 
-**评审调用应走后台，`run_in_background` 是 Bash 工具参数、不是命令的一部分**——它写在工具调用的 `run_in_background` 字段里，照抄上面的命令文本抄不到它。理由是通道容量：前台 Bash 调用的 `timeout` 上限 600000ms 是硬顶，而评审时长随 PR 体量与 `--effort` 增长、无上限，撞顶即被 SIGTERM 杀（`Exit code 143`）或被静默移入后台；后台通道无此上限。正文与诊断既已全部落盘，前台阻塞也换不回任何多余信息。
+**评审调用应走后台，`run_in_background` 是 Bash 工具参数、不是命令的一部分**——它写在工具调用的 `run_in_background` 字段里，照抄上面的命令文本抄不到它。理由是通道容量：前台 Bash 调用的 `timeout` 上限 600000ms 是硬顶，而评审时长随 PR 体量与 `--effort` 增长、无上限，撞顶即被 SIGTERM 杀（`Exit code 143`）或被静默移入后台。`timeout` 只约束前台调用——后台任务不受它裁剪，跑多久由进程自己决定，直到退出时发出完成通知。正文与诊断既已全部落盘，前台阻塞也换不回任何多余信息。
 
 两步分开跑，是因为 shell 变量不跨 Bash 调用保留——第 2 步须自带 `REVIEW` / `LOG` 赋值，不能指望第 1 步的赋值还在。
 
@@ -56,8 +56,20 @@ LOG="$(git rev-parse --git-dir)/pr-review"
 
 **被中断时不要重开一轮**：后台通道无超时，剩余的中断来源只有用户主动中断与 session 结束。此时残日志**不得**拿来裁决，两条路径的补救不同：
 
-- **首轮**——SID 在 `.err` 的 `session=` 行里（脚本在调引擎**之前**就打了它），应丢弃残日志，用 `--session <SID> --followup "<继续评审的指令>"` 续接，不重发全量 diff。续接失败时脚本会明确报 session 已失效并要求重开首轮，故这条路径**宜**先试——试错成本低于无条件重发全量 diff。
-- **复核轮**——session 已在 state 文件里，应丢弃残日志**只重跑这一轮 `--followup`**，不要回头重开首轮（那会覆写 SID）。
+- **首轮**——SID 在 `.err` 的 `session=` 行里（脚本在调引擎**之前**就打了它），应丢弃残日志按下方命令续接，不重发全量 diff。续接失败时脚本会明确报 session 已失效并要求重开首轮，故这条路径**宜**先试——试错成本低于无条件重发全量 diff。
+- **复核轮**——session 已在 state 文件里，应丢弃残日志**只重跑这一轮 `--followup`**（形态同下方命令，去掉 `--session`），不要回头重开首轮（那会覆写 SID）。
+
+首轮续接命令，同样走**后台**（`run_in_background: true`）：
+
+```bash
+REVIEW="${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh"
+[ -x "$REVIEW" ] || { echo "pr-review 脚本路径解析失败" >&2; exit 1; }
+LOG="$(git rev-parse --git-dir)/pr-review"
+"$REVIEW" <PR> --session <SID> --followup "<继续评审的指令>" \
+  > "$LOG/<PR>-r1b.log" 2> "$LOG/<PR>-r1b.err"
+```
+
+`--session` 只在配 `--followup` 时合法，且 `<PR>` 不可省——脚本对二者都会 Fail Fast。
 
 ### 2. 裁决：主线 Read 评审日志（每轮都回到这一步）
 
@@ -89,7 +101,7 @@ LOG="$(git rev-parse --git-dir)/pr-review"
 - **cwd 钉死为首轮的仓库 toplevel，禁用 worktree 隔离**——脚本按 `git rev-parse --show-toplevel` 钉 session 身份，换路径直接 Fail Fast
 - 改完 `git commit` 新 commit（勿 `git amend` 首轮 tip），然后跑**一次**复核：
   `<REVIEW 绝对路径> <PR> --followup "<复核指令 + 驳回清单>" > <日志目录>/<PR>-r<N>.log 2> <日志目录>/<PR>-r<N>.err`
-- **该复核调用与首轮同样走后台**（`run_in_background: true`），等完成通知，不轮询——超时上限对子任务一样是硬顶，理由见 §1
+- **该复核调用与首轮同样走后台**（`run_in_background: true`），等完成通知，不轮询——前台 `timeout` 的 600000ms 上限在子任务里同样是硬顶，故子任务也**不应**用前台跑评审，理由见 §1
 - **回传 exit code 与两个日志路径，到此为止**——不判定收敛、不循环、不自行裁决
 
 脚本路径与日志目录在工单里**应展开成字面绝对路径**：子任务不继承主线的 shell 变量，`${CLAUDE_PLUGIN_ROOT}` 在子任务 prompt 里也不展开。

--- a/plugins/pr-review/skills/pr-review/references/grok-review.md
+++ b/plugins/pr-review/skills/pr-review/references/grok-review.md
@@ -17,18 +17,31 @@ scripts/grok-review.sh <PR> --followup "<复核指令>" [--since <ref>] [--sessi
 
 不带 `--repo` 时自动用当前仓库。首轮与复核轮是两条独立路径，机制见下方"多轮 session 复用"。
 
-上面两行是**参数形态说明**，不是可直接照抄的调用式——agent 调用一律按下节「调用形态」两流分文件重定向。
+上面两行是**参数形态说明**，不是可直接照抄的调用式——agent 调用一律按下节「调用形态」后台执行 + 两流分文件重定向。
 
-## 调用形态：重定向落盘
+## 调用形态：后台执行 + 重定向落盘
 
-评审正文只打到 stdout、诊断与告警走 stderr，两者都不落盘。主线调用时**两流分别重定向**，主线上下文里只留 `exit=` 一行，随后 Read `.log` 拿无损原文裁决：
+评审正文只打到 stdout、诊断与告警走 stderr，两者都不落盘。主线调用时**两流分别重定向**，随后 Read `.log` 拿无损原文裁决。
+
+前台，切分支 + 建日志目录：
+
+```bash
+gh pr checkout <PR>
+mkdir -p "$(git rev-parse --git-dir)/pr-review"
+```
+
+**后台**（Bash 工具参数 `run_in_background: true`），跑评审：
 
 ```bash
 REVIEW="${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh"
 [ -x "$REVIEW" ] || { echo "pr-review 脚本路径解析失败" >&2; exit 1; }
-LOG="$(git rev-parse --git-dir)/pr-review"; mkdir -p "$LOG"
-"$REVIEW" <PR> > "$LOG/<PR>-r1.log" 2> "$LOG/<PR>-r1.err"; echo "exit=$?"
+LOG="$(git rev-parse --git-dir)/pr-review"
+"$REVIEW" <PR> > "$LOG/<PR>-r1.log" 2> "$LOG/<PR>-r1.err"
 ```
+
+**评审调用应走后台**：前台 Bash 调用的 `timeout` 上限 600000ms 是硬顶，评审时长随 PR 体量与 `--effort` 增长、无上限，撞顶即被 SIGTERM 杀（`Exit code 143`）或被静默移入后台；后台通道无此上限。跑完后完成通知自动送达主线，其中带 `<status>` 与 exit code，故不必在命令尾部追加 `echo "exit=$?"`。等通知即可，**不应**用 `sleep` + `tail` 轮询日志。中断后的补救分路见 `SKILL.md`「执行分工」§1。
+
+两步分开跑，是因为 shell 变量不跨 Bash 调用保留——第 2 步须自带 `REVIEW` / `LOG` 赋值。
 
 **不得写成 `2>&1`**：脚本有意分开两个流，而首轮的 grok 调用不做 stderr 隔离，合并会让进度与告警插进评审正文中间。脚本非零退出时读 `.err` 拿原文，不自行重试、不改用其他评审方式。
 
@@ -65,12 +78,12 @@ LOG="$(git rev-parse --git-dir)/pr-review"; mkdir -p "$LOG"
   - **增量语义要看清**：默认增量是 `git diff <BASE_SHA>`（BASE_SHA=首轮 HEAD），即**累积自首轮起的全部本地 delta**，不是严格的"仅相对上一轮"。好处是改完 commit 也不会漏；代价是多轮 followup 时早先几轮的改动会重复出现在增量里（grok 侧有会话记忆，多为冗余强化而非新信息）。想要严格的"仅本轮"增量、或自定义基线，复核轮传 `--since <上一轮的 tag/sha>`。相对首轮那份远程全量 PR diff，本地增量始终小得多，省 token 目标成立。
   - 首轮工作区若非干净，BASE_SHA 之后的未提交改动会被计入复核增量（脚本首轮会 stderr 警告）；需要干净语义就先 commit/stash，或复核轮用 `--since`。
 
-典型两轮命令：
+典型两轮命令（两轮都按上节走**后台**，`run_in_background: true`；日志目录先在前台 `mkdir -p "$(git rev-parse --git-dir)/pr-review"` 建好）：
 
 ```bash
 REVIEW="${CLAUDE_PLUGIN_ROOT}/skills/pr-review/scripts/pr-review.sh"   # 与上节「调用形态」同一定义，本块可独立照抄
 [ -x "$REVIEW" ] || { echo "pr-review 脚本路径解析失败" >&2; exit 1; }
-LOG="$(git rev-parse --git-dir)/pr-review"; mkdir -p "$LOG"
+LOG="$(git rev-parse --git-dir)/pr-review"
 
 # 第 1 轮：全量评审
 "$REVIEW" 123 > "$LOG/123-r1.log" 2> "$LOG/123-r1.err"

--- a/plugins/pr-review/skills/pr-review/references/grok-review.md
+++ b/plugins/pr-review/skills/pr-review/references/grok-review.md
@@ -39,7 +39,7 @@ LOG="$(git rev-parse --git-dir)/pr-review"
 "$REVIEW" <PR> > "$LOG/<PR>-r1.log" 2> "$LOG/<PR>-r1.err"
 ```
 
-**评审调用应走后台**：前台 Bash 调用的 `timeout` 上限 600000ms 是硬顶，评审时长随 PR 体量与 `--effort` 增长、无上限，撞顶即被 SIGTERM 杀（`Exit code 143`）或被静默移入后台；后台通道无此上限。跑完后完成通知自动送达主线，其中带 `<status>` 与 exit code，故不必在命令尾部追加 `echo "exit=$?"`。等通知即可，**不应**用 `sleep` + `tail` 轮询日志。中断后的补救分路见 `SKILL.md`「执行分工」§1。
+**评审调用应走后台**：前台 Bash 调用的 `timeout` 上限 600000ms 是硬顶，评审时长随 PR 体量与 `--effort` 增长、无上限，撞顶即被 SIGTERM 杀（`Exit code 143`）或被静默移入后台。`timeout` 只约束前台调用——后台任务不受它裁剪，跑多久由进程自己决定。跑完后完成通知自动送达主线，其中带 `<status>` 与 exit code，故不必在命令尾部追加 `echo "exit=$?"`。等通知即可，**不应**用 `sleep` + `tail` 轮询日志。中断后的补救分路与首轮续接命令见 `SKILL.md`「执行分工」§1。
 
 两步分开跑，是因为 shell 变量不跨 Bash 调用保留——第 2 步须自带 `REVIEW` / `LOG` 赋值。
 


### PR DESCRIPTION
## 问题

`pr-review.sh` 前台调用频繁被 `Exit code 143`（SIGTERM）杀死，随后人工用 `run_in_background` 重跑——首轮被杀等于整轮作废，全量 diff 白烧一遍。

## 根因

三层：

1. **通道容量是硬顶**。Bash 工具 `timeout` 默认 120000ms、上限 600000ms；评审时长随 PR 体量与 `--effort` 增长、无上限。
2. **配方漏了这个参数**。`run_in_background` / `timeout` 都是**工具参数**，不在命令文本里。旧文只写「前台调用应给足超时」，既未给数也未说明它是工具参数——照抄配方拿到默认 120s（实测 14% 的调用如此）。
3. **前台阻塞零收益**（真根子）。正文与诊断已全量重定向落盘，前台调用只换回一个整数。

实测（685 份 transcript，N=398 前台调用）：

| min | p50 | p75 | p90 | max |
|---|---|---|---|---|
| 0s | 85s | 168s | 312s | 601s |

超 120s 占 36.4%，超时事件占 5.8%（真被杀 4 条 + 静默转后台 19 条）。**耗时最长的 5 条全部恰为 601s**——右截断，真实尾部长度未知，故任何固定超时值都是错的答案。

## 方案

评审调用改走后台通道，不调大超时值。后台通道无时长上限，完成通知自带 `<status>` 与 exit code。可靠性实测 N=102 后台调用：通知送达 86.3%，主线自行轮询拿到 9.8%，被 worktree 隔离 hook 拒绝 3.9%，**任务石沉大海 0%**。

备选方案（前台保留 + `trap TERM` 落盘 SID + `.interrupted` 侧写文件 + 三态中断判定）被驳回：那些机器全是为收拾 143 的残局，而后台让 143 不再发生；且该方案依赖一个未验证前提（引擎服务端是否持久化被中断的半截 turn）。裁决记录见私有 `docs/pr-review-internals.md`。

## 顺带修的两处文档缺陷

- 旧文「首轮 `state_write` 未执行故 session 未建立」是**事实错误**。SID 由 `gen_uuid` 在调引擎**之前**生成、经 `-s` 传入，同时已打到 stderr——本地 state 未写 ≠ 远端 session 未建。据此指导「整轮重跑」= 白烧第二遍全量 diff。改为按 `--session <SID> --followup` 续接。
- 旧文把「被杀」与「静默转后台」混为一谈。后者进程仍在写同一个 `.log`，此时重开一轮会起第二个引擎进程往同一文件写（静默数据损坏）。后台方案下该状态直接消失。

## 变更

零脚本改动，纯 skill 文档 + 版本号。配方移除冗余的 `; echo "exit=$?"`（后台完成通知本就带 exit code）。

- `SKILL.md`：§1 拆前台建目录 + 后台跑评审两步；补工具参数与通道容量说明；删旧「跑不完时」段，改写为「等通知不轮询」+「被中断时按首轮/复核轮分路补救」；§3 与「对抗式多轮复评」块同步
- `references/grok-review.md`：「调用形态」与「典型两轮命令」同步
- 版本号 1.2.1 → 1.2.2（两处）

## 验证

- [x] bats 套件全绿：100 ok / 0 fail
- [x] 私有 docs 断链检查无新增断链
- [x] 两处版本号一致

fix #201

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)