### PR TITLE
fix(dispatch): 收敛预定义 agent 模型所有权

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "plan-review",
       "description": "Adversarial plan review via cross-model consultation (agy/Claude/Codex)",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "author": {
         "name": "WooDragon"
       },
@@ -84,8 +84,8 @@
     },
     {
       "name": "dispatch-contract",
-      "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop) + background-dispatch sync guard + dispatch-capability guard + channel guard (PreToolUse) + dispatch-rules injection (SubagentStart)",
-      "version": "1.5.0",
+      "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop) + sync, agent-ownership, capability, and channel guards (PreToolUse) + dispatch-rules injection (SubagentStart)",
+      "version": "1.6.0",
       "author": {
         "name": "WooDragon"
       },

--- a/plugins/dispatch-contract/.claude-plugin/plugin.json
+++ b/plugins/dispatch-contract/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dispatch-contract",
-  "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop) + background-dispatch sync guard + dispatch-capability guard + channel guard (PreToolUse) + dispatch-rules injection (SubagentStart)",
-  "version": "1.5.0",
+  "description": "Subagent dispatch contract — four dispatch rules + %%DONE%% finalization gate (SubagentStop) + sync, agent-ownership, capability, and channel guards (PreToolUse) + dispatch-rules injection (SubagentStart)",
+  "version": "1.6.0",
   "author": { "name": "WooDragon" },
   "skills": ["./skills/subagent-dispatch"]
 }

--- a/plugins/dispatch-contract/README.md
+++ b/plugins/dispatch-contract/README.md
@@ -2,7 +2,7 @@
 
 Subagent dispatch contract enforcement for Claude Code — a `%%DONE%%` finalization gate plus a methodology skill for reliable subagent delegation.
 
-The plugin has six parts: three **PreToolUse hooks** — one blocks dispatch calls omitting `run_in_background:false`, a second blocks dispatch calls whose `subagent_type`/`model` cannot deliver what the prompt asks for, a third blocks a `name`-carrying dispatch (upgrading a one-shot subagent to a teammate) whose `subagent_type` is not a recognized team-ops role — a **SubagentStart hook** that injects the dispatch rules into every spawned subagent, a **SubagentStop hook** that enforces the `%%DONE%%` finalization marker when it is declared in the dispatch prompt, and a **`subagent-dispatch` skill** that inlines the four dispatch rules, offload-scenario guidance, and background-subagent patterns on demand.
+The plugin has seven parts: four **PreToolUse hooks** — one blocks dispatch calls omitting `run_in_background:false`, one enforces model ownership, one blocks dispatch calls whose `subagent_type`/`model` cannot deliver what the prompt asks for, and one blocks a `name`-carrying dispatch (upgrading a one-shot subagent to a teammate) whose `subagent_type` is not a recognized team-ops role — a **SubagentStart hook** that injects the dispatch rules into every spawned subagent, a **SubagentStop hook** that enforces the `%%DONE%%` finalization marker when it is declared in the dispatch prompt, and a **`subagent-dispatch` skill** that inlines the four dispatch rules, offload-scenario guidance, and background-subagent patterns on demand.
 
 ## Installation
 
@@ -70,9 +70,10 @@ skills/subagent-dispatch  (no hook — loaded by description match)
          contract is reachable at dispatch time rather than only after a block.
 ```
 
-This plugin registers five hooks: `PreToolUse` (dispatch-sync-guard,
-dispatch-capability-guard, pre-dispatch-channel-guard), `SubagentStart`
-(dispatch-rules-inject), and `SubagentStop` (subagent-done-gate).
+This plugin registers six hooks: `PreToolUse` (dispatch-sync-guard,
+dispatch-agent-ownership-guard, dispatch-capability-guard,
+pre-dispatch-channel-guard), `SubagentStart` (dispatch-rules-inject), and
+`SubagentStop` (subagent-done-gate).
 There is no dispatch-side hook that guesses whether a given task needs a
 `%%DONE%%` deliverable — that judgment is semantic, and a keyword guess would
 misfire often enough to be ignored. The skill closes that gap instead.
@@ -233,6 +234,20 @@ synchronous dispatch requestable again. `ALLOW_BACKGROUND_DISPATCH=1` does not f
 case — it silences the guard everywhere, including runtimes where the background
 channel is real and the guard is protecting against an actual notification-loss risk.
 
+## The Dispatch Agent Ownership Guard
+
+`dispatch-agent-ownership-guard.sh` runs independently on `PreToolUse` for
+`Agent` and `Task`. It fails open with `[GATE-DEGRADE]` when it cannot parse
+its judgment data. It exits 2 only for a semantic ownership violation. The
+runtime-owned classifier lives only in `hooks/lib/agent-kind.sh`; do not copy
+its type list into another hook or document. Read
+`skills/subagent-dispatch/references/dispatch-contract.md` before changing the
+policy, the caller-side model field, or its escape hatch.
+
+The guard has two repairs: add a runtime model for a runtime-owned built-in, or
+remove model from a registered agent call. If the registered agent cannot do
+the work, select another role instead of overriding its model.
+
 ## The Dispatch Capability Guard
 
 `dispatch-capability-guard.sh` also runs on `PreToolUse` for `Agent` and `Task`
@@ -286,9 +301,11 @@ stderr message before a single trailing `exit 2`:
   Edit/Write/NotebookEdit disabled and Bash limited to a read-only whitelist
   — the dispatch would dead-end after a full round trip. Fix: redispatch to
   `general-purpose` or `dev` (team-ops).
-- **Judgment C** (new): `NEEDS_CAP && model` contains the substring `haiku`
-  (matched as a substring because real values look like
-  `claude-haiku-4-5-20251001`, never the bare word) → block. Interpreting
+- **Judgment C** (new): `NEEDS_CAP && runtime-owned type && explicit model`
+  contains the substring `haiku` (matched as a substring because real values
+  look like `claude-haiku-4-5-20251001`, never the bare word) → block.
+  Registered agents are outside C because their frontmatter owns model
+  selection. Interpreting
   run/test/build output well enough to decide what to do next is a
   judgment-forming action the daily model-tiering rubric excludes from the
   haiku tier. Fix: redispatch at `sonnet` or the task's required tier.
@@ -443,6 +460,7 @@ The skill triggers on dispatch-related requests: "派发 subagent", "dispatch su
 # Requires bats-core
 bats plugins/dispatch-contract/tests/subagent-done-gate.bats
 bats plugins/dispatch-contract/tests/dispatch-sync-guard.bats
+bats plugins/dispatch-contract/tests/dispatch-agent-ownership-guard.bats
 bats plugins/dispatch-contract/tests/dispatch-capability-guard.bats
 bats plugins/dispatch-contract/tests/dispatch-channel-guard.bats
 bats plugins/dispatch-contract/tests/gate-composition.bats
@@ -465,7 +483,9 @@ malformed-stdin shapes), plus the rules-injector's JSON-shape checks (normal
 `agent_type` gets all three rules, `Explore` omits the scope-fence rule, empty stdin
 and `ALLOW_NO_RULES_INJECT=1` both leave stdout fully empty).
 
-`dispatch-capability-guard.bats` has 53 test cases covering: signal extraction
+`dispatch-agent-ownership-guard.bats` covers all runtime-owned types, model field presence states, case normalization, registered-agent `inherit`/empty/whitespace overrides, both `Agent` and `Task`, escape-hatch and fail-open paths, plus a temp-copy mutation that proves the runtime rejection is load-bearing.
+
+`dispatch-capability-guard.bats` covers: signal extraction
 (EXEC/WRITE/RO/NEG, including the double-negation and exclusive-write-scope scrub
 logic), the `NEEDS_CAP` derived predicate and its deliberately-accepted mixed-prompt
 miss, judgments A/B/C individually and in combination (Explore + haiku triggering both
@@ -488,8 +508,8 @@ across recognized vs unrecognized `subagent_type` values, the escape hatch,
 and fail-open paths (empty stdin, missing `jq`, malformed JSON, `tool_name`
 outside `{Agent, Task}`).
 
-`gate-composition.bats` has 7 test cases that discover every `PreToolUse`
-hook this plugin declares against the `Agent` matcher directly from
+`gate-composition.bats` discovers every `PreToolUse` hook this plugin declares
+against the `Agent` matcher directly from
 `hooks.json` (see `discover_agent_gates` in `test_helper/common-setup.bash`)
 and run each against a shared payload, so an outroute one gate's own test
 file exercises is also verified not to still get caught by a sibling gate —
@@ -498,10 +518,11 @@ exists to catch mechanically rather than by header comment.
 
 ## Block Response Shape (Deliberate Choice)
 
-All four blocking hooks in this plugin — `dispatch-sync-guard.sh`
-(PreToolUse), `dispatch-capability-guard.sh` (PreToolUse),
-`pre-dispatch-channel-guard.sh` (PreToolUse), and `subagent-done-gate.sh`
-(SubagentStop) — block via `exit 2` plus a stderr message. Some sibling plugins
+All five blocking hooks in this plugin — `dispatch-sync-guard.sh`
+(PreToolUse), `dispatch-agent-ownership-guard.sh` (PreToolUse),
+`dispatch-capability-guard.sh` (PreToolUse), `pre-dispatch-channel-guard.sh`
+(PreToolUse), and `subagent-done-gate.sh` (SubagentStop) — block via `exit 2`
+plus a stderr message. Some sibling plugins
 in this repo use a different shape instead: `plan-review`'s `dispatch-check.sh`
 and `doc-gate`'s `skill-gate.sh` return JSON `permissionDecision: deny`. This
 repo does not use one block-response shape across all plugins — `guardrails`'
@@ -521,5 +542,6 @@ the model sees. The correction message reaches model context either way.
 | `ALLOW_UNMANAGED_TEAMMATE` | _(unset)_ | `1` disables the dispatch channel guard entirely — set in `settings.json`'s `env` section, since `export` in a Bash tool call does not reach the hook process |
 | `CLAUDE_CODE_FORK_SUBAGENT` | _(unset)_ | `0` disables the fork-subagent feature — restores `run_in_background` to the Agent input schema, the correct fix for step 9b's fork-world block |
 | `ALLOW_DISPATCH_CAPABILITY_MISMATCH` | _(unset)_ | `1` disables the dispatch-capability guard entirely — set in `settings.json`'s `env` section, since `export` in a Bash tool call does not reach the hook process |
+| `ALLOW_AGENT_MODEL_INHERIT` | _(unset)_ | `1` temporarily bypasses the agent ownership guard — remove it after diagnosing the call, because it disables model ownership validation |
 | `CLAUDE_AUTO_BACKGROUND_TASKS` | _(unset)_ | Truthy value defeats `run_in_background:false`'s synchronous-delivery guarantee past 120s runtime — the sync guard blocks (step 8b) rather than silently misjudge a passing dispatch as safe; clear this variable to fix |
 | `DONE_GATE_BODY_FLOOR` | `500` | Byte floor for the marker-absent branch — a final message with no marker and a body below this is blocked; at or above it passes with a `systemMessage` warning. Derivation in `The %%DONE%% Contract` above |

--- a/plugins/dispatch-contract/README.md
+++ b/plugins/dispatch-contract/README.md
@@ -2,6 +2,10 @@
 
 Subagent dispatch contract enforcement for Claude Code — a `%%DONE%%` finalization gate plus a methodology skill for reliable subagent delegation.
 
+## Version 1.6.0: Breaking Model Contract
+
+Version 1.6.0 makes caller-side `model` ownership explicit. Runtime-owned built-ins must carry a non-empty `model` in an `Agent` or `Task` call. Registered agents must omit `model`; `model: null` is equivalent to omission and preserves the agent frontmatter preset. Any other registered-agent model value is rejected because it overrides that preset. This is a breaking contract for callers that previously supplied a model for a registered agent.
+
 The plugin has seven parts: four **PreToolUse hooks** — one blocks dispatch calls omitting `run_in_background:false`, one enforces model ownership, one blocks dispatch calls whose `subagent_type`/`model` cannot deliver what the prompt asks for, and one blocks a `name`-carrying dispatch (upgrading a one-shot subagent to a teammate) whose `subagent_type` is not a recognized team-ops role — a **SubagentStart hook** that injects the dispatch rules into every spawned subagent, a **SubagentStop hook** that enforces the `%%DONE%%` finalization marker when it is declared in the dispatch prompt, and a **`subagent-dispatch` skill** that inlines the four dispatch rules, offload-scenario guidance, and background-subagent patterns on demand.
 
 ## Installation
@@ -542,6 +546,6 @@ the model sees. The correction message reaches model context either way.
 | `ALLOW_UNMANAGED_TEAMMATE` | _(unset)_ | `1` disables the dispatch channel guard entirely — set in `settings.json`'s `env` section, since `export` in a Bash tool call does not reach the hook process |
 | `CLAUDE_CODE_FORK_SUBAGENT` | _(unset)_ | `0` disables the fork-subagent feature — restores `run_in_background` to the Agent input schema, the correct fix for step 9b's fork-world block |
 | `ALLOW_DISPATCH_CAPABILITY_MISMATCH` | _(unset)_ | `1` disables the dispatch-capability guard entirely — set in `settings.json`'s `env` section, since `export` in a Bash tool call does not reach the hook process |
-| `ALLOW_AGENT_MODEL_INHERIT` | _(unset)_ | `1` temporarily bypasses the agent ownership guard — remove it after diagnosing the call, because it disables model ownership validation |
+| `ALLOW_AGENT_MODEL_INHERIT` | _(unset)_ | Emergency-only `1` bypass for diagnosing an ownership false positive. Remove it immediately after diagnosis: it disables model ownership validation and is not a supported dispatch mode. |
 | `CLAUDE_AUTO_BACKGROUND_TASKS` | _(unset)_ | Truthy value defeats `run_in_background:false`'s synchronous-delivery guarantee past 120s runtime — the sync guard blocks (step 8b) rather than silently misjudge a passing dispatch as safe; clear this variable to fix |
 | `DONE_GATE_BODY_FLOOR` | `500` | Byte floor for the marker-absent branch — a final message with no marker and a body below this is blocked; at or above it passes with a `systemMessage` warning. Derivation in `The %%DONE%% Contract` above |

--- a/plugins/dispatch-contract/hooks/dispatch-agent-ownership-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-agent-ownership-guard.sh
@@ -25,8 +25,7 @@ if ! jq -e '.tool_input | type == "object"' <<<"$GATE_INPUT" >/dev/null 2>&1; th
   exit 0
 fi
 
-TYPE="$subagent_type"
-[ -z "$TYPE" ] && TYPE="general-purpose"
+TYPE=$(normalize_agent_type "$subagent_type")
 
 if is_runtime_model_agent "$TYPE"; then
   if jq -e '.tool_input.model | type == "string" and test("[^[:space:]]")' <<<"$GATE_INPUT" >/dev/null 2>&1; then

--- a/plugins/dispatch-contract/hooks/dispatch-agent-ownership-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-agent-ownership-guard.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Agent|Task): keep model ownership with the runtime for
+# built-in types and with registered agent definitions for every other named
+# type. Missing subagent_type follows the runtime's general-purpose default.
+#
+# This guard deliberately does not rely on sibling gates: model ownership is a
+# complete judgment over this call's payload and is valid regardless of whether
+# another gate later accepts or rejects the dispatch.
+#
+# Fail-open only covers unavailable judgment data. A model value that violates
+# ownership is a semantic error and exits 2.
+
+set -u
+
+. "${BASH_SOURCE[0]%/*}/lib/gate.sh"
+. "${BASH_SOURCE[0]%/*}/lib/agent-kind.sh"
+
+gate_preamble dispatch-agent-ownership-guard ALLOW_AGENT_MODEL_INHERIT subagent_type || exit 0
+
+# gate_preamble validates JSON and extracts fields, but model-field ownership
+# depends on distinguishing absent, null, blank, and nonblank values. Its
+# field extractor intentionally collapses those states, so inspect raw input.
+if ! jq -e '.tool_input | type == "object"' <<<"$GATE_INPUT" >/dev/null 2>&1; then
+  printf '[GATE-DEGRADE] dispatch-agent-ownership-guard: tool_input extract failed\n' >&2
+  exit 0
+fi
+
+TYPE="$subagent_type"
+[ -z "$TYPE" ] && TYPE="general-purpose"
+
+if is_runtime_model_agent "$TYPE"; then
+  if jq -e '.tool_input.model | type == "string" and test("[^[:space:]]")' <<<"$GATE_INPUT" >/dev/null 2>&1; then
+    exit 0
+  fi
+
+  printf '[dispatch-agent-ownership-guard] 内置 runtime-owned agent(subagent_type=%s) 必须显式带非空、非空白 model。\n' "$TYPE" >&2
+  printf '[dispatch-agent-ownership-guard] 出路：补 runtime model 后重派。\n' >&2
+  exit 2
+fi
+
+# Null and omission both mean no caller-side override. Any other present
+# value—including "inherit", an empty string, or whitespace—is an explicit
+# override and would shadow the registered agent's frontmatter model.
+if jq -e '(.tool_input | has("model")) and .tool_input.model != null' <<<"$GATE_INPUT" >/dev/null 2>&1; then
+  printf '[dispatch-agent-ownership-guard] 具名注册 agent(subagent_type=%s) 的 model 必须完全省略；model:null 可表示不覆盖，但任何其他字段值都会覆盖注册定义。\n' "$TYPE" >&2
+  printf '[dispatch-agent-ownership-guard] 出路：删除 model；若注册 agent 的能力不足，换用合适角色。\n' >&2
+  exit 2
+fi
+
+exit 0

--- a/plugins/dispatch-contract/hooks/dispatch-capability-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-capability-guard.sh
@@ -32,7 +32,7 @@
 #      condition, A fired and told the caller to re-dispatch to Explore — but
 #      Explore's Edit/Write is physically disabled, so the re-dispatch cannot
 #      do what the prompt asks. That is a dead end the gate manufactured,
-#      not a legitimate rejection (see issue's Critical finding #1). Adding
+#      not a legitimate rejection. Adding
 #      !WRITE closes it: a prompt carrying write intent is no longer routed
 #      toward an agent that cannot write, regardless of what RO/NEG also say
 #      in the same prompt.
@@ -147,8 +147,7 @@ MODEL=$(jq -r '.tool_input.model // empty' <<< "$INPUT" 2>/dev/null) || {
 # subagent_type default differs from prompt/model-style fields: absent means
 # "general-purpose", not "treat as missing" (mirrors
 # pre-dispatch-readonly-guard.sh's same rule, kept for judgment A's parity).
-[ -z "$SUBAGENT_TYPE" ] && SUBAGENT_TYPE="general-purpose"
-TYPE=$(tr '[:upper:]' '[:lower:]' <<< "$SUBAGENT_TYPE")
+TYPE=$(normalize_agent_type "$SUBAGENT_TYPE")
 
 # Fold ASCII to lowercase so English signals match regardless of case; CJK is
 # unaffected by tr. All English patterns below are written lowercase to match
@@ -163,7 +162,7 @@ MODEL_LC=$(tr '[:upper:]' '[:lower:]' <<< "$MODEL")
 # This hook reuses it as a REJECTION signal (judgment B blocks on EXEC_HIT),
 # which flips the safety direction: a bare keyword list now widens the set
 # of prompts BLOCKED, and false positives there have a real cost (실측 in
-# Major finding #2 — "查一下跑测试的脚本在哪" is pure research and got
+# A prior false positive showed that "查一下跑测试的脚本在哪" is pure research and got
 # blocked). Per gate-design.md §2 (anchor syntactic shape, not bare
 # keywords), EXEC_HIT now requires a bare-keyword match to sit in an
 # imperative/delegation clause, not a research-frame or negated clause.
@@ -189,7 +188,7 @@ RE_EXEC_FRAME_EN='document how to|find where|explain why|show me where|do not|do
 # what keeps the two apart — same reasoning pre-dispatch-readonly-guard.sh's
 # RE_WRITE_SCOPE comment already documents for a different judgment.
 WRITE_VERB='修改|修复|重构|实现|新增|添加|删除|重命名|改写|补充|编写|落地|开发|加一个|加个'
-# bug|issue|error added per Minor finding #4: "fix the bug in auth" carries
+# Include bug|issue|error because: "fix the bug in auth" carries
 # no code/file/test noun at all, only a defect noun, and was missing from
 # the object list. English tokens kept as-is (not translated) because 中文
 # 句子里 bug 常年以英文原词出现（"修复 auth 模块的 bug"），同一 token 双语都要收。
@@ -392,7 +391,7 @@ case "$TYPE" in
   general-purpose|claude)
     if [ "$EXEC_HIT" -eq 0 ] && [ "$WRITE_HIT_A" -eq 0 ] && { [ "$RO_HIT" -eq 1 ] || [ "$NEG_HIT" -eq 1 ]; }; then
       printf '[dispatch-capability-guard] 命中判据 A: 只读任务声明但派了全权 agent(subagent_type=%s),应改派内置 Explore(Edit/Write/NotebookEdit 物理禁用,越权改不了文件)。\n' "$TYPE" >&2
-      printf '[dispatch-capability-guard] 出路: 改派 subagent_type=Explore。需 code-search/web-search 时在 prompt 内 Skill(...) 加载。任务其实要执行脚本/跑测试(Explore 的 Bash 限只读白名单,会拒执行)时,在 prompt 里写明执行意图(如"前台同步执行"/"跑脚本")即豁免——这类任务留 general-purpose 是对的。\n' >&2
+      printf '[dispatch-capability-guard] 修复方式：只读任务改派 subagent_type=Explore。若任务需要执行脚本或跑测试，保留 general-purpose 并在 prompt 中明确执行意图；Explore 的 Bash 仅允许只读操作。\n' >&2
       REJECT=1
     fi
     ;;
@@ -403,7 +402,7 @@ case "$TYPE" in
   explore|plan)
     if [ "$NEEDS_CAP" -eq 1 ]; then
       printf '[dispatch-capability-guard] 命中判据 B: 本任务需要超出只读的能力(subagent_type=%s),但 Explore/Plan 的 Edit/Write/NotebookEdit 被平台物理禁用、Bash 限只读白名单,派过去会空转一轮后 dead-end。\n' "$TYPE" >&2
-      printf '[dispatch-capability-guard] 出路: 改派 subagent_type=general-purpose 或 dev(team-ops 场景)。\n' >&2
+      printf '[dispatch-capability-guard] 修复方式：改派 subagent_type=general-purpose；team-ops 场景改派 dev。\n' >&2
       REJECT=1
     fi
     ;;
@@ -417,7 +416,7 @@ if [ "$NEEDS_CAP" -eq 1 ] \
    && is_runtime_model_agent "$TYPE" \
    && [[ "$MODEL_LC" == *haiku* ]]; then
   printf '[dispatch-capability-guard] 命中判据 C: 本任务需要超出只读的能力,但 runtime-owned agent 的显式 model=%s 落在 haiku 档;解读执行/测试输出并决定下一步属"产出取舍结论"的落地活,daily 模型分层判据把这类工作排除在 haiku 之外。\n' "$MODEL" >&2
-  printf '[dispatch-capability-guard] 出路: 把 model 升到 sonnet(或按任务要求的档位)重派。\n' >&2
+  printf '[dispatch-capability-guard] 修复方式：将 model 升至 sonnet，或选择任务要求的更高档位后重派。\n' >&2
   REJECT=1
 fi
 

--- a/plugins/dispatch-contract/hooks/dispatch-capability-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-capability-guard.sh
@@ -107,6 +107,8 @@
 # writing it would misleadingly imply the check does something.
 set -u
 
+. "${BASH_SOURCE[0]%/*}/lib/agent-kind.sh"
+
 INPUT=$(cat)
 
 # Knowing bypass is checked first: an open hatch is the reason this dispatch
@@ -407,9 +409,14 @@ case "$TYPE" in
     ;;
 esac
 
-# --- Judgment C (new): NEEDS_CAP && model contains "haiku" -----------------
-if [ "$NEEDS_CAP" -eq 1 ] && [[ "$MODEL_LC" == *haiku* ]]; then
-  printf '[dispatch-capability-guard] 命中判据 C: 本任务需要超出只读的能力,但 model=%s 落在 haiku 档;解读执行/测试输出并决定下一步属"产出取舍结论"的落地活,daily 模型分层判据把这类工作排除在 haiku 之外。\n' "$MODEL" >&2
+# --- Judgment C (new): NEEDS_CAP && runtime-owned type && explicit haiku ---
+# Registered agents own their model in frontmatter. Their model field must be
+# omitted (enforced by dispatch-agent-ownership-guard.sh), so C only judges
+# runtime-owned built-ins that explicitly select a haiku model on this call.
+if [ "$NEEDS_CAP" -eq 1 ] \
+   && is_runtime_model_agent "$TYPE" \
+   && [[ "$MODEL_LC" == *haiku* ]]; then
+  printf '[dispatch-capability-guard] 命中判据 C: 本任务需要超出只读的能力,但 runtime-owned agent 的显式 model=%s 落在 haiku 档;解读执行/测试输出并决定下一步属"产出取舍结论"的落地活,daily 模型分层判据把这类工作排除在 haiku 之外。\n' "$MODEL" >&2
   printf '[dispatch-capability-guard] 出路: 把 model 升到 sonnet(或按任务要求的档位)重派。\n' >&2
   REJECT=1
 fi

--- a/plugins/dispatch-contract/hooks/dispatch-capability-guard.sh
+++ b/plugins/dispatch-contract/hooks/dispatch-capability-guard.sh
@@ -107,11 +107,19 @@
 # writing it would misleadingly imply the check does something.
 set -u
 
-. "${BASH_SOURCE[0]%/*}/lib/agent-kind.sh"
+AGENT_KIND_LIB="${BASH_SOURCE[0]%/*}/lib/agent-kind.sh"
+if ! . "$AGENT_KIND_LIB"; then
+  printf '[GATE-DEGRADE] dispatch-capability-guard: agent-kind.sh unavailable\n' >&2
+  exit 0
+fi
+if ! declare -F normalize_agent_type >/dev/null 2>&1 || ! declare -F is_runtime_model_agent >/dev/null 2>&1; then
+  printf '[GATE-DEGRADE] dispatch-capability-guard: agent-kind.sh lacks required helpers\n' >&2
+  exit 0
+fi
 
 INPUT=$(cat)
 
-# Knowing bypass is checked first: an open hatch is the reason this dispatch
+# The bypass check occurs first: an open hatch is the reason this dispatch
 # passes, not evidence the gate is broken, and it must be reported as such
 # regardless of whether any judgment below would otherwise have fired.
 if [[ "${ALLOW_DISPATCH_CAPABILITY_MISMATCH:-}" == "1" ]]; then
@@ -391,7 +399,7 @@ case "$TYPE" in
   general-purpose|claude)
     if [ "$EXEC_HIT" -eq 0 ] && [ "$WRITE_HIT_A" -eq 0 ] && { [ "$RO_HIT" -eq 1 ] || [ "$NEG_HIT" -eq 1 ]; }; then
       printf '[dispatch-capability-guard] 命中判据 A: 只读任务声明但派了全权 agent(subagent_type=%s),应改派内置 Explore(Edit/Write/NotebookEdit 物理禁用,越权改不了文件)。\n' "$TYPE" >&2
-      printf '[dispatch-capability-guard] 修复方式：只读任务改派 subagent_type=Explore。若任务需要执行脚本或跑测试，保留 general-purpose 并在 prompt 中明确执行意图；Explore 的 Bash 仅允许只读操作。\n' >&2
+      printf '[dispatch-capability-guard] 修复方式：只读任务改派 Agent(subagent_type="Explore", model="sonnet", ...)。若任务需要执行脚本或跑测试，保留 Agent(subagent_type="general-purpose", model="sonnet", ...) 并在 prompt 中明确执行意图；Explore 的 Bash 仅允许只读操作。\n' >&2
       REJECT=1
     fi
     ;;
@@ -402,7 +410,7 @@ case "$TYPE" in
   explore|plan)
     if [ "$NEEDS_CAP" -eq 1 ]; then
       printf '[dispatch-capability-guard] 命中判据 B: 本任务需要超出只读的能力(subagent_type=%s),但 Explore/Plan 的 Edit/Write/NotebookEdit 被平台物理禁用、Bash 限只读白名单,派过去会空转一轮后 dead-end。\n' "$TYPE" >&2
-      printf '[dispatch-capability-guard] 修复方式：改派 subagent_type=general-purpose；team-ops 场景改派 dev。\n' >&2
+      printf '[dispatch-capability-guard] 修复方式：改派 Agent(subagent_type="general-purpose", model="sonnet", ...)。team-ops 场景改派 Agent(subagent_type="dev", ...) 且省略 model，让注册 agent 的 frontmatter 决定模型。\n' >&2
       REJECT=1
     fi
     ;;

--- a/plugins/dispatch-contract/hooks/hooks.json
+++ b/plugins/dispatch-contract/hooks/hooks.json
@@ -1,11 +1,12 @@
 {
-  "description": "Dispatch contract: %%DONE%% finalization gate on SubagentStop, background-dispatch sync guard, dispatch-capability guard and channel guard on PreToolUse, dispatch-rules injection on SubagentStart",
+  "description": "Dispatch contract: %%DONE%% finalization gate on SubagentStop, sync, agent-ownership, capability, and channel guards on PreToolUse, dispatch-rules injection on SubagentStart",
   "hooks": {
     "PreToolUse": [
       {
         "matcher": "Agent",
         "hooks": [
           { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-sync-guard.sh", "timeout": 5 },
+          { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-agent-ownership-guard.sh", "timeout": 5 },
           { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-capability-guard.sh", "timeout": 5 },
           { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-dispatch-channel-guard.sh", "timeout": 5 }
         ]
@@ -14,6 +15,7 @@
         "matcher": "Task",
         "hooks": [
           { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-sync-guard.sh", "timeout": 5 },
+          { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-agent-ownership-guard.sh", "timeout": 5 },
           { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-capability-guard.sh", "timeout": 5 },
           { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-dispatch-channel-guard.sh", "timeout": 5 }
         ]

--- a/plugins/dispatch-contract/hooks/lib/agent-kind.sh
+++ b/plugins/dispatch-contract/hooks/lib/agent-kind.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Runtime-owned built-in agent types are the only dispatch shapes whose model
+# is selected by the runtime rather than by a registered agent definition.
+
+is_runtime_model_agent() {
+  # Bash 3.2 has no ${value,,}; keep normalization aligned with the existing
+  # capability guard's tr-based type handling.
+  local normalized_type
+  normalized_type=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+
+  case "$normalized_type" in
+    general-purpose|claude|explore|plan|claude-code-guide|statusline-setup)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}

--- a/plugins/dispatch-contract/hooks/lib/agent-kind.sh
+++ b/plugins/dispatch-contract/hooks/lib/agent-kind.sh
@@ -2,11 +2,18 @@
 # Runtime-owned built-in agent types are the only dispatch shapes whose model
 # is selected by the runtime rather than by a registered agent definition.
 
+# normalize_agent_type VALUE
+# Canonicalizes a dispatch type for every consumer. An absent, null-decoded, or
+# empty value follows Claude Code's general-purpose runtime default.
+normalize_agent_type() {
+  local agent_type="${1:-general-purpose}"
+  [ -n "$agent_type" ] || agent_type="general-purpose"
+  printf '%s' "$agent_type" | tr '[:upper:]' '[:lower:]'
+}
+
 is_runtime_model_agent() {
-  # Bash 3.2 has no ${value,,}; keep normalization aligned with the existing
-  # capability guard's tr-based type handling.
   local normalized_type
-  normalized_type=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  normalized_type=$(normalize_agent_type "$1")
 
   case "$normalized_type" in
     general-purpose|claude|explore|plan|claude-code-guide|statusline-setup)

--- a/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/SKILL.md
@@ -96,7 +96,7 @@ description: |
 
 ## References 导航
 
-- 需要每条铁律的正反例与常见踩坑时，读取：`references/dispatch-contract.md`
+- 需要每条铁律的正反例、常见踩坑或 model ownership 规则时，读取：`references/dispatch-contract.md`
 - 判断某任务该不该卸载、用哪个模型档时，读取：`references/offload-scenarios.md`
 - 派发 Explore 时任务级别钉哪一档，见本节「Explore 任务级别」
 - spawn background subagent 后如何收产物 / 判活性 / 何时能 TaskStop，读取：`references/mailbox-liveness.md`
@@ -107,4 +107,4 @@ description: |
 
 team-ops 语境下派发由 team-ops 协议（handoff/control-signal）接管，不适用本 skill；web-search 的搜索隔离用 web-search skill 自己的规范。
 
-**即席派发经济性**：分两件事，别混同。model/agent 取值与任务能力是否匹配（该派 Explore 还是全权 agent、该用 sonnet 还是 haiku）已落地进本插件的 `hooks/dispatch-capability-guard.sh`（PreToolUse，判据 A/B/C），逃生舱 `ALLOW_DISPATCH_CAPABILITY_MISMATCH=1`。「`model` 字段在不在场」是另一件事——仍是插件外可选配置，可另配 PreToolUse hook 拦截省略 `model` 的派发调用逼显式指定档位；注册 agent（frontmatter 已钉 model）可豁免；紧急放行写在 `~/.claude/settings.json` 的 `env` 段设 `"ALLOW_AGENT_MODEL_INHERIT": "1"`（Bash 内 `export` 传不进 hook 进程）。
+**即席派发经济性**：先按任务能力选择角色和模型，再按所有权填写调用字段。`hooks/dispatch-capability-guard.sh` 判断角色/模型能否执行请求（判据 A/B/C）。`hooks/dispatch-agent-ownership-guard.sh` 判断调用者是否有权覆盖 `model`：runtime-owned 内置类型必须显式提供非空 model；具名注册 agent 必须省略 model。派发前应先读取 `references/dispatch-contract.md` 的「Model ownership」；该节再指向唯一维护类型清单的 helper。紧急放行可在 `~/.claude/settings.json` 的 `env` 段设 `"ALLOW_AGENT_MODEL_INHERIT": "1"`；Bash 内 `export` 不会传给 hook 进程。

--- a/plugins/dispatch-contract/skills/subagent-dispatch/references/dispatch-contract.md
+++ b/plugins/dispatch-contract/skills/subagent-dispatch/references/dispatch-contract.md
@@ -50,13 +50,22 @@
 **反例**：
 > 看到初步结论说全部确认，立即派 agent 开始修复。
 
-**同族纪律**：④管"信息完不完整就别拍板"，另有两条己方端纪律管 background 派发后的"通道"与"活性"——产物走 `SendMessage(to:"main")` 回传（该工具在 subagent 默认 deferred，须先 ToolSearch 加载）、活性判定不靠文件轮询、TaskStop 存疑多等一 turn。见 `references/mailbox-liveness.md`。
+**同族纪律**：④管"信息完不完整就别拍板"，另有两条己方端纪律管 background 派发后的"通道"与"活性"——产物走 `SendMessage(to:"main")` 回传（该工具在 subagent 默认 deferred，须先 ToolSearch 加载）、活性判定不靠文件轮询、TaskStop 存疑多等一 turn。见 `mailbox-liveness.md`。
 
 ## 铁律①的技术边界
 
 日常 `Agent`/`Task` 工具**没有 schema 参数**，字段级结构化产物（如强制 JSON 各字段类型、validation 失败自动重试）仍只能升级到 `Workflow` 的 `agent({schema})` 机制才可校验——见 workflow-schema.md。
 
 但"定稿与否"这一件事已不再纯靠措辞：SubagentStop 门禁 + `%%DONE%%` 标记把它变成可机器判定的二元事实——末个非空行是否精确等于标记，以及除标记外是否还有非空行。两条都不依赖语义理解，也都必须判："标记在场"不等于"报告在场"，只判前者等于承认一行标记就是交付物。门禁只保证"报告在场"，不判断"内容是否成立"；证据是否成立仍是主上下文的裁决活，字段级 schema 校验仍是 Workflow 的专属能力。
+
+## Model ownership
+
+`Agent` 和 `Task` 调用应让正确的一方拥有 `model`。runtime-owned 内置类型必须在调用中提供非空、非空白的 model。具名注册 agent 必须省略 model；`null` 表示不覆盖，任何其他值（包括 `inherit`、空字符串和空白）都会被视为覆盖并被拒绝。
+
+> **前置阅读**：runtime-owned 内置类型的唯一维护清单，修改类型归属或判断派发字段前必须先读取：
+> [`hooks/lib/agent-kind.sh`](../../../hooks/lib/agent-kind.sh)
+
+当注册 agent 的能力不足时，应选择满足能力的角色。不要用调用侧 model 覆盖其注册定义。需要紧急放行时，可在 `settings.json` 的 `env` 段设 `ALLOW_AGENT_MODEL_INHERIT=1`；该开关仅用于临时排障，恢复后应移除。
 
 ## 派发端补充：干活别照镜子（persona 规避）
 

--- a/plugins/dispatch-contract/tests/dispatch-agent-ownership-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-agent-ownership-guard.bats
@@ -116,16 +116,104 @@ teardown() {
   [[ "$OWNERSHIP_STDERR" == *"jq unavailable"* ]]
 }
 
-@test "ownership #11: a temp-copy mutation of the runtime rejection is present and makes its block expectation fail" {
+@test "ownership #11: non-Agent/Task payload passes without ownership judgment" {
+  local tool payload
+  for tool in Bash Read; do
+    payload=$(mk_ownership_payload "$tool" general-purpose omit)
+    run_ownership_guard "$payload"
+    assert_ownership_pass
+  done
+}
+
+@test "ownership #12: null subagent_type normalizes to general-purpose" {
+  local payload
+  payload=$(mk_ownership_payload Agent null string sonnet)
+  [[ "$(jq -r '.tool_input.subagent_type' <<<"$payload")" == "null" ]]
+  run_ownership_guard "$payload"
+  assert_ownership_pass
+
+  payload=$(mk_ownership_payload Task null omit)
+  run_ownership_guard "$payload"
+  assert_ownership_block
+}
+
+@test "ownership #13: invalid mk_ownership_payload mode fails loudly" {
+  run mk_ownership_payload Agent general-purpose invalid
+  [ "$status" -eq 2 ] || {
+    echo "Expected invalid model mode to return 2, got $status"
+    return 1
+  }
+}
+
+@test "ownership #14: TERM cleanup removes test-owned temporary directory and terminates" {
+  local temp_dir_record continued_record
+  temp_dir_record="$TEST_TEMP_DIR/interrupted-temp-dir"
+  continued_record="$TEST_TEMP_DIR/continued-after-term"
+  run bash -c '
+    source "$1"
+    common_setup
+    printf "%s" "$TEST_TEMP_DIR" > "$2"
+    kill -TERM "$$"
+    printf "continued" > "$3"
+  ' _ "${BATS_TEST_DIRNAME}/test_helper/common-setup.bash" "$temp_dir_record" "$continued_record"
+  [ "$status" -eq 143 ] || {
+    echo "Expected TERM to terminate with 143, got status $status: $output"
+    return 1
+  }
+  [ -s "$temp_dir_record" ] || {
+    echo "Interrupted helper did not record its temporary directory"
+    return 1
+  }
+  [ ! -e "$(<"$temp_dir_record")" ] || {
+    echo "TERM trap left test temporary directory: $(<"$temp_dir_record")"
+    return 1
+  }
+  [ ! -e "$continued_record" ] || {
+    echo "TERM trap swallowed interruption and continued execution"
+    return 1
+  }
+}
+
+@test "ownership #15: common teardown restores caller EXIT, INT, and TERM traps" {
+  local caller_exit_record
+  caller_exit_record="$TEST_TEMP_DIR/caller-exit-ran"
+  run bash -c '
+    trap '"'"'printf caller-exit > "$1"'"'"' EXIT
+    trap '"'"':'"'"' INT
+    trap '"'"':'"'"' TERM
+    source "$2"
+    common_setup
+    common_teardown
+    trap -p EXIT
+    trap -p INT
+    trap -p TERM
+  ' _ "$caller_exit_record" "${BATS_TEST_DIRNAME}/test_helper/common-setup.bash"
+  [ "$status" -eq 0 ] || {
+    echo "Expected teardown to preserve caller traps, got status $status: $output"
+    return 1
+  }
+  [[ "$output" == *"EXIT"* && "$output" == *"INT"* && "$output" == *"TERM"* ]] || {
+    echo "Expected restored EXIT, INT, and TERM traps, got: $output"
+    return 1
+  }
+  [ "$(<"$caller_exit_record")" = "caller-exit" ] || {
+    echo "Caller EXIT trap did not run after common_teardown"
+    return 1
+  }
+}
+
+@test "ownership #16: a temp-copy mutation of the runtime rejection is present and makes its block expectation fail" {
   local mutant payload
   mkdir -p "$TEST_TEMP_DIR/mutant/hooks"
   mutant="$TEST_TEMP_DIR/mutant/hooks/dispatch-agent-ownership-guard.sh"
   cp "$OWNERSHIP_GUARD_SCRIPT" "$mutant"
   cp -R "${OWNERSHIP_GUARD_SCRIPT%/*}/lib" "$TEST_TEMP_DIR/mutant/hooks/lib"
-  perl -0pi -e 's/  exit 2\nfi\n\n# Null/  exit 0 # MUTATION\nfi\n\n# Null/' "$mutant"
 
-  # Assert the edit actually landed before interpreting its behavioral result.
-  run grep -F "exit 0 # MUTATION" "$mutant"
+  # Assert the production anchor before making the temp-copy mutation.
+  run grep -F 'exit 2' "$mutant"
+  [ "$status" -eq 0 ]
+  perl -0pi -e 's/  exit 2\nfi\n\n# Null/  exit 0 # MUTATION\nfi\n\n# Null/' "$mutant"
+  run grep -F 'exit 0 # MUTATION' "$mutant"
   [ "$status" -eq 0 ]
 
   payload=$(mk_ownership_payload Agent general-purpose omit)

--- a/plugins/dispatch-contract/tests/dispatch-agent-ownership-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-agent-ownership-guard.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# BDD coverage for runtime model ownership on PreToolUse(Agent|Task).
+# Runtime-owned built-ins require a nonblank model. Registered named agents
+# own their model in frontmatter, so callers may omit the field or pass null
+# but may not provide any other value.
+
+setup() {
+  load 'test_helper/common-setup'
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+@test "ownership #1: all six runtime-owned agent types accept a nonblank model for Agent and Task" {
+  local tool type payload
+  for tool in Agent Task; do
+    for type in general-purpose claude Explore Plan claude-code-guide statusline-setup; do
+      payload=$(mk_ownership_payload "$tool" "$type" string sonnet)
+      [[ "$(jq -r '.tool_input.model' <<<"$payload")" == "sonnet" ]]
+      run_ownership_guard "$payload"
+      assert_ownership_pass
+    done
+  done
+}
+
+@test "ownership #2: missing subagent_type defaults to general-purpose and requires model" {
+  local payload
+  payload=$(mk_ownership_payload Agent omit omit)
+  [[ "$(jq -e '.tool_input | has("subagent_type") | not' <<<"$payload")" == "true" ]]
+  run_ownership_guard "$payload"
+  assert_ownership_block
+  [[ "$OWNERSHIP_STDERR" == *"补 runtime model"* ]]
+}
+
+@test "ownership #3: runtime-owned types reject omitted, null, empty, and whitespace model fields" {
+  local payload
+  payload=$(mk_ownership_payload Agent Explore omit)
+  run_ownership_guard "$payload"
+  assert_ownership_block
+
+  payload=$(mk_ownership_payload Agent Explore null)
+  run_ownership_guard "$payload"
+  assert_ownership_block
+
+  payload=$(mk_ownership_payload Agent Explore string '')
+  run_ownership_guard "$payload"
+  assert_ownership_block
+
+  payload=$(mk_ownership_payload Agent Explore string '  ')
+  run_ownership_guard "$payload"
+  assert_ownership_block
+}
+
+@test "ownership #4: type classification is case-insensitive like capability handling" {
+  local payload
+  payload=$(mk_ownership_payload Task GENERAL-PURPOSE string haiku)
+  run_ownership_guard "$payload"
+  assert_ownership_pass
+}
+
+@test "ownership #5: registered agents accept only model omission or null" {
+  local type model_mode payload
+  for type in dev dev-econ; do
+    for model_mode in omit null; do
+      payload=$(mk_ownership_payload Agent "$type" "$model_mode")
+      run_ownership_guard "$payload"
+      assert_ownership_pass
+    done
+  done
+}
+
+@test "ownership #6: registered agent rejects model inherit, empty, whitespace, haiku, and sonnet overrides" {
+  local value payload
+  for value in inherit '' '  ' haiku sonnet; do
+    payload=$(mk_ownership_payload Task dev string "$value")
+    [[ "$(jq -e '.tool_input | has("model")' <<<"$payload")" == "true" ]]
+    run_ownership_guard "$payload"
+    assert_ownership_block
+    [[ "$OWNERSHIP_STDERR" == *"删除 model"* ]]
+  done
+}
+
+@test "ownership #7: explicit model override is rejected for dev-econ too" {
+  local payload
+  payload=$(mk_ownership_payload Agent dev-econ string haiku)
+  run_ownership_guard "$payload"
+  assert_ownership_block
+}
+
+@test "ownership #8: escape hatch emits GATE-BYPASS and passes" {
+  local payload
+  payload=$(mk_ownership_payload Agent general-purpose omit)
+  run_ownership_guard "$payload" "ALLOW_AGENT_MODEL_INHERIT=1"
+  [ "$OWNERSHIP_EXIT" -eq 0 ]
+  [[ "$OWNERSHIP_STDERR" == *"[GATE-BYPASS]"* ]]
+}
+
+@test "ownership #9: empty and malformed JSON fail open with GATE-DEGRADE" {
+  run_ownership_guard ""
+  [ "$OWNERSHIP_EXIT" -eq 0 ]
+  [[ "$OWNERSHIP_STDERR" == *"[GATE-DEGRADE]"* ]]
+
+  run_ownership_guard "not json"
+  [ "$OWNERSHIP_EXIT" -eq 0 ]
+  [[ "$OWNERSHIP_STDERR" == *"[GATE-DEGRADE]"* ]]
+}
+
+@test "ownership #10: jq unavailable fails open with GATE-DEGRADE" {
+  local payload
+  payload=$(mk_ownership_payload Agent general-purpose omit)
+  run_ownership_guard_no_jq "$payload"
+  [ "$OWNERSHIP_EXIT" -eq 0 ]
+  [[ "$OWNERSHIP_STDERR" == *"[GATE-DEGRADE]"* ]]
+  [[ "$OWNERSHIP_STDERR" == *"jq unavailable"* ]]
+}
+
+@test "ownership #11: a temp-copy mutation of the runtime rejection is present and makes its block expectation fail" {
+  local mutant payload
+  mkdir -p "$TEST_TEMP_DIR/mutant/hooks"
+  mutant="$TEST_TEMP_DIR/mutant/hooks/dispatch-agent-ownership-guard.sh"
+  cp "$OWNERSHIP_GUARD_SCRIPT" "$mutant"
+  cp -R "${OWNERSHIP_GUARD_SCRIPT%/*}/lib" "$TEST_TEMP_DIR/mutant/hooks/lib"
+  perl -0pi -e 's/  exit 2\nfi\n\n# Null/  exit 0 # MUTATION\nfi\n\n# Null/' "$mutant"
+
+  # Assert the edit actually landed before interpreting its behavioral result.
+  run grep -F "exit 0 # MUTATION" "$mutant"
+  [ "$status" -eq 0 ]
+
+  payload=$(mk_ownership_payload Agent general-purpose omit)
+  run_ownership_script "$mutant" "$payload"
+  [ "$OWNERSHIP_EXIT" -eq 0 ] || {
+    echo "Mutated runtime rejection unexpectedly still blocked: $OWNERSHIP_STDERR"
+    return 1
+  }
+}

--- a/plugins/dispatch-contract/tests/dispatch-agent-ownership-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-agent-ownership-guard.bats
@@ -145,81 +145,69 @@ teardown() {
   }
 }
 
-@test "ownership #14: TERM cleanup removes test-owned temporary directory and terminates" {
-  local temp_dir_record continued_record
-  temp_dir_record="$TEST_TEMP_DIR/interrupted-temp-dir"
-  continued_record="$TEST_TEMP_DIR/continued-after-term"
-  run bash -c '
-    source "$1"
-    common_setup
-    printf "%s" "$TEST_TEMP_DIR" > "$2"
-    kill -TERM "$$"
-    printf "continued" > "$3"
-  ' _ "${BATS_TEST_DIRNAME}/test_helper/common-setup.bash" "$temp_dir_record" "$continued_record"
-  [ "$status" -eq 143 ] || {
-    echo "Expected TERM to terminate with 143, got status $status: $output"
+@test "ownership #14: Bats reports an intentional failure and still executes teardown" {
+  local probe marker helper
+  probe="$TEST_TEMP_DIR/intentional-failure-probe.bats"
+  marker="$TEST_TEMP_DIR/teardown-ran"
+  helper="${BATS_TEST_DIRNAME}/test_helper/common-setup.bash"
+  cat > "$probe" <<'EOF'
+#!/usr/bin/env bats
+setup() {
+  source "$HELPER"
+  common_setup
+}
+teardown() {
+  printf 'teardown-ran' > "$MARKER"
+  common_teardown
+}
+@test "intentional failure" {
+  false
+}
+EOF
+
+  run env HELPER="$helper" MARKER="$marker" bats "$probe"
+  [ "$status" -ne 0 ] || {
+    echo "Intentional failing probe was reported as passing: $output"
     return 1
   }
-  [ -s "$temp_dir_record" ] || {
-    echo "Interrupted helper did not record its temporary directory"
+  [[ "$output" == *"not ok"* && "$output" == *"intentional failure"* ]] || {
+    echo "Bats did not report the intentional failure: $output"
     return 1
   }
-  [ ! -e "$(<"$temp_dir_record")" ] || {
-    echo "TERM trap left test temporary directory: $(<"$temp_dir_record")"
-    return 1
-  }
-  [ ! -e "$continued_record" ] || {
-    echo "TERM trap swallowed interruption and continued execution"
+  [ "$(<"$marker")" = "teardown-ran" ] || {
+    echo "Bats did not execute teardown after the intentional failure"
     return 1
   }
 }
 
-@test "ownership #15: common teardown restores caller EXIT, INT, and TERM traps" {
-  local caller_exit_record
-  caller_exit_record="$TEST_TEMP_DIR/caller-exit-ran"
-  run bash -c '
-    trap '"'"'printf caller-exit > "$1"'"'"' EXIT
-    trap '"'"':'"'"' INT
-    trap '"'"':'"'"' TERM
-    source "$2"
-    common_setup
-    common_teardown
-    trap -p EXIT
-    trap -p INT
-    trap -p TERM
-  ' _ "$caller_exit_record" "${BATS_TEST_DIRNAME}/test_helper/common-setup.bash"
-  [ "$status" -eq 0 ] || {
-    echo "Expected teardown to preserve caller traps, got status $status: $output"
-    return 1
-  }
-  [[ "$output" == *"EXIT"* && "$output" == *"INT"* && "$output" == *"TERM"* ]] || {
-    echo "Expected restored EXIT, INT, and TERM traps, got: $output"
-    return 1
-  }
-  [ "$(<"$caller_exit_record")" = "caller-exit" ] || {
-    echo "Caller EXIT trap did not run after common_teardown"
-    return 1
-  }
-}
-
-@test "ownership #16: a temp-copy mutation of the runtime rejection is present and makes its block expectation fail" {
-  local mutant payload
+@test "ownership #15: runtime rejection mutation makes the focused block assertion red, then restores it" {
+  local mutant payload anchor anchor_count
   mkdir -p "$TEST_TEMP_DIR/mutant/hooks"
   mutant="$TEST_TEMP_DIR/mutant/hooks/dispatch-agent-ownership-guard.sh"
   cp "$OWNERSHIP_GUARD_SCRIPT" "$mutant"
   cp -R "${OWNERSHIP_GUARD_SCRIPT%/*}/lib" "$TEST_TEMP_DIR/mutant/hooks/lib"
 
-  # Assert the production anchor before making the temp-copy mutation.
-  run grep -F 'exit 2' "$mutant"
-  [ "$status" -eq 0 ]
-  perl -0pi -e 's/  exit 2\nfi\n\n# Null/  exit 0 # MUTATION\nfi\n\n# Null/' "$mutant"
+  anchor='  printf '\''[dispatch-agent-ownership-guard] 内置 runtime-owned agent(subagent_type=%s) 必须显式带非空、非空白 model。\n'\'' "$TYPE" >&2'
+  anchor_count=$(grep -Fxc "$anchor" "$mutant")
+  [ "$anchor_count" -eq 1 ] || {
+    echo "Expected exactly one complete runtime-rejection anchor, found $anchor_count"
+    return 1
+  }
+  perl -0pi -e 's/(内置 runtime-owned agent\(subagent_type=%s\).*?\n.*?\n  exit) 2/$1 0 # MUTATION/s' "$mutant"
   run grep -F 'exit 0 # MUTATION' "$mutant"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 0 ] || {
+    echo "Runtime rejection mutation did not land"
+    return 1
+  }
 
   payload=$(mk_ownership_payload Agent general-purpose omit)
   run_ownership_script "$mutant" "$payload"
-  [ "$OWNERSHIP_EXIT" -eq 0 ] || {
-    echo "Mutated runtime rejection unexpectedly still blocked: $OWNERSHIP_STDERR"
+  if assert_ownership_block; then
+    echo "Mutated runtime rejection still satisfied the focused block assertion"
     return 1
-  }
+  fi
+
+  cp "$OWNERSHIP_GUARD_SCRIPT" "$mutant"
+  run_ownership_script "$mutant" "$payload"
+  assert_ownership_block
 }

--- a/plugins/dispatch-contract/tests/dispatch-capability-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-capability-guard.bats
@@ -613,3 +613,44 @@ teardown() {
     return 1
   }
 }
+
+@test "cap #46: copied hook without agent-kind.sh fails open with [GATE-DEGRADE]" {
+  local copied_guard payload
+  copied_guard="$TEST_TEMP_DIR/dependency-missing/dispatch-capability-guard.sh"
+  mkdir -p "${copied_guard%/*}"
+  cp "$CAP_GUARD_SCRIPT" "$copied_guard"
+
+  payload=$(mk_cap_payload "explore" "修复 main.py" "omit")
+  run_cap_guard_script "$copied_guard" "$payload"
+  [ "$CAP_EXIT" -eq 0 ] || {
+    echo "Expected dependency-missing copied hook to fail open, got $CAP_EXIT: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" == *"[GATE-DEGRADE]"* && "$CAP_STDERR" == *"agent-kind.sh unavailable"* ]] || {
+    echo "Expected agent-kind dependency degrade, got: $CAP_STDERR"
+    return 1
+  }
+}
+
+@test "cap #47: A and B rejection exits provide complete executable dispatch fields" {
+  local payload
+  payload=$(mk_cap_payload "general-purpose" "只读调研，查看代码逻辑" "sonnet")
+  run_cap_guard "$payload"
+  assert_cap_block "A"
+  [[ "$CAP_STDERR" == *'Agent(subagent_type="Explore", model="sonnet", ...)'* ]] || {
+    echo "Expected complete Explore re-dispatch fields, got: $CAP_STDERR"
+    return 1
+  }
+
+  payload=$(mk_cap_payload "explore" "修复 main.py" "omit")
+  run_cap_guard "$payload"
+  assert_cap_block "B"
+  [[ "$CAP_STDERR" == *'Agent(subagent_type="general-purpose", model="sonnet", ...)'* ]] || {
+    echo "Expected complete general-purpose re-dispatch fields, got: $CAP_STDERR"
+    return 1
+  }
+  [[ "$CAP_STDERR" == *'Agent(subagent_type="dev", ...)'* && "$CAP_STDERR" == *"省略 model"* ]] || {
+    echo "Expected registered-agent model ownership guidance, got: $CAP_STDERR"
+    return 1
+  }
+}

--- a/plugins/dispatch-contract/tests/dispatch-capability-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-capability-guard.bats
@@ -357,7 +357,7 @@ teardown() {
 # Malformed input fail-open
 # ============================================================
 
-@test "cap #30a: empty stdin -> exit 0 with [GATE-DEGRADE] (Major finding #3: empty stdin is a degrade path, not a silent no-signal pass — not assert_cap_pass, same reasoning as #30b)" {
+@test "cap #30a: empty stdin -> exit 0 with [GATE-DEGRADE] (empty stdin is a degrade path, not a silent no-signal pass)" {
   run_cap_guard_stdin ""
   [ "$CAP_EXIT" -eq 0 ] || {
     echo "Expected exit 0, got $CAP_EXIT"
@@ -448,7 +448,7 @@ teardown() {
 }
 
 # ============================================================
-# Regression: 4 defects fixed post-AI-review
+# Regression: four fixed dispatch-capability defects
 # (WRITE_HIT_A dead-end close, EXEC exec-intent anchor, GATE-DEGRADE for
 # empty stdin / missing jq, WRITE_OBJ bug|issue|error). See preamble in
 # hooks/dispatch-capability-guard.sh ("A's exemption" block comment) for

--- a/plugins/dispatch-contract/tests/dispatch-capability-guard.bats
+++ b/plugins/dispatch-contract/tests/dispatch-capability-guard.bats
@@ -155,6 +155,44 @@ teardown() {
   assert_cap_pass
 }
 
+@test "cap #15d: missing or null subagent_type defaults to general-purpose, so explicit haiku write dispatch blocks C for Agent and Task" {
+  local tool type_mode payload
+  for tool in Agent Task; do
+    for type_mode in omit null; do
+      payload=$(mk_cap_payload "$type_mode" "修复 main.py" "haiku")
+      payload=$(jq -c --arg tool "$tool" '. + {tool_name:$tool}' <<<"$payload")
+      if [[ "$type_mode" == "omit" ]]; then
+        [[ "$(jq -e '.tool_input | has("subagent_type") | not' <<<"$payload")" == "true" ]]
+      else
+        [[ "$(jq -r '.tool_input.subagent_type' <<<"$payload")" == "null" ]]
+      fi
+      run_cap_guard "$payload"
+      assert_cap_block "C"
+    done
+  done
+}
+
+@test "cap #15a: dev-econ + write prompt + model=haiku -> PASS (registered agents are outside judgment C)" {
+  local payload
+  payload=$(mk_cap_payload "dev-econ" "修复 main.py" "haiku")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #15b: dev-econ + write prompt + model=sonnet -> PASS (registered agents are outside judgment C)" {
+  local payload
+  payload=$(mk_cap_payload "dev-econ" "修复 main.py" "sonnet")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
+@test "cap #15c: dev-econ + write prompt + model absent -> PASS (registered agents are outside judgment C)" {
+  local payload
+  payload=$(mk_cap_payload "dev-econ" "修复 main.py" "omit")
+  run_cap_guard "$payload"
+  assert_cap_pass
+}
+
 # ============================================================
 # WRITE anchoring: syntactic shape, not bare keyword
 # ============================================================

--- a/plugins/dispatch-contract/tests/gate-composition.bats
+++ b/plugins/dispatch-contract/tests/gate-composition.bats
@@ -18,7 +18,7 @@
 # test_helper/common-setup.bash) reads hooks.json's PreToolUse section at
 # test time instead of hardcoding script names — a fourth PreToolUse guard
 # added to this plugin later is automatically included in every test below
-# without touching this file. hooks.json registers the same three guards
+# without touching this file. hooks.json registers the same four guards
 # under BOTH the "Agent" and "Task" matchers (Lead/PM can dispatch via
 # either tool), so this file checks both matchers independently (composition
 # #7/#8/#9 below) — the Agent-only checks alone would stay green even if a
@@ -57,6 +57,7 @@ setup() {
   unset CLAUDE_CODE_DISABLE_BACKGROUND_TASKS
   unset CLAUDE_AUTO_BACKGROUND_TASKS
   unset ALLOW_DISPATCH_CAPABILITY_MISMATCH
+  unset ALLOW_AGENT_MODEL_INHERIT
   discover_agent_gates
   # A neutral prompt/description pair carrying no EXEC/WRITE/RO/NEG signal
   # dispatch-capability-guard.sh's regex set recognizes (verified directly
@@ -105,14 +106,16 @@ teardown() {
     [ -f "$s" ] || { echo "Discovered gate path does not exist on disk: $s"; return 1; }
   done
 
-  # Check 3: all three known guards must be present in the discovered set.
-  local found_sync=0 found_capability=0 found_channel=0
+  # Check 3: all four known guards must be present in the discovered set.
+  local found_sync=0 found_ownership=0 found_capability=0 found_channel=0
   for s in "${GATE_SCRIPTS[@]}"; do
     [[ "$s" == *"/hooks/dispatch-sync-guard.sh" ]] && found_sync=1
+    [[ "$s" == *"/hooks/dispatch-agent-ownership-guard.sh" ]] && found_ownership=1
     [[ "$s" == *"/hooks/dispatch-capability-guard.sh" ]] && found_capability=1
     [[ "$s" == *"/hooks/pre-dispatch-channel-guard.sh" ]] && found_channel=1
   done
   [ "$found_sync" -eq 1 ] || { echo "dispatch-sync-guard.sh not in discovered set: ${GATE_SCRIPTS[*]}"; return 1; }
+  [ "$found_ownership" -eq 1 ] || { echo "dispatch-agent-ownership-guard.sh not in discovered set: ${GATE_SCRIPTS[*]}"; return 1; }
   [ "$found_capability" -eq 1 ] || { echo "dispatch-capability-guard.sh not in discovered set: ${GATE_SCRIPTS[*]}"; return 1; }
   [ "$found_channel" -eq 1 ] || { echo "pre-dispatch-channel-guard.sh not in discovered set: ${GATE_SCRIPTS[*]}"; return 1; }
 }
@@ -124,7 +127,7 @@ teardown() {
 
 @test "composition #1: outroute ① (no name, run_in_background:false) clears every discovered gate" {
   local payload
-  payload=$(mk_composed_payload "Agent" "false" "omit" "omit" "omit" "$NEUTRAL_PROMPT" "$NEUTRAL_DESC")
+  payload=$(mk_composed_payload "Agent" "false" "omit" "omit" "omit" "$NEUTRAL_PROMPT" "$NEUTRAL_DESC" "sonnet")
   # fixture self-check: a real Agent dispatch always carries a prompt — a
   # payload with no prompt field makes dispatch-capability-guard.sh's
   # participation in this test a no-op (see setup's NEUTRAL_PROMPT comment).
@@ -154,14 +157,14 @@ teardown() {
   mkdir -p "$cwd/.claude/agents"
   printf 'dev role\n' > "$cwd/.claude/agents/dev.md"
   local payload
-  # model is included because a real Lead starting a teammate always sends
-  # one; PROMPT/DESC per setup's NEUTRAL_PROMPT comment.
-  payload=$(mk_composed_payload "Agent" "omit" "lead" "dev" "$cwd" "$NEUTRAL_PROMPT" "$NEUTRAL_DESC" "sonnet")
+  # Registered teammates own their model in frontmatter, so callers must omit
+  # model. PROMPT/DESC are supplied per setup's NEUTRAL_PROMPT comment.
+  payload=$(mk_composed_payload "Agent" "omit" "lead" "dev" "$cwd" "$NEUTRAL_PROMPT" "$NEUTRAL_DESC")
   # fixture self-check
   [[ "$(jq -r '.tool_input.name' <<< "$payload")" == "lead" ]]
   [[ "$(jq -r '.tool_input.subagent_type' <<< "$payload")" == "dev" ]]
   [[ "$(jq -r '.tool_input.prompt' <<< "$payload")" == "$NEUTRAL_PROMPT" ]]
-  [[ "$(jq -r '.tool_input.model' <<< "$payload")" == "sonnet" ]]
+  [[ "$(jq -e '.tool_input | has("model") | not' <<< "$payload")" == "true" ]]
   run jq -e '.tool_input | has("run_in_background")' <<< "$payload"
   [ "$status" -eq 1 ]
   local s rc
@@ -283,7 +286,7 @@ teardown() {
 @test "composition #8: outroute ① via Task matcher clears every discovered Task-side gate" {
   discover_task_gates
   local payload
-  payload=$(mk_composed_payload "Task" "false" "omit" "omit" "omit" "$NEUTRAL_PROMPT" "$NEUTRAL_DESC")
+  payload=$(mk_composed_payload "Task" "false" "omit" "omit" "omit" "$NEUTRAL_PROMPT" "$NEUTRAL_DESC" "sonnet")
   local s rc
   for s in "${GATE_SCRIPTS[@]}"; do
     run_one_gate "$s" "$payload"
@@ -302,7 +305,7 @@ teardown() {
   mkdir -p "$cwd/.claude/agents"
   printf 'dev role\n' > "$cwd/.claude/agents/dev.md"
   local payload
-  payload=$(mk_composed_payload "Task" "omit" "lead" "dev" "$cwd" "$NEUTRAL_PROMPT" "$NEUTRAL_DESC" "sonnet")
+  payload=$(mk_composed_payload "Task" "omit" "lead" "dev" "$cwd" "$NEUTRAL_PROMPT" "$NEUTRAL_DESC")
   local s rc
   for s in "${GATE_SCRIPTS[@]}"; do
     run_one_gate "$s" "$payload"
@@ -396,4 +399,90 @@ teardown() {
     echo "Expected '命中判据 B' in stderr, got: $ONE_GATE_STDERR"
     return 1
   }
+}
+
+@test "composition #12: ownership guard blocks an Agent and Task runtime default without model" {
+  local ownership_script="${PLUGIN_ROOT_DIR}/hooks/dispatch-agent-ownership-guard.sh"
+  local tool payload
+  for tool in Agent Task; do
+    payload=$(mk_composed_payload "$tool" "false" "omit" "omit" "omit" "$NEUTRAL_PROMPT" "$NEUTRAL_DESC")
+    run_one_gate "$ownership_script" "$payload"
+    [ "$ONE_GATE_EXIT" -eq 2 ] || {
+      echo "Expected ownership guard to block $tool without model, got exit $ONE_GATE_EXIT"
+      echo "stderr: $ONE_GATE_STDERR"
+      return 1
+    }
+    [[ "$ONE_GATE_STDERR" == *"runtime-owned"* ]] || {
+      echo "Expected runtime-owned ownership message, got: $ONE_GATE_STDERR"
+      return 1
+    }
+  done
+}
+
+@test "composition #13: dev-econ write dispatch without model clears all Agent and Task gates" {
+  local tool payload s
+  for tool in Agent Task; do
+    discover_agent_gates
+    [[ "$tool" == "Task" ]] && discover_task_gates
+    payload=$(mk_composed_payload "$tool" "false" "omit" "dev-econ" "omit" "修复 main.py 里的 bug" "$NEUTRAL_DESC")
+    [[ "$(jq -e '.tool_input | has("model") | not' <<<"$payload")" == "true" ]]
+    for s in "${GATE_SCRIPTS[@]}"; do
+      run_one_gate "$s" "$payload"
+      [ "$ONE_GATE_EXIT" -eq 0 ] || {
+        echo "Expected dev-econ write dispatch to pass $(basename "$s") for $tool, got exit $ONE_GATE_EXIT"
+        echo "stderr: $ONE_GATE_STDERR"
+        return 1
+      }
+    done
+  done
+}
+
+@test "composition #14: missing or null type normalizes to general-purpose before C for both Agent and Task" {
+  local tool type_mode payload s
+  for tool in Agent Task; do
+    discover_agent_gates
+    [[ "$tool" == "Task" ]] && discover_task_gates
+    for type_mode in omit __NULL__; do
+      payload=$(mk_composed_payload "$tool" "false" "omit" "$type_mode" "omit" "修复 main.py 里的 bug" "$NEUTRAL_DESC" "haiku")
+      for s in "${GATE_SCRIPTS[@]}"; do
+        run_one_gate "$s" "$payload"
+        if [[ "$s" == *"/dispatch-capability-guard.sh" ]]; then
+          [ "$ONE_GATE_EXIT" -eq 2 ] || {
+            echo "Expected capability C to block $tool/$type_mode, got exit $ONE_GATE_EXIT"
+            echo "stderr: $ONE_GATE_STDERR"
+            return 1
+          }
+          [[ "$ONE_GATE_STDERR" == *"命中判据 C"* ]] || {
+            echo "Expected judgment C for $tool/$type_mode, got: $ONE_GATE_STDERR"
+            return 1
+          }
+        else
+          [ "$ONE_GATE_EXIT" -eq 0 ] || {
+            echo "Expected sibling gate $(basename "$s") to pass $tool/$type_mode, got exit $ONE_GATE_EXIT"
+            echo "stderr: $ONE_GATE_STDERR"
+            return 1
+          }
+        fi
+      done
+    done
+  done
+}
+
+@test "composition #15: missing or null type plus sonnet write dispatch clears all Agent and Task gates" {
+  local tool type_mode payload s
+  for tool in Agent Task; do
+    discover_agent_gates
+    [[ "$tool" == "Task" ]] && discover_task_gates
+    for type_mode in omit __NULL__; do
+      payload=$(mk_composed_payload "$tool" "false" "omit" "$type_mode" "omit" "修复 main.py 里的 bug" "$NEUTRAL_DESC" "sonnet")
+      for s in "${GATE_SCRIPTS[@]}"; do
+        run_one_gate "$s" "$payload"
+        [ "$ONE_GATE_EXIT" -eq 0 ] || {
+          echo "Expected sonnet dispatch $tool/$type_mode to pass $(basename "$s"), got exit $ONE_GATE_EXIT"
+          echo "stderr: $ONE_GATE_STDERR"
+          return 1
+        }
+      done
+    done
+  done
 }

--- a/plugins/dispatch-contract/tests/gate-composition.bats
+++ b/plugins/dispatch-contract/tests/gate-composition.bats
@@ -16,8 +16,8 @@
 #
 # Gate discovery (see discover_agent_gates/discover_task_gates in
 # test_helper/common-setup.bash) reads hooks.json's PreToolUse section at
-# test time instead of hardcoding script names — a fourth PreToolUse guard
-# added to this plugin later is automatically included in every test below
+# test time instead of hardcoding script names — any additional PreToolUse
+# guard added to this plugin later is automatically included in every test below
 # without touching this file. hooks.json registers the same four guards
 # under BOTH the "Agent" and "Task" matchers (Lead/PM can dispatch via
 # either tool), so this file checks both matchers independently (composition
@@ -88,9 +88,9 @@ teardown() {
   # hooks.json — a different jq traversal (recursive descent via `..` instead
   # of discover_agent_gates' explicit `.hooks.PreToolUse[]` field walk) so
   # this check cannot pass by construction just because both expressions
-  # share the same bug. This is what makes the assertion resilient to a
-  # fourth guard being added later: the expected number is computed from the
-  # same file discover_agent_gates reads, not hardcoded here.
+  # share the same bug. This is what makes the assertion resilient to an
+  # additional guard being added later: the expected number is computed from
+  # the same file discover_agent_gates reads, not hardcoded here.
   local independent_count
   independent_count=$(jq '
     [.. | objects | select(has("matcher") and .matcher == "Agent") | .hooks[]?] | length

--- a/plugins/dispatch-contract/tests/subagent-done-gate.bats
+++ b/plugins/dispatch-contract/tests/subagent-done-gate.bats
@@ -257,7 +257,7 @@ teardown() {
   # Drive with timeout to guarantee non-hang even if the hook regresses.
   HOOK_STDOUT="" HOOK_STDERR="" HOOK_EXIT=0
   local stderr_file
-  stderr_file=$(mktemp)
+  stderr_file=$(mktemp "$TEST_TEMP_DIR/stderr.XXXXXX") || return 1
   HOOK_STDOUT=$(printf '%s' "$payload" | timeout 10 bash "$GATE_SCRIPT" 2>"$stderr_file") || HOOK_EXIT=$?
   HOOK_STDERR=$(cat "$stderr_file")
   rm -f "$stderr_file"

--- a/plugins/dispatch-contract/tests/test_helper/common-setup.bash
+++ b/plugins/dispatch-contract/tests/test_helper/common-setup.bash
@@ -326,7 +326,7 @@ mk_channel_payload() {
 # run_channel_guard PAYLOAD [env_overrides...]
 # Sets: CHANNEL_STDOUT, CHANNEL_STDERR, CHANNEL_EXIT
 #
-# Isolates all five escape-hatch/fail-open env vars any of this plugin's
+# Isolates all six escape-hatch/fail-open env vars any of this plugin's
 # PreToolUse(Agent|Task) guards read, not just this gate's own
 # ALLOW_UNMANAGED_TEAMMATE — a BLOCK test here must not silently PASS because
 # the calling shell happens to have ALLOW_BACKGROUND_DISPATCH,
@@ -344,9 +344,9 @@ run_channel_guard() {
   stderr_file=$(mktemp)
 
   if [[ "${2:-}" != "" ]]; then
-    CHANNEL_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_UNMANAGED_TEAMMATE -u ALLOW_BACKGROUND_DISPATCH -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS -u CLAUDE_AUTO_BACKGROUND_TASKS -u ALLOW_DISPATCH_CAPABILITY_MISMATCH "${@:2}" bash "$CHANNEL_GUARD_SCRIPT" 2>"$stderr_file") || CHANNEL_EXIT=$?
+    CHANNEL_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_UNMANAGED_TEAMMATE -u ALLOW_BACKGROUND_DISPATCH -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS -u CLAUDE_AUTO_BACKGROUND_TASKS -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT "${@:2}" bash "$CHANNEL_GUARD_SCRIPT" 2>"$stderr_file") || CHANNEL_EXIT=$?
   else
-    CHANNEL_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_UNMANAGED_TEAMMATE -u ALLOW_BACKGROUND_DISPATCH -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS -u CLAUDE_AUTO_BACKGROUND_TASKS -u ALLOW_DISPATCH_CAPABILITY_MISMATCH bash "$CHANNEL_GUARD_SCRIPT" 2>"$stderr_file") || CHANNEL_EXIT=$?
+    CHANNEL_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_UNMANAGED_TEAMMATE -u ALLOW_BACKGROUND_DISPATCH -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS -u CLAUDE_AUTO_BACKGROUND_TASKS -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT bash "$CHANNEL_GUARD_SCRIPT" 2>"$stderr_file") || CHANNEL_EXIT=$?
   fi
   CHANNEL_STDERR=$(cat "$stderr_file")
   rm -f "$stderr_file"
@@ -471,7 +471,7 @@ CAP_GUARD_SCRIPT="${BATS_TEST_DIRNAME}/../hooks/dispatch-capability-guard.sh"
 # --- Payload Builder (dispatch-capability-guard) ---
 
 # mk_cap_payload SUBAGENT_TYPE_MODE PROMPT [MODEL_MODE]
-# SUBAGENT_TYPE_MODE: omit | any other string (used verbatim as subagent_type value)
+# SUBAGENT_TYPE_MODE: omit | null | any other string (used verbatim as subagent_type value)
 # PROMPT: prompt text. Pass "" for an explicit empty string (field present but
 #         blank); use PROMPT_MODE=omit (4th positional, see below) to omit the
 #         field entirely instead.
@@ -481,9 +481,11 @@ CAP_GUARD_SCRIPT="${BATS_TEST_DIRNAME}/../hooks/dispatch-capability-guard.sh"
 mk_cap_payload() {
   local type_mode="$1" prompt="$2" model_mode="${3:-omit}" prompt_field_mode="${4:-present}"
   local ti='{}'
-  if [[ "$type_mode" != "omit" ]]; then
-    ti=$(jq -cn --argjson base "$ti" --arg v "$type_mode" '$base + {subagent_type:$v}')
-  fi
+  case "$type_mode" in
+    omit) ;;
+    null) ti=$(jq -cn --argjson base "$ti" '$base + {subagent_type:null}') ;;
+    *) ti=$(jq -cn --argjson base "$ti" --arg v "$type_mode" '$base + {subagent_type:$v}') ;;
+  esac
   if [[ "$prompt_field_mode" != "omit" ]]; then
     ti=$(jq -cn --argjson base "$ti" --arg v "$prompt" '$base + {prompt:$v}')
   fi
@@ -517,9 +519,9 @@ run_cap_guard() {
   # 导致每个 BLOCK 用例假通过。-u 排在显式 override 之前,用例仍能主动传该
   # 变量做正向测试（见 GATE-BYPASS 用例）。
   if [[ "${2:-}" != "" ]]; then
-    CAP_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH "${@:2}" bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
+    CAP_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT "${@:2}" bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
   else
-    CAP_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
+    CAP_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
   fi
   CAP_STDERR=$(cat "$stderr_file")
   rm -f "$stderr_file"
@@ -539,9 +541,9 @@ run_cap_guard_stdin() {
   stderr_file=$(mktemp)
 
   if [[ "${2:-}" != "" ]]; then
-    CAP_STDOUT=$(printf '%s' "$raw" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH "${@:2}" bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
+    CAP_STDOUT=$(printf '%s' "$raw" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT "${@:2}" bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
   else
-    CAP_STDOUT=$(printf '%s' "$raw" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
+    CAP_STDOUT=$(printf '%s' "$raw" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
   fi
   CAP_STDERR=$(cat "$stderr_file")
   rm -f "$stderr_file"
@@ -684,7 +686,7 @@ discover_agent_gates() {
 }
 
 # discover_task_gates — matcher "Task". Sets GATE_SCRIPTS. hooks.json
-# mirrors the same three PreToolUse guards under both the "Agent" and
+# mirrors the same four PreToolUse guards under both the "Agent" and
 # "Task" matchers (Lead/PM dispatch via the Task tool as well as Agent), so
 # any composition assertion built only from discover_agent_gates would stay
 # green even if someone stripped a guard from the "Task" side only — the
@@ -706,7 +708,7 @@ discover_task_gates() {
 #
 # RIB_MODE:      omit | false | true
 # NAME_MODE:     omit | <literal string>   (tool_input.name)
-# SUBTYPE_MODE:  omit | <literal string>   (tool_input.subagent_type)
+# SUBTYPE_MODE:  omit | __NULL__ | <literal string>   (tool_input.subagent_type)
 # CWD_MODE:      omit | <literal path>     (top-level .cwd)
 # PROMPT_MODE:   omit | <literal string>   (tool_input.prompt, default omit)
 # DESC_MODE:     omit | <literal string>   (tool_input.description, default omit)
@@ -727,9 +729,11 @@ mk_composed_payload() {
   if [[ "$name" != "omit" ]]; then
     ti=$(jq -cn --argjson b "$ti" --arg n "$name" '$b + {name:$n}')
   fi
-  if [[ "$subtype" != "omit" ]]; then
-    ti=$(jq -cn --argjson b "$ti" --arg s "$subtype" '$b + {subagent_type:$s}')
-  fi
+  case "$subtype" in
+    omit) ;;
+    __NULL__) ti=$(jq -cn --argjson b "$ti" '$b + {subagent_type:null}') ;;
+    *) ti=$(jq -cn --argjson b "$ti" --arg s "$subtype" '$b + {subagent_type:$s}') ;;
+  esac
   if [[ "$prompt" != "omit" ]]; then
     ti=$(jq -cn --argjson b "$ti" --arg p "$prompt" '$b + {prompt:$p}')
   fi
@@ -752,7 +756,7 @@ mk_composed_payload() {
 #
 # Same escape-hatch/fail-open isolation discipline as the sibling
 # run_*_guard helpers above: a BLOCK case here must not silently PASS
-# because the invoking shell happens to carry one of these five vars for an
+# because the invoking shell happens to carry one of these six vars for an
 # unrelated reason. This runner is shared across every gate discovered by
 # discover_agent_gates/discover_task_gates (dispatch-sync-guard.sh,
 # dispatch-capability-guard.sh, pre-dispatch-channel-guard.sh) — it must
@@ -767,10 +771,99 @@ run_one_gate() {
   local stderr_file
   stderr_file=$(mktemp)
   if [[ "${1:-}" != "" ]]; then
-    printf '%s' "$payload" | env -u ALLOW_UNMANAGED_TEAMMATE -u ALLOW_BACKGROUND_DISPATCH -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS -u CLAUDE_AUTO_BACKGROUND_TASKS -u ALLOW_DISPATCH_CAPABILITY_MISMATCH "$@" bash "$script" >/dev/null 2>"$stderr_file" || ONE_GATE_EXIT=$?
+    printf '%s' "$payload" | env -u ALLOW_UNMANAGED_TEAMMATE -u ALLOW_BACKGROUND_DISPATCH -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS -u CLAUDE_AUTO_BACKGROUND_TASKS -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT "$@" bash "$script" >/dev/null 2>"$stderr_file" || ONE_GATE_EXIT=$?
   else
-    printf '%s' "$payload" | env -u ALLOW_UNMANAGED_TEAMMATE -u ALLOW_BACKGROUND_DISPATCH -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS -u CLAUDE_AUTO_BACKGROUND_TASKS -u ALLOW_DISPATCH_CAPABILITY_MISMATCH bash "$script" >/dev/null 2>"$stderr_file" || ONE_GATE_EXIT=$?
+    printf '%s' "$payload" | env -u ALLOW_UNMANAGED_TEAMMATE -u ALLOW_BACKGROUND_DISPATCH -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS -u CLAUDE_AUTO_BACKGROUND_TASKS -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT bash "$script" >/dev/null 2>"$stderr_file" || ONE_GATE_EXIT=$?
   fi
   ONE_GATE_STDERR=$(cat "$stderr_file")
   rm -f "$stderr_file"
+}
+
+# ============================================================
+# Additions below support dispatch-agent-ownership-guard.bats.
+# ============================================================
+
+OWNERSHIP_GUARD_SCRIPT="${BATS_TEST_DIRNAME}/../hooks/dispatch-agent-ownership-guard.sh"
+
+# mk_ownership_payload TOOL_NAME TYPE_MODE MODEL_MODE [MODEL_VALUE]
+# TYPE_MODE: omit | any literal type. MODEL_MODE: omit | null | string.
+mk_ownership_payload() {
+  local tool="$1" type_mode="$2" model_mode="$3" model_value="${4:-}"
+  local ti='{}'
+
+  if [[ "$type_mode" != "omit" ]]; then
+    ti=$(jq -cn --argjson base "$ti" --arg value "$type_mode" '$base + {subagent_type:$value}')
+  fi
+  case "$model_mode" in
+    null) ti=$(jq -cn --argjson base "$ti" '$base + {model:null}') ;;
+    string) ti=$(jq -cn --argjson base "$ti" --arg value "$model_value" '$base + {model:$value}') ;;
+    omit) ;;
+    *) return 2 ;;
+  esac
+  jq -cn --arg tool "$tool" --argjson ti "$ti" '{tool_name:$tool, tool_input:$ti}'
+}
+
+# run_ownership_guard PAYLOAD [env_overrides...]
+# Sets: OWNERSHIP_STDOUT, OWNERSHIP_STDERR, OWNERSHIP_EXIT. The runner clears
+# the ownership hatch before applying a test's explicit override.
+run_ownership_guard() {
+  run_ownership_script "$OWNERSHIP_GUARD_SCRIPT" "$@"
+}
+
+# run_ownership_script SCRIPT PAYLOAD [env_overrides...]
+# Like run_ownership_guard, but accepts a temp-copy script for mutation tests.
+run_ownership_script() {
+  local script="$1" payload="$2"
+  shift 2
+  OWNERSHIP_STDOUT=""
+  OWNERSHIP_STDERR=""
+  OWNERSHIP_EXIT=0
+
+  local stderr_file
+  stderr_file=$(mktemp)
+  if [[ "${1:-}" != "" ]]; then
+    OWNERSHIP_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_AGENT_MODEL_INHERIT "$@" bash "$script" 2>"$stderr_file") || OWNERSHIP_EXIT=$?
+  else
+    OWNERSHIP_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_AGENT_MODEL_INHERIT bash "$script" 2>"$stderr_file") || OWNERSHIP_EXIT=$?
+  fi
+  OWNERSHIP_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+run_ownership_guard_no_jq() {
+  local payload="$1" no_jq_dir
+  no_jq_dir=$(mk_no_jq_path)
+  OWNERSHIP_STDOUT=""
+  OWNERSHIP_STDERR=""
+  OWNERSHIP_EXIT=0
+
+  local stderr_file
+  stderr_file=$(mktemp)
+  OWNERSHIP_STDOUT=$(printf '%s' "$payload" | env -i PATH="$no_jq_dir" bash "$OWNERSHIP_GUARD_SCRIPT" 2>"$stderr_file") || OWNERSHIP_EXIT=$?
+  OWNERSHIP_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+assert_ownership_pass() {
+  [ "$OWNERSHIP_EXIT" -eq 0 ] || {
+    echo "Expected exit 0, got $OWNERSHIP_EXIT"
+    echo "stderr: $OWNERSHIP_STDERR"
+    return 1
+  }
+  [[ "$OWNERSHIP_STDERR" != *"[dispatch-agent-ownership-guard]"* ]] || {
+    echo "Expected no ownership BLOCK marker, got: $OWNERSHIP_STDERR"
+    return 1
+  }
+}
+
+assert_ownership_block() {
+  [ "$OWNERSHIP_EXIT" -eq 2 ] || {
+    echo "Expected exit 2, got $OWNERSHIP_EXIT"
+    echo "stderr: $OWNERSHIP_STDERR"
+    return 1
+  }
+  [[ "$OWNERSHIP_STDERR" == *"[dispatch-agent-ownership-guard]"* ]] || {
+    echo "Expected ownership BLOCK marker, got: $OWNERSHIP_STDERR"
+    return 1
+  }
 }

--- a/plugins/dispatch-contract/tests/test_helper/common-setup.bash
+++ b/plugins/dispatch-contract/tests/test_helper/common-setup.bash
@@ -7,38 +7,28 @@ MARK='%%DONE%%'
 
 # --- Setup / Teardown ---
 
+# Bats owns its per-test directory and its lifecycle traps. Keep this helper
+# out of EXIT/INT/TERM entirely: stealing those traps can hide a test failure
+# or prevent Bats from running teardown. Outside Bats, use an independent
+# directory and remove only that directory from the explicit teardown call.
 cleanup_test_temp_dir() {
-  rm -rf "${TEST_TEMP_DIR:-}"
-}
-
-restore_common_setup_traps() {
-  trap - EXIT INT TERM
-  [ -n "${COMMON_SETUP_PREVIOUS_EXIT_TRAP:-}" ] && eval "$COMMON_SETUP_PREVIOUS_EXIT_TRAP"
-  [ -n "${COMMON_SETUP_PREVIOUS_INT_TRAP:-}" ] && eval "$COMMON_SETUP_PREVIOUS_INT_TRAP"
-  [ -n "${COMMON_SETUP_PREVIOUS_TERM_TRAP:-}" ] && eval "$COMMON_SETUP_PREVIOUS_TERM_TRAP"
-  return 0
-}
-
-cleanup_and_terminate() {
-  local signal="$1"
-  cleanup_test_temp_dir
-  trap - EXIT INT TERM
-  kill -s "$signal" "$$"
+  if [[ "${TEST_TEMP_DIR_BATS_OWNED:-0}" != "1" ]]; then
+    rm -rf "${TEST_TEMP_DIR:-}"
+  fi
 }
 
 common_setup() {
-  COMMON_SETUP_PREVIOUS_EXIT_TRAP=$(trap -p EXIT)
-  COMMON_SETUP_PREVIOUS_INT_TRAP=$(trap -p INT)
-  COMMON_SETUP_PREVIOUS_TERM_TRAP=$(trap -p TERM)
-  TEST_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/dispatch-contract.XXXXXX") || return 1
-  trap cleanup_test_temp_dir EXIT
-  trap 'cleanup_and_terminate INT' INT
-  trap 'cleanup_and_terminate TERM' TERM
+  if [[ -n "${BATS_TEST_TMPDIR:-}" ]]; then
+    TEST_TEMP_DIR=$(mktemp -d "${BATS_TEST_TMPDIR%/}/dispatch-contract.XXXXXX") || return 1
+    TEST_TEMP_DIR_BATS_OWNED=1
+  else
+    TEST_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/dispatch-contract.XXXXXX") || return 1
+    TEST_TEMP_DIR_BATS_OWNED=0
+  fi
 }
 
 common_teardown() {
   cleanup_test_temp_dir
-  restore_common_setup_traps
 }
 
 # --- Transcript Fixture Builders ---
@@ -557,6 +547,32 @@ run_cap_guard() {
 # Like run_cap_guard but takes a raw stdin string instead of building/echoing
 # a JSON payload — for malformed-input fixtures (empty, non-JSON, etc.) where
 # there is no well-formed payload to build.
+# run_cap_guard_script SCRIPT PAYLOAD [env_overrides...]
+# Like run_cap_guard, but executes a copied guard for dependency/mutation
+# probes without changing the production script.
+run_cap_guard_script() {
+  local script="$1" payload="$2"
+  shift 2
+  CAP_STDOUT=""
+  CAP_STDERR=""
+  CAP_EXIT=0
+
+  local stderr_file
+  stderr_file=$(mktemp "$TEST_TEMP_DIR/stderr.XXXXXX") || return 1
+
+  if [[ "${1:-}" != "" ]]; then
+    CAP_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT "$@" bash "$script" 2>"$stderr_file") || CAP_EXIT=$?
+  else
+    CAP_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT bash "$script" 2>"$stderr_file") || CAP_EXIT=$?
+  fi
+  CAP_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+# run_cap_guard_stdin RAW_STDIN [env_overrides...]
+# Like run_cap_guard but takes a raw stdin string instead of building/echoing
+# a JSON payload — for malformed-input fixtures (empty, non-JSON, etc.) where
+# there is no well-formed payload to build.
 run_cap_guard_stdin() {
   local raw="$1"
   CAP_STDOUT=""
@@ -670,7 +686,7 @@ PLUGIN_ROOT_DIR="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
 # enforces it) is only invoked once per payload.
 #
 # This is the mechanism that keeps the composition test honest as the plugin
-# grows: a third PreToolUse guard added to hooks.json tomorrow is picked up
+# grows: an additional PreToolUse guard added to hooks.json tomorrow is picked up
 # here automatically, with no edit to this file or to gate-composition.bats
 # required. A hardcoded GATE_SCRIPTS=(a.sh b.sh) list would not have that
 # property — it is exactly the shape of drift that let the channel-guard
@@ -785,7 +801,8 @@ mk_composed_payload() {
 # because the invoking shell happens to carry one of these six vars for an
 # unrelated reason. This runner is shared across every gate discovered by
 # discover_agent_gates/discover_task_gates (dispatch-sync-guard.sh,
-# dispatch-capability-guard.sh, pre-dispatch-channel-guard.sh) — it must
+# dispatch-agent-ownership-guard.sh, dispatch-capability-guard.sh,
+# pre-dispatch-channel-guard.sh) — it must
 # clear the union of all their escape hatches, not just the ones the gate
 # under test in a given call happens to read, since a caller composing a
 # payload for one gate may still route it through this same helper for

--- a/plugins/dispatch-contract/tests/test_helper/common-setup.bash
+++ b/plugins/dispatch-contract/tests/test_helper/common-setup.bash
@@ -7,12 +7,38 @@ MARK='%%DONE%%'
 
 # --- Setup / Teardown ---
 
+cleanup_test_temp_dir() {
+  rm -rf "${TEST_TEMP_DIR:-}"
+}
+
+restore_common_setup_traps() {
+  trap - EXIT INT TERM
+  [ -n "${COMMON_SETUP_PREVIOUS_EXIT_TRAP:-}" ] && eval "$COMMON_SETUP_PREVIOUS_EXIT_TRAP"
+  [ -n "${COMMON_SETUP_PREVIOUS_INT_TRAP:-}" ] && eval "$COMMON_SETUP_PREVIOUS_INT_TRAP"
+  [ -n "${COMMON_SETUP_PREVIOUS_TERM_TRAP:-}" ] && eval "$COMMON_SETUP_PREVIOUS_TERM_TRAP"
+  return 0
+}
+
+cleanup_and_terminate() {
+  local signal="$1"
+  cleanup_test_temp_dir
+  trap - EXIT INT TERM
+  kill -s "$signal" "$$"
+}
+
 common_setup() {
-  TEST_TEMP_DIR=$(mktemp -d)
+  COMMON_SETUP_PREVIOUS_EXIT_TRAP=$(trap -p EXIT)
+  COMMON_SETUP_PREVIOUS_INT_TRAP=$(trap -p INT)
+  COMMON_SETUP_PREVIOUS_TERM_TRAP=$(trap -p TERM)
+  TEST_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/dispatch-contract.XXXXXX") || return 1
+  trap cleanup_test_temp_dir EXIT
+  trap 'cleanup_and_terminate INT' INT
+  trap 'cleanup_and_terminate TERM' TERM
 }
 
 common_teardown() {
-  rm -rf "$TEST_TEMP_DIR"
+  cleanup_test_temp_dir
+  restore_common_setup_traps
 }
 
 # --- Transcript Fixture Builders ---
@@ -121,7 +147,7 @@ run_gate() {
   HOOK_EXIT=0
 
   local stderr_file
-  stderr_file=$(mktemp)
+  stderr_file=$(mktemp "$TEST_TEMP_DIR/stderr.XXXXXX") || return 1
 
   # 夹具必须隔离调用者环境：若跑测试的 shell 里设了 ALLOW_UNMARKED_FINAL=1
   # (subagent-done-gate 的逃生舱),门禁会全局失效,导致每个 BLOCK 用例假通过。
@@ -206,7 +232,7 @@ run_sync_guard() {
   SYNC_EXIT=0
 
   local stderr_file
-  stderr_file=$(mktemp)
+  stderr_file=$(mktemp "$TEST_TEMP_DIR/stderr.XXXXXX") || return 1
 
   # 夹具必须隔离调用者环境：若跑测试的 shell 里设了 ALLOW_BACKGROUND_DISPATCH=1、
   # CLAUDE_CODE_DISABLE_BACKGROUND_TASKS 或 CLAUDE_AUTO_BACKGROUND_TASKS,门禁
@@ -231,7 +257,7 @@ run_rules_inject() {
   INJECT_EXIT=0
 
   local stderr_file
-  stderr_file=$(mktemp)
+  stderr_file=$(mktemp "$TEST_TEMP_DIR/stderr.XXXXXX") || return 1
 
   # 夹具必须隔离调用者环境：若跑测试的 shell 里设了 ALLOW_NO_RULES_INJECT=1
   # (dispatch-rules-inject 的逃生舱),门禁会静默 exit 0 不注入,导致用例假通过。
@@ -341,7 +367,7 @@ run_channel_guard() {
   CHANNEL_EXIT=0
 
   local stderr_file
-  stderr_file=$(mktemp)
+  stderr_file=$(mktemp "$TEST_TEMP_DIR/stderr.XXXXXX") || return 1
 
   if [[ "${2:-}" != "" ]]; then
     CHANNEL_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_UNMANAGED_TEAMMATE -u ALLOW_BACKGROUND_DISPATCH -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS -u CLAUDE_AUTO_BACKGROUND_TASKS -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT "${@:2}" bash "$CHANNEL_GUARD_SCRIPT" 2>"$stderr_file") || CHANNEL_EXIT=$?
@@ -512,7 +538,7 @@ run_cap_guard() {
   CAP_EXIT=0
 
   local stderr_file
-  stderr_file=$(mktemp)
+  stderr_file=$(mktemp "$TEST_TEMP_DIR/stderr.XXXXXX") || return 1
 
   # 夹具必须隔离调用者环境：若跑测试的 shell 里设了
   # ALLOW_DISPATCH_CAPABILITY_MISMATCH=1 (本 hook 的逃生舱),门禁会全局失效,
@@ -538,7 +564,7 @@ run_cap_guard_stdin() {
   CAP_EXIT=0
 
   local stderr_file
-  stderr_file=$(mktemp)
+  stderr_file=$(mktemp "$TEST_TEMP_DIR/stderr.XXXXXX") || return 1
 
   if [[ "${2:-}" != "" ]]; then
     CAP_STDOUT=$(printf '%s' "$raw" | env -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT "${@:2}" bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
@@ -583,7 +609,7 @@ run_cap_guard_no_jq() {
   CAP_EXIT=0
 
   local stderr_file
-  stderr_file=$(mktemp)
+  stderr_file=$(mktemp "$TEST_TEMP_DIR/stderr.XXXXXX") || return 1
 
   CAP_STDOUT=$(printf '%s' "$payload" | env -i PATH="$no_jq_dir" bash "$CAP_GUARD_SCRIPT" 2>"$stderr_file") || CAP_EXIT=$?
   CAP_STDERR=$(cat "$stderr_file")
@@ -769,7 +795,7 @@ run_one_gate() {
   shift 2
   ONE_GATE_EXIT=0
   local stderr_file
-  stderr_file=$(mktemp)
+  stderr_file=$(mktemp "$TEST_TEMP_DIR/stderr.XXXXXX") || return 1
   if [[ "${1:-}" != "" ]]; then
     printf '%s' "$payload" | env -u ALLOW_UNMANAGED_TEAMMATE -u ALLOW_BACKGROUND_DISPATCH -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS -u CLAUDE_AUTO_BACKGROUND_TASKS -u ALLOW_DISPATCH_CAPABILITY_MISMATCH -u ALLOW_AGENT_MODEL_INHERIT "$@" bash "$script" >/dev/null 2>"$stderr_file" || ONE_GATE_EXIT=$?
   else
@@ -786,14 +812,16 @@ run_one_gate() {
 OWNERSHIP_GUARD_SCRIPT="${BATS_TEST_DIRNAME}/../hooks/dispatch-agent-ownership-guard.sh"
 
 # mk_ownership_payload TOOL_NAME TYPE_MODE MODEL_MODE [MODEL_VALUE]
-# TYPE_MODE: omit | any literal type. MODEL_MODE: omit | null | string.
+# TYPE_MODE: omit | null | any literal type. MODEL_MODE: omit | null | string.
 mk_ownership_payload() {
   local tool="$1" type_mode="$2" model_mode="$3" model_value="${4:-}"
   local ti='{}'
 
-  if [[ "$type_mode" != "omit" ]]; then
-    ti=$(jq -cn --argjson base "$ti" --arg value "$type_mode" '$base + {subagent_type:$value}')
-  fi
+  case "$type_mode" in
+    omit) ;;
+    null) ti=$(jq -cn --argjson base "$ti" '$base + {subagent_type:null}') ;;
+    *) ti=$(jq -cn --argjson base "$ti" --arg value "$type_mode" '$base + {subagent_type:$value}') ;;
+  esac
   case "$model_mode" in
     null) ti=$(jq -cn --argjson base "$ti" '$base + {model:null}') ;;
     string) ti=$(jq -cn --argjson base "$ti" --arg value "$model_value" '$base + {model:$value}') ;;
@@ -820,7 +848,7 @@ run_ownership_script() {
   OWNERSHIP_EXIT=0
 
   local stderr_file
-  stderr_file=$(mktemp)
+  stderr_file=$(mktemp "$TEST_TEMP_DIR/stderr.XXXXXX") || return 1
   if [[ "${1:-}" != "" ]]; then
     OWNERSHIP_STDOUT=$(printf '%s' "$payload" | env -u ALLOW_AGENT_MODEL_INHERIT "$@" bash "$script" 2>"$stderr_file") || OWNERSHIP_EXIT=$?
   else
@@ -838,7 +866,7 @@ run_ownership_guard_no_jq() {
   OWNERSHIP_EXIT=0
 
   local stderr_file
-  stderr_file=$(mktemp)
+  stderr_file=$(mktemp "$TEST_TEMP_DIR/stderr.XXXXXX") || return 1
   OWNERSHIP_STDOUT=$(printf '%s' "$payload" | env -i PATH="$no_jq_dir" bash "$OWNERSHIP_GUARD_SCRIPT" 2>"$stderr_file") || OWNERSHIP_EXIT=$?
   OWNERSHIP_STDERR=$(cat "$stderr_file")
   rm -f "$stderr_file"

--- a/plugins/plan-review/.claude-plugin/plugin.json
+++ b/plugins/plan-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-review",
   "description": "Adversarial plan review via cross-model consultation (agy/Claude/Codex)",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": {
     "name": "woodragon"
   }

--- a/plugins/plan-review/README.md
+++ b/plugins/plan-review/README.md
@@ -127,9 +127,11 @@ is written, separate from `plan-review.log`.
 
 ### Dispatch Manifest v2
 
-When an approved plan has a Dispatch Manifest, `plan-review.sh` stores only its
-v2 signature set. The fixed columns are `step | location | subagent_type |
-model_source | model | depends_on | parallel_with`.
+A plan with dispatch keywords must include a Dispatch Manifest with at least one
+`agent` row. A plan without dispatch keywords, including Tier0 work, remains
+Manifest-free. `plan-review.sh` stores only the approved v2 signature set. The
+fixed columns are `step | location | subagent_type | model_source | model |
+depends_on | parallel_with`.
 
 - `main` rows use `-` for `subagent_type`, `model_source`, and `model`.
 - `agent` + `preset` rows require `subagent_type` and require the tool call to

--- a/plugins/plan-review/README.md
+++ b/plugins/plan-review/README.md
@@ -50,11 +50,11 @@ scripts/
                                truth on version identifiers, Review Discipline, Finding Quality
                                Gate, Severity Definitions, Verdict Rules, Output Format). Does not
                                assume the artifact under review is a plan.
-    review-plan.md            Plan-specific layer (framing, Scope Boundary, the 9 Review
+    review-plan.md            Plan-specific layer (framing, Scope Boundary, the 8 Review
                                Criteria, output length cap). Concatenated ahead of
                                review-common.md when plan-review.sh assembles the hook's system
                                prompt — this is the only consumer that concatenates the two.
-  dispatch-check.sh           Layer 2 hook — Agent/Task dispatch-parameter enforcement
+  dispatch-check.sh           Layer 2 hook — Manifest v2 Agent/Task signature-set enforcement
   precompact-review.sh        PreCompact hook — plan recovery across compaction
 ```
 
@@ -123,7 +123,25 @@ is written, separate from `plan-review.log`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DISPATCH_CHECK_DISABLED` | `0` | Set `1` to disable the Layer 2 dispatch-parameter check (kill switch) |
+| `DISPATCH_CHECK_DISABLED` | `0` | Set `1` to disable the Layer 2 Manifest v2 signature check (kill switch) |
+
+### Dispatch Manifest v2
+
+When an approved plan has a Dispatch Manifest, `plan-review.sh` stores only its
+v2 signature set. The fixed columns are `step | location | subagent_type |
+model_source | model | depends_on | parallel_with`.
+
+- `main` rows use `-` for `subagent_type`, `model_source`, and `model`.
+- `agent` + `preset` rows require `subagent_type` and require the tool call to
+  omit `model`.
+- `agent` + `runtime` rows require both `subagent_type` and `model`; the hook
+  matches both values exactly.
+
+The hook permits repeated matching calls. It does not implement a step cursor,
+call count, execution order, or global model ownership policy. State with no
+schema marker is treated as temporary Manifest v1 compatibility state: the hook
+emits a migration prompt and skips enforcement. Corrupt, stale, or invalid state
+fails open.
 
 ## Consultation Flow
 
@@ -141,13 +159,13 @@ on that second call permits execution.
 
 ## Review Criteria
 
-Nine criteria — authoritative text is split across two files (see [Architecture](#architecture)):
+Eight criteria — authoritative text is split across two files (see [Architecture](#architecture)):
 
 - `scripts/assets/review-common.md` — the generic layer: version-identifier ground truth, Review
   Discipline, Finding Quality Gate, Severity Definitions, Verdict Rules, Output Format. Shared by
   every caller of the engine infrastructure, including `second-opinion.sh`; it never assumes the
   reviewed artifact is a plan.
-- `scripts/assets/review-plan.md` — the plan-specific layer: framing, Scope Boundary, the 9
+- `scripts/assets/review-plan.md` — the plan-specific layer: framing, Scope Boundary, the 8
   criteria below, and the output length cap. Only `plan-review.sh` uses this file, concatenating
   it ahead of `review-common.md` when assembling the hook's system prompt.
 
@@ -159,9 +177,8 @@ Nine criteria — authoritative text is split across two files (see [Architectur
 | 4 | **Safety** | Security risks, data loss, backwards-compatibility breaks? |
 | 5 | **Testability** | Test strategy presence; test pyramid completeness; e2e selector cascade (evidence-gated); deletion completeness for exported symbols |
 | 6 | **Architecture fit** | Consistent with project patterns? |
-| 7 | **Execution topology** | Each step annotated with execution location and scheduling order? |
+| 7 | **Dispatch Economy** | Main decision work, preset registered agents, runtime built-ins, and mechanical work delegation rules |
 | 8 | **Reuse over reinvention** | Using existing dependencies before building custom? |
-| 9 | **Dispatch Manifest** | Agent/Task steps declare `agent_type`, `model`, `depends_on`, `parallel_with`? |
 
 Criterion #5 (Testability) is evidence-gated: e2e selector audits only trigger if the plan or project context reveals e2e coverage (Playwright, Cypress, `*.spec.ts`, `e2e/` directory).
 

--- a/plugins/plan-review/scripts/assets/review-plan.md
+++ b/plugins/plan-review/scripts/assets/review-plan.md
@@ -53,7 +53,9 @@ Keep your response under 3000 characters.
      model_source | model | depends_on | parallel_with`. Main rows use `-` for
      subagent_type, model_source, and model; preset rows omit model; runtime
      rows require it. Missing manifest when dispatch keywords are present is
-     [Major]; a structurally invalid manifest is [Critical].
+     [Major]; a structurally invalid manifest is [Critical]. A dispatch
+     Manifest with no `agent` row is full hoarding [Critical]. A Manifest that
+     retains some delegable work in Main is partial hoarding [Major].
    - Do not require every implementation step to be Sonnet, and do not require
      every Agent row to copy a concrete model. The plan-review plugin validates
      only the approved manifest signature set; global model ownership is outside

--- a/plugins/plan-review/scripts/assets/review-plan.md
+++ b/plugins/plan-review/scripts/assets/review-plan.md
@@ -38,46 +38,24 @@ Keep your response under 3000 characters.
      local/internal symbols, or provably dead code with no external consumers (grep
      evidence in the plan).
 6. **Architecture fit** — Consistent with project patterns?
-7. **Dispatch Economy** — Work nature determines who executes, to protect the
-   main context's lifespan and minimize token cost. Classify each step by its
-   NATURE (not by a fuzzy complexity estimate), then check the assigned tier:
-   - **Decision work** (architecture, root-cause debugging, requirements
-     breakdown, plan authoring, review judgment) → tier `opus` → runs in main
-     context (manifest model/agent_type = `-`).
-   - **Implementation work** (writing code, editing files, producing content)
-     → tier `sonnet` → MUST be delegated to a typed agent.
-   - **Retrieval work** (read-only exploration, search, data extraction with
-     zero reasoning) → tier `haiku` → MUST be delegated to a typed agent.
-   The default is to delegate: only decision steps legitimately stay in main
-   context. The single whole-plan exemption is **Tier 0** — ALL of: single
-   file, no new dependency, no API-contract / DB-schema change, no cross-file
-   coordination, not an ops task. A Tier-0 plan needs no manifest at all. Do
-   NOT count lines of code to judge Tier 0 — the moment a plan touches multiple
-   files, adds a dependency, or changes an interface, it is not Tier 0 and its
-   implementation steps must be delegated, regardless of how few lines they are.
-   Even a Tier-0 plan, if its text contains dispatch keywords (Task(,
-   subagent_type, worker agent, etc.), must still obey the underlying syntax
-   gate: either remove the keywords or supply a full manifest — otherwise a
-   static check will hard-block it (avoid the split-brain where the reviewer
-   approves but the script rejects).
-   - **Severity calibration** (do not weaken the existing rule):
-     - **Full hoarding** — a non-Tier-0 plan whose manifest leaves ALL
-       implementation/retrieval steps on `-` (main session swallowing every
-       offloadable task) → [Critical] → REJECT. This preserves the existing
-       contract: an all-dash manifest on a complex plan is a Critical blocker.
-     - **Partial hoarding** — individual implementation steps kept in main,
-       a sonnet-grade task kept in main, OR main context (opus) hoarding
-       retrieval/extraction work → [Major] → CONCERNS. Opus hoarding retrieval
-       (haiku-grade, zero-reasoning, high-token work) pollutes the main window
-       worse than hoarding code-writing, so it must force CONCERNS, never Minor.
-     - **Pure mis-tiering / fragmentation** — a sonnet-grade task already inside
-       an agent, or implementation steps sharing one file set split across
-       multiple agents that each reload the same context → [Minor].
-   - Manifest format: Agent steps require both agent_type + model. The model
-     column holds a tier name — `opus` / `sonnet` / `haiku` — and these ARE
-     the canonical values in the target environment (Scope Boundary applies):
-     never demand versioned model identifiers in their place. Main-context
-     steps use `-`. Missing manifest when dispatch keywords are present =
-     [Major]. Agent step missing model = [Critical]. This tier list matches
-     the target environment's own manifest generator; do not diverge from it.
+7. **Dispatch Economy** — Work nature determines who executes, protecting the
+   main context without inventing global model ownership rules.
+   - **Decision and review judgment** (architecture, root-cause debugging,
+     requirements breakdown, plan authoring, review acceptance) stay in Main.
+   - A **registered agent** uses `model_source = preset`: declare its
+     `subagent_type`, but do not copy a concrete model into the plan.
+   - A built-in agent that needs a selected runtime tier uses
+     `model_source = runtime`: declare both `subagent_type` and `model`.
+   - Mechanical, already-specified implementation may use `dev-econ` or
+     `worker-econ`. Use `dev` or `worker` only when the next step has an
+     unresolved trade-off.
+   - Manifest v2 columns are exactly: `step | location | subagent_type |
+     model_source | model | depends_on | parallel_with`. Main rows use `-` for
+     subagent_type, model_source, and model; preset rows omit model; runtime
+     rows require it. Missing manifest when dispatch keywords are present is
+     [Major]; a structurally invalid manifest is [Critical].
+   - Do not require every implementation step to be Sonnet, and do not require
+     every Agent row to copy a concrete model. The plan-review plugin validates
+     only the approved manifest signature set; global model ownership is outside
+     this criterion.
 8. **Reuse over reinvention** — Does the plan propose building something that already exists in the project dependencies, framework, or standard library? Custom implementations require explicit justification (e.g., "framework X lacks feature Y" with concrete evidence). Without strong justification, prefer existing solutions. This is a [Major] issue.

--- a/plugins/plan-review/scripts/dispatch-check.sh
+++ b/plugins/plan-review/scripts/dispatch-check.sh
@@ -29,7 +29,10 @@ SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null || tru
 
 DISPATCH_DIR="${REVIEW_COUNTER_DIR:-/tmp/claude-reviews}"
 DISPATCH_FILE="$DISPATCH_DIR/.dispatch-${SESSION_ID}.json"
-find "$DISPATCH_DIR" -maxdepth 1 -name '.dispatch-*.json' -mmin +30 -delete 2>/dev/null || true
+# Layer 2 owns its own stale-state cleanup too: it can run without a fresh
+# plan-review invocation. Match both published files and the writer's
+# `.dispatch-<session>.json.XXXXXX` temporary files.
+find "$DISPATCH_DIR" -maxdepth 1 -name '.dispatch-*.json*' -mmin +30 -delete 2>/dev/null || true
 [ -f "$DISPATCH_FILE" ] || exit 0
 
 file_mtime=$(stat -f %m "$DISPATCH_FILE" 2>/dev/null || stat -c %Y "$DISPATCH_FILE" 2>/dev/null || echo 0)
@@ -44,9 +47,7 @@ fi
 if jq -e '.requires_dispatch_check == true and (has("schema_version") | not)' "$DISPATCH_FILE" >/dev/null 2>&1; then
   migration_message="dispatch-check: Manifest v1 state detected. Matching is skipped for this temporary state; re-run plan review to create schema_version: 2 before relying on dispatch enforcement."
   migration_json=$(printf '%s' "$migration_message" | jq -Rs .)
-  cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":${migration_json}},"systemMessage":${migration_json}}
-EOF
+  printf '{"systemMessage":%s}\n' "$migration_json"
   exit 0
 fi
 
@@ -87,17 +88,27 @@ fi
 
 MANIFEST_PREVIEW=$(jq -r '
   .allowed_signatures |
-  map(if .model_source == "preset"
-      then "  - preset: subagent_type=" + .subagent_type + ", model omitted"
-      else "  - runtime: subagent_type=" + .subagent_type + ", model=" + .model
-      end) |
-  join("\n")
+  if length == 0 then ""
+  else map(if .model_source == "preset"
+           then "  - preset: subagent_type=" + .subagent_type + ", model omitted"
+           else "  - runtime: subagent_type=" + .subagent_type + ", model=" + .model
+           end) |
+       join("\n")
+  end
 ' "$DISPATCH_FILE" 2>/dev/null || echo "  (manifest parse failed)")
 
-MSG="dispatch-check: Agent/Task call does not match an approved Manifest v2 signature.${preset_model_hint}
+if [ -n "$MANIFEST_PREVIEW" ]; then
+  DECLARED_SIGNATURES="
 
 Declared signatures:
-${MANIFEST_PREVIEW}
+${MANIFEST_PREVIEW}"
+else
+  DECLARED_SIGNATURES="
+
+This approved Manifest contains no agent signatures."
+fi
+
+MSG="dispatch-check: Agent/Task call does not match an approved Manifest v2 signature.${preset_model_hint}${DECLARED_SIGNATURES}
 
 Preset calls must omit model; runtime calls must provide the exact model. To disable this guard, set DISPATCH_CHECK_DISABLED=1."
 DENY_JSON=$(printf '%s' "$MSG" | jq -Rs .)

--- a/plugins/plan-review/scripts/dispatch-check.sh
+++ b/plugins/plan-review/scripts/dispatch-check.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-# PreToolUse:Agent/Task hook — Layer 2 dispatch enforcement.
+# PreToolUse:Agent/Task hook — Manifest v2 signature-set enforcement.
 #
-# Reads dispatch JSON written by plan-review.sh APPROVE path; if present,
-# requires Agent tool call to provide both subagent_type and model.
-# Fail-open on ALL anomalies: jq missing, JSON corrupt, session absent, stale file, etc.
+# A valid v2 state written by plan-review.sh declares permitted dispatch
+# signatures. Preset signatures require the model field to be omitted; runtime
+# signatures require exact type/model values. This hook intentionally tracks no
+# step cursor, invocation count, execution order, or global model ownership.
+# Fail open on missing, corrupt, stale, or structurally invalid state.
 #
 # Environment variables:
 #   DISPATCH_CHECK_DISABLED=1  — kill switch, bypass entirely
@@ -12,30 +14,24 @@ set -euo pipefail
 
 INPUT=$(cat)
 
-# Kill switch (highest priority)
 [ "${DISPATCH_CHECK_DISABLED:-0}" != "1" ] || exit 0
-
-# jq required for JSON parsing
 command -v jq >/dev/null 2>&1 || exit 0
+MANIFEST_LIB="$(dirname "$0")/lib/manifest.sh"
+[ -s "$MANIFEST_LIB" ] || exit 0
+if ! . "$MANIFEST_LIB"; then
+  exit 0
+fi
 
-# Extract tool_name and session_id — fail-open on parse errors
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || true)
 SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null || true)
-
-# Only intercept Agent and Task tool calls (belt-and-suspenders with hook matcher)
 [ "$TOOL_NAME" = "Agent" ] || [ "$TOOL_NAME" = "Task" ] || exit 0
 [ -n "$SESSION_ID" ] || exit 0
 
 DISPATCH_DIR="${REVIEW_COUNTER_DIR:-/tmp/claude-reviews}"
 DISPATCH_FILE="$DISPATCH_DIR/.dispatch-${SESSION_ID}.json"
-
-# Opportunistic global cleanup: remove stale dispatch files from all sessions
 find "$DISPATCH_DIR" -maxdepth 1 -name '.dispatch-*.json' -mmin +30 -delete 2>/dev/null || true
-
-# No dispatch file → no active plan constraint → allow
 [ -f "$DISPATCH_FILE" ] || exit 0
 
-# Stale check (>30min) — dispatch from a previous session leaked through
 file_mtime=$(stat -f %m "$DISPATCH_FILE" 2>/dev/null || stat -c %Y "$DISPATCH_FILE" 2>/dev/null || echo 0)
 now=$(date +%s)
 if (( now - file_mtime > 1800 )); then
@@ -43,46 +39,67 @@ if (( now - file_mtime > 1800 )); then
   exit 0
 fi
 
-# JSON sanity check — corrupt dispatch file → fail-open
-jq -e '.requires_dispatch_check == true' "$DISPATCH_FILE" >/dev/null 2>&1 || exit 0
-
-# Check that Agent call has both non-empty model AND subagent_type
-has_model="no"
-has_type="no"
-if printf '%s' "$INPUT" | jq -e \
-    '.tool_input.model and (.tool_input.model | type == "string") and (.tool_input.model | length > 0)' \
-    >/dev/null 2>&1; then
-  has_model="yes"
-fi
-if printf '%s' "$INPUT" | jq -e \
-    '.tool_input.subagent_type and (.tool_input.subagent_type | type == "string") and (.tool_input.subagent_type | length > 0)' \
-    >/dev/null 2>&1; then
-  has_type="yes"
-fi
-
-# Both present → silent allow
-if [ "$has_model" = "yes" ] && [ "$has_type" = "yes" ]; then
+# A state from pre-v2 plan-review has no schema marker. Preserve compatibility
+# for its short TTL but visibly ask the caller to regenerate the approval.
+if jq -e '.requires_dispatch_check == true and (has("schema_version") | not)' "$DISPATCH_FILE" >/dev/null 2>&1; then
+  migration_message="dispatch-check: Manifest v1 state detected. Matching is skipped for this temporary state; re-run plan review to create schema_version: 2 before relying on dispatch enforcement."
+  migration_json=$(printf '%s' "$migration_message" | jq -Rs .)
+  cat <<EOF
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":${migration_json}},"systemMessage":${migration_json}}
+EOF
   exit 0
 fi
 
-# Compose deny with manifest preview
-MANIFEST_PREVIEW=$(jq -r \
-  '.steps | map("  - step " + .id + ": agent_type=" + (.agent_type // "-") + ", model=" + (.model // "-")) | join("\n")' \
-  "$DISPATCH_FILE" 2>/dev/null || echo "  (manifest parse failed)")
+# Only a complete, currently supported state can constrain tool calls. The
+# shared predicate also proves allowed_signatures are derived from steps; it
+# has no catalog scan, frontmatter snapshot, or plugin-list lookup.
+dispatch_state_is_valid_v2 "$DISPATCH_FILE" || exit 0
 
-missing=""
-[ "$has_type" = "yes" ] || missing="${missing}subagent_type "
-[ "$has_model" = "yes" ] || missing="${missing}model"
+CALL_TYPE=$(printf '%s' "$INPUT" | jq -r '.tool_input.subagent_type // ""' 2>/dev/null || true)
+MODEL_PRESENT="no"
+if printf '%s' "$INPUT" | jq -e '.tool_input | has("model")' >/dev/null 2>&1; then
+  MODEL_PRESENT="yes"
+fi
+CALL_MODEL=$(printf '%s' "$INPUT" | jq -r '.tool_input.model // ""' 2>/dev/null || true)
 
-MSG="dispatch-check: Agent 调用必须显式传 subagent_type 和 model（plan 已声明 Dispatch Manifest，承诺被强制执行）。
+# Preset means exact type plus an absent model key, not merely an empty model.
+if [ "$MODEL_PRESENT" = "no" ] && jq -e --arg type "$CALL_TYPE" \
+    'any(.allowed_signatures[]; .model_source == "preset" and .subagent_type == $type)' \
+    "$DISPATCH_FILE" >/dev/null 2>&1; then
+  exit 0
+fi
 
-当前调用缺失：${missing}
+# Runtime means exact type and a nonempty exact model string.
+if [ "$MODEL_PRESENT" = "yes" ] && [ -n "$CALL_MODEL" ] && jq -e \
+    --arg type "$CALL_TYPE" --arg model "$CALL_MODEL" \
+    'any(.allowed_signatures[]; .model_source == "runtime" and .subagent_type == $type and .model == $model)' \
+    "$DISPATCH_FILE" >/dev/null 2>&1; then
+  exit 0
+fi
 
-请查阅 Manifest 取值：
+# Explain the common preset error without weakening exact signature matching.
+preset_model_hint=""
+if [ "$MODEL_PRESENT" = "yes" ] && jq -e --arg type "$CALL_TYPE" \
+    'any(.allowed_signatures[]; .model_source == "preset" and .subagent_type == $type)' \
+    "$DISPATCH_FILE" >/dev/null 2>&1; then
+  preset_model_hint=" The declared preset signature requires you to omit model entirely."
+fi
+
+MANIFEST_PREVIEW=$(jq -r '
+  .allowed_signatures |
+  map(if .model_source == "preset"
+      then "  - preset: subagent_type=" + .subagent_type + ", model omitted"
+      else "  - runtime: subagent_type=" + .subagent_type + ", model=" + .model
+      end) |
+  join("\n")
+' "$DISPATCH_FILE" 2>/dev/null || echo "  (manifest parse failed)")
+
+MSG="dispatch-check: Agent/Task call does not match an approved Manifest v2 signature.${preset_model_hint}
+
+Declared signatures:
 ${MANIFEST_PREVIEW}
 
-如需关闭强制检查，设置 DISPATCH_CHECK_DISABLED=1。"
-
+Preset calls must omit model; runtime calls must provide the exact model. To disable this guard, set DISPATCH_CHECK_DISABLED=1."
 DENY_JSON=$(printf '%s' "$MSG" | jq -Rs .)
 cat <<EOF
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":${DENY_JSON}}}

--- a/plugins/plan-review/scripts/lib/manifest.sh
+++ b/plugins/plan-review/scripts/lib/manifest.sh
@@ -5,6 +5,35 @@
 
 needs_manifest() { printf '%s' "$1" | grep -qiE '(Task\(|subagent_type|agent_type|Plan agent|Explore agent|worker agent|dev agent)'; }
 has_manifest() { printf '%s' "$1" | grep -qi '^## Dispatch Manifest'; }
+# manifest_table_rows <plan>
+# Emits only table rows in the Dispatch Manifest section. A single terminal CR
+# is normalized as line ending syntax; after the table starts, a blank line is
+# a hard boundary so later prose/tables cannot affect validation or dispatch.
+manifest_table_rows() {
+  printf '%s\n' "$1" | awk '
+    tolower($0) ~ /^## dispatch manifest/ { in_manifest=1; next }
+    !in_manifest { next }
+    /^## / { exit }
+    {
+      line=$0
+      sub(/\r$/, "", line)
+    }
+    table_started && line ~ /^[[:space:]]*$/ { exit }
+    line ~ /^[[:space:]]*\|/ { table_started=1; print line }
+  '
+}
+
+manifest_has_agent_signature() {
+  manifest_table_rows "$1" | awk '
+    {
+      line=$0
+      sub(/^[[:space:]]*\|[[:space:]]*/, "", line)
+      split(line, fields, /[[:space:]]*\|[[:space:]]*/)
+      if (tolower(fields[2]) ~ /^[[:space:]]*agent[[:space:]]*$/) found=1
+    }
+    END { exit !found }
+  '
+}
 
 # Manifest v2 is intentionally explicit about dispatch ownership:
 # - main rows describe work retained in the main context;
@@ -33,13 +62,11 @@ MANIFEST_EOF
 # stores a human-readable structural reason in MANIFEST_ERROR for pre-flight.
 validate_manifest_v2() {
   local plan="$1"
-  MANIFEST_ERROR=$(printf '%s\n' "$plan" | awk '
+  MANIFEST_ERROR=$(manifest_table_rows "$plan" | awk '
     function trim(value) { sub(/^[[:space:]]+/, "", value); sub(/[[:space:]]+$/, "", value); return value }
     function fail(message) { print message; failed=1; exit 1 }
     BEGIN { expected[1]="step"; expected[2]="location"; expected[3]="subagent_type"; expected[4]="model_source"; expected[5]="model"; expected[6]="depends_on"; expected[7]="parallel_with" }
-    tolower($0) ~ /^## dispatch manifest/ { in_manifest=1; next }
-    in_manifest && /^## / { in_manifest=0 }
-    in_manifest && /^[[:space:]]*\|/ {
+    {
       # The serializer uses tab-delimited records internally. Reject control
       # separators before extraction so a cell cannot alter that framing.
       if (header_seen && (index($0, "\t") || index($0, "\r"))) fail("data cells must not contain tab or carriage-return")
@@ -74,7 +101,6 @@ validate_manifest_v2() {
       data_seen=1
       next
     }
-    in_manifest && data_seen && /^[[:space:]]*$/ { in_manifest=0 }
     END {
       if (!failed && !header_seen) { print "missing v2 table header"; exit 1 }
       if (!failed && !separator_seen) { print "missing table separator"; exit 1 }
@@ -90,11 +116,9 @@ validate_manifest_v2() {
 parse_manifest_to_json() {
   local plan="$1" hash="$2"
   validate_manifest_v2 "$plan" || return 1
-  printf '%s\n' "$plan" | awk '
+  manifest_table_rows "$plan" | awk '
     function trim(value) { sub(/^[[:space:]]+/, "", value); sub(/[[:space:]]+$/, "", value); return value }
-    tolower($0) ~ /^## dispatch manifest/ { in_manifest=1; next }
-    in_manifest && /^## / { in_manifest=0 }
-    in_manifest && /^[[:space:]]*\|/ {
+    {
       line=$0; sub(/^[[:space:]]*\|[[:space:]]*/, "", line); sub(/[[:space:]]*\|[[:space:]]*$/, "", line)
       count=split(line, fields, /[[:space:]]*\|[[:space:]]*/)
       for (i=1; i<=count; i++) fields[i]=trim(fields[i])

--- a/plugins/plan-review/scripts/lib/manifest.sh
+++ b/plugins/plan-review/scripts/lib/manifest.sh
@@ -1,82 +1,188 @@
-# lib/manifest.sh — Dispatch Manifest detection + parsing primitives.
-# Sourced (not executed) by plan-review.sh. The two pre-flight `if` guards
-# (missing-manifest / degenerate-manifest deny branches) stay in the caller —
-# this file only supplies the functions/variable those guards call.
-#
+# lib/manifest.sh — Dispatch Manifest v2 detection, validation, and serialization.
+# Sourced by plan-review.sh. This file validates only manifest structure; it
+# deliberately has no dynamic agent catalog or model ownership policy.
 # bash 3.2 compatible: no associative arrays, no ${var^^}, no &>>.
 
-# --- Manifest detection helpers (case-insensitive: LLM may write "Worker Agent"/"TASK(") ---
 needs_manifest() { printf '%s' "$1" | grep -qiE '(Task\(|subagent_type|agent_type|Plan agent|Explore agent|worker agent|dev agent)'; }
-has_manifest()   { printf '%s' "$1" | grep -qi '^## Dispatch Manifest'; }
+has_manifest() { printf '%s' "$1" | grep -qi '^## Dispatch Manifest'; }
 
-# Returns 0 if at least one manifest data row has a non-dash agent_type.
-manifest_has_real_agent() {
-  printf '%s\n' "$1" | awk '
-    /^## Dispatch Manifest/ {in_m=1; seen_table=0; next}
-    in_m && /^## / {in_m=0}
-    in_m && /^ *\|/ {seen_table=1}
-    in_m && seen_table && /^ *$/ {in_m=0}
-    in_m && /^\|/ && !/^\|---/ && !/^\| *[Ss][Tt][Ee][Pp]/ {
-      gsub(/^\| *| *\| *$/, ""); n = split($0, f, / *\| */)
-      if (n >= 2) { at=f[2]; gsub(/^ +| +$|"/, "", at); if (at != "-" && at != "") found=1 }
-    }
-    END { exit (found ? 0 : 1) }
-  '
-}
-
-# --- Canonical manifest example (single source of truth for both deny messages) ---
-# Single-quoted heredoc: backticks, $ and <placeholders> stay literal (no command
-# substitution, no expansion). Embedded verbatim into deny reasons so a blocked LLM
-# sees the exact format inline instead of guessing column names from CLAUDE.md.
-# Agent-row values are <placeholders>, not a copy-pastable real step, so the LLM
-# can't paste the example wholesale and inject a phantom dispatch step.
+# Manifest v2 is intentionally explicit about dispatch ownership:
+# - main rows describe work retained in the main context;
+# - agent/preset rows name a registered agent and must omit model;
+# - agent/runtime rows name both the agent and exact runtime model.
 MANIFEST_EXAMPLE=$(cat <<'MANIFEST_EOF'
 格式示例（占位值 <...> 替换为你 plan 的真实步骤，勿原样复制本表）：
 
 ## Dispatch Manifest
-| step | agent_type    | model   | depends_on | parallel_with |
-|------|---------------|---------|------------|---------------|
-| 1    | -             | -       | -          | -             |
-| 2    | <agent_type>  | <model> | 1          | -             |
+| step | location | subagent_type | model_source | model | depends_on | parallel_with |
+|------|----------|---------------|--------------|-------|------------|---------------|
+| 1    | main     | -             | -            | -     | -          | -             |
+| 2    | agent    | <agent_type>  | preset       | -     | 1          | -             |
+| 3    | agent    | <agent_type>  | runtime      | <model> | 1        | 2             |
 
 填写规则：
-- 主上下文执行的 step：agent_type 与 model 两列均填 `-`。
-- 委派给 Agent 的 step：两列必填，model 用全名（sonnet / opus / haiku）。
+- `main` 行：subagent_type、model_source、model 均填 `-`。
+- `agent` + `preset` 行：subagent_type 必填，model 必须填 `-`（调用时完全省略 model）。
+- `agent` + `runtime` 行：subagent_type 与 model 必填（调用时二者精确匹配）。
 - depends_on / parallel_with：填依赖/并行的 step 号，无则填 `-`。
 MANIFEST_EOF
 )
-# NOTE: the "sonnet / opus / haiku" tier enumeration above must stay in sync
-# with assets/review-system-prompt.md's "Manifest format" bullet (Criterion 7,
-# Dispatch Economy) — dispatch-check.sh:49-55 only checks the model column is
-# non-empty, it does not validate against a value list, so this comment pair
-# is the only thing preventing the two prose copies from drifting apart.
 
-# --- Manifest JSON serializer (called only from APPROVE branch; failures are silent) ---
-# Parses the ## Dispatch Manifest markdown table and outputs a dispatch JSON blob.
-# JSON injection defense: strips stray double-quotes LLM may write in manifest rows.
+# validate_manifest_v2 <plan>
+# Returns zero only for the v2 table shape and row semantics. On failure it
+# stores a human-readable structural reason in MANIFEST_ERROR for pre-flight.
+validate_manifest_v2() {
+  local plan="$1"
+  MANIFEST_ERROR=$(printf '%s\n' "$plan" | awk '
+    function trim(value) { sub(/^[[:space:]]+/, "", value); sub(/[[:space:]]+$/, "", value); return value }
+    function fail(message) { print message; failed=1; exit 1 }
+    BEGIN { expected[1]="step"; expected[2]="location"; expected[3]="subagent_type"; expected[4]="model_source"; expected[5]="model"; expected[6]="depends_on"; expected[7]="parallel_with" }
+    tolower($0) ~ /^## dispatch manifest/ { in_manifest=1; next }
+    in_manifest && /^## / { in_manifest=0 }
+    in_manifest && /^[[:space:]]*\|/ {
+      # The serializer uses tab-delimited records internally. Reject control
+      # separators before extraction so a cell cannot alter that framing.
+      if (header_seen && (index($0, "\t") || index($0, "\r"))) fail("data cells must not contain tab or carriage-return")
+      line=$0; sub(/^[[:space:]]*\|[[:space:]]*/, "", line); sub(/[[:space:]]*\|[[:space:]]*$/, "", line)
+      count=split(line, fields, /[[:space:]]*\|[[:space:]]*/)
+      for (i=1; i<=count; i++) fields[i]=trim(fields[i])
+      if (!header_seen) {
+        if (count != 7) fail("header must have seven v2 columns")
+        for (i=1; i<=7; i++) if (fields[i] != expected[i]) fail("header must be: step | location | subagent_type | model_source | model | depends_on | parallel_with")
+        header_seen=1
+        next
+      }
+      if (fields[1] ~ /^-+$/) { separator_seen=1; next }
+      if (count != 7) fail("every row must have seven columns")
+      step=fields[1]; location=fields[2]; agent_type=fields[3]; model_source=fields[4]; model=fields[5]
+      if (step == "" || step == "-") fail("step is required")
+      if (location == "main") {
+        if (agent_type != "-" || model_source != "-" || model != "-") fail("main rows require subagent_type, model_source, and model to be -")
+      } else if (location == "agent") {
+        if (agent_type == "" || agent_type == "-") fail("agent rows require subagent_type")
+        if (model_source == "preset") {
+          if (model != "-") fail("preset rows require model to be -")
+        } else if (model_source == "runtime") {
+          if (model == "" || model == "-") fail("runtime rows require model")
+        } else {
+          fail("agent rows require model_source preset or runtime")
+        }
+      } else {
+        fail("location must be main or agent")
+      }
+      row_count++
+      data_seen=1
+      next
+    }
+    in_manifest && data_seen && /^[[:space:]]*$/ { in_manifest=0 }
+    END {
+      if (!failed && !header_seen) { print "missing v2 table header"; exit 1 }
+      if (!failed && !separator_seen) { print "missing table separator"; exit 1 }
+      if (!failed && row_count == 0) { print "manifest has no data rows"; exit 1 }
+    }
+  ')
+}
+
+# parse_manifest_to_json <plan> <hash>
+# The validator has already checked the table and rejected TSV framing controls.
+# awk only extracts tab-delimited records; jq is the sole JSON serializer, so
+# quotes and backslashes are escaped instead of being stripped or spliced.
 parse_manifest_to_json() {
   local plan="$1" hash="$2"
-  printf '%s\n' "$plan" | awk -v hash="$hash" -v now="$(date +%s)" '
-    /^## Dispatch Manifest/ {in_manifest=1; seen_table=0; next}
-    in_manifest && /^## / {in_manifest=0}
-    in_manifest && /^ *\|/ {seen_table=1}
-    in_manifest && seen_table && /^ *$/ {in_manifest=0}
-    in_manifest && /^\|/ && !/^\|---/ && !/^\| *[Ss][Tt][Ee][Pp]/ {
-      gsub(/^\| *| *\| *$/, ""); n = split($0, f, / *\| */)
-      if (n >= 3) {
-        id=f[1]; at=f[2]; md=f[3]
-        gsub(/^ +| +$/, "", id); gsub(/^ +| +$/, "", at); gsub(/^ +| +$/, "", md)
-        gsub(/"/, "", id); gsub(/"/, "", at); gsub(/"/, "", md)
-        rows[++count] = sprintf("{\"id\":\"%s\",\"agent_type\":%s,\"model\":%s}",
-          id,
-          (at == "-" ? "null" : "\"" at "\""),
-          (md == "-" ? "null" : "\"" md "\""))
-      }
+  validate_manifest_v2 "$plan" || return 1
+  printf '%s\n' "$plan" | awk '
+    function trim(value) { sub(/^[[:space:]]+/, "", value); sub(/[[:space:]]+$/, "", value); return value }
+    tolower($0) ~ /^## dispatch manifest/ { in_manifest=1; next }
+    in_manifest && /^## / { in_manifest=0 }
+    in_manifest && /^[[:space:]]*\|/ {
+      line=$0; sub(/^[[:space:]]*\|[[:space:]]*/, "", line); sub(/[[:space:]]*\|[[:space:]]*$/, "", line)
+      count=split(line, fields, /[[:space:]]*\|[[:space:]]*/)
+      for (i=1; i<=count; i++) fields[i]=trim(fields[i])
+      if (!header_seen) { header_seen=1; next }
+      if (fields[1] ~ /^-+$/ || count != 7) next
+      printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", fields[1], fields[2], fields[3], fields[4], fields[5], fields[6], fields[7]
     }
-    END {
-      printf "{\"plan_hash\":\"%s\",\"created_at\":%s,\"requires_dispatch_check\":true,\"steps\":[", hash, now
-      for (i=1; i<=count; i++) printf "%s%s", (i>1?",":""), rows[i]
-      printf "]}\n"
+  ' | jq -Rn --arg hash "$hash" --argjson created_at "$(date +%s)" '
+    def null_if_dash: if . == "-" then null else . end;
+    [inputs | split("\t") | {
+      id: .[0],
+      location: .[1],
+      subagent_type: (.[2] | null_if_dash),
+      model_source: (.[3] | null_if_dash),
+      model: (.[4] | null_if_dash),
+      depends_on: (.[5] | null_if_dash),
+      parallel_with: (.[6] | null_if_dash)
+    }] as $steps |
+    {
+      schema_version: 2,
+      plan_hash: $hash,
+      created_at: $created_at,
+      requires_dispatch_check: true,
+      steps: $steps,
+      allowed_signatures: (
+        reduce ($steps[] | select(.location == "agent") |
+          if .model_source == "preset" then
+            {subagent_type, model_source}
+          else
+            {subagent_type, model_source, model}
+          end
+        ) as $signature
+        ([]; if index($signature) == null then . + [$signature] else . end)
+      )
     }
   '
+}
+
+# dispatch_state_is_valid_v2 <state-file>
+# The state writer and dispatch hook share this predicate. It accepts only a
+# complete v2 payload whose signature set is exactly derived from its steps.
+dispatch_state_is_valid_v2() {
+  local state_file="$1"
+  jq -e '
+    def nonempty_string: type == "string" and length > 0;
+    def nullable_string: . == null or type == "string";
+    def step_signatures:
+      [.steps[] | select(.location == "agent") |
+        if .model_source == "preset" then
+          {subagent_type, model_source}
+        else
+          {subagent_type, model_source, model}
+        end] |
+      unique_by([.subagent_type, .model_source, (.model // "")]);
+    def declared_signatures:
+      .allowed_signatures |
+      unique_by([.subagent_type, .model_source, (.model // "")]);
+
+    .schema_version == 2 and
+    .requires_dispatch_check == true and
+    (.plan_hash | nonempty_string) and
+    (.created_at | type == "number") and
+    (.steps | type == "array") and
+    all(.steps[];
+      (.id | nonempty_string) and
+      (.depends_on | nullable_string) and
+      (.parallel_with | nullable_string) and
+      if .location == "main" then
+        .subagent_type == null and .model_source == null and .model == null
+      elif .location == "agent" and .model_source == "preset" then
+        (.subagent_type | nonempty_string) and .model == null
+      elif .location == "agent" and .model_source == "runtime" then
+        (.subagent_type | nonempty_string) and (.model | nonempty_string)
+      else
+        false
+      end
+    ) and
+    (.allowed_signatures | type == "array") and
+    all(.allowed_signatures[];
+      (.subagent_type | nonempty_string) and
+      if .model_source == "preset" then
+        (has("model") | not)
+      elif .model_source == "runtime" then
+        (.model | nonempty_string)
+      else
+        false
+      end
+    ) and
+    declared_signatures == step_signatures
+  ' "$state_file" >/dev/null 2>&1
 }

--- a/plugins/plan-review/scripts/lib/manifest.sh
+++ b/plugins/plan-review/scripts/lib/manifest.sh
@@ -10,21 +10,53 @@ has_manifest() { printf '%s' "$1" | grep -qi '^## Dispatch Manifest'; }
 # is normalized as line ending syntax; after the table starts, a blank line is
 # a hard boundary so later prose/tables cannot affect validation or dispatch.
 manifest_table_rows() {
-  printf '%s\n' "$1" | awk '
-    tolower($0) ~ /^## dispatch manifest/ { in_manifest=1; next }
-    !in_manifest { next }
-    /^## / { exit }
-    {
-      line=$0
-      sub(/\r$/, "", line)
-    }
-    table_started && line ~ /^[[:space:]]*$/ { exit }
-    line ~ /^[[:space:]]*\|/ { table_started=1; print line }
-  '
+  local plan="$1" line="" in_manifest=0 table_started=0
+  local had_nocasematch=0
+  local carriage_return=$'\r'
+
+  # Do not pipe the complete plan into an early-exiting reader. On a large plan,
+  # awk's former `exit` closed the pipe while printf was still writing; pipefail
+  # then turned the expected section boundary into SIGPIPE. Iterate the argument
+  # directly instead: no pipe writer and no heredoc delimiter that plan content
+  # could accidentally terminate. This is supported by macOS bash 3.2.
+  shopt -q nocasematch && had_nocasematch=1 || shopt -s nocasematch
+  while [ -n "$plan" ]; do
+    case "$plan" in
+      *$'\n'*)
+        line=${plan%%$'\n'*}
+        plan=${plan#*$'\n'}
+        ;;
+      *)
+        line=$plan
+        plan=""
+        ;;
+    esac
+    line=${line%"$carriage_return"}
+    if [ "$in_manifest" -eq 0 ]; then
+      case "$line" in
+        '## Dispatch Manifest'*) in_manifest=1 ;;
+      esac
+      continue
+    fi
+
+    case "$line" in
+      '## '*) break ;;
+    esac
+    if [ "$table_started" -eq 1 ] && [[ "$line" =~ ^[[:space:]]*$ ]]; then
+      break
+    fi
+    if [[ "$line" =~ ^[[:space:]]*\| ]]; then
+      table_started=1
+      printf '%s\n' "$line"
+    fi
+  done
+  [ "$had_nocasematch" -eq 1 ] || shopt -u nocasematch
 }
 
 manifest_has_agent_signature() {
-  manifest_table_rows "$1" | awk '
+  local rows
+  rows=$(manifest_table_rows "$1")
+  awk '
     {
       line=$0
       sub(/^[[:space:]]*\|[[:space:]]*/, "", line)
@@ -32,7 +64,9 @@ manifest_has_agent_signature() {
       if (tolower(fields[2]) ~ /^[[:space:]]*agent[[:space:]]*$/) found=1
     }
     END { exit !found }
-  '
+  ' <<MANIFEST_ROWS_EOF
+$rows
+MANIFEST_ROWS_EOF
 }
 
 # Manifest v2 is intentionally explicit about dispatch ownership:
@@ -64,23 +98,30 @@ validate_manifest_v2() {
   local plan="$1"
   MANIFEST_ERROR=$(manifest_table_rows "$plan" | awk '
     function trim(value) { sub(/^[[:space:]]+/, "", value); sub(/[[:space:]]+$/, "", value); return value }
-    function fail(message) { print message; failed=1; exit 1 }
+    # Keep consuming rows after the first error. The caller runs under pipefail;
+    # exiting here would SIGPIPE manifest_table_rows on a large valid plan.
+    function fail(message) { if (!failed) { print message; failed=1 } }
     BEGIN { expected[1]="step"; expected[2]="location"; expected[3]="subagent_type"; expected[4]="model_source"; expected[5]="model"; expected[6]="depends_on"; expected[7]="parallel_with" }
     {
+      if (failed) next
       # The serializer uses tab-delimited records internally. Reject control
       # separators before extraction so a cell cannot alter that framing.
-      if (header_seen && (index($0, "\t") || index($0, "\r"))) fail("data cells must not contain tab or carriage-return")
+      if (header_seen && (index($0, "\t") || index($0, "\r"))) { fail("data cells must not contain tab or carriage-return"); next }
       line=$0; sub(/^[[:space:]]*\|[[:space:]]*/, "", line); sub(/[[:space:]]*\|[[:space:]]*$/, "", line)
       count=split(line, fields, /[[:space:]]*\|[[:space:]]*/)
       for (i=1; i<=count; i++) fields[i]=trim(fields[i])
       if (!header_seen) {
-        if (count != 7) fail("header must have seven v2 columns")
-        for (i=1; i<=7; i++) if (fields[i] != expected[i]) fail("header must be: step | location | subagent_type | model_source | model | depends_on | parallel_with")
+        if (count != 7) { fail("header must have seven v2 columns"); next }
+        for (i=1; i<=7; i++) if (fields[i] != expected[i]) { fail("header must be: step | location | subagent_type | model_source | model | depends_on | parallel_with"); next }
         header_seen=1
         next
       }
-      if (fields[1] ~ /^-+$/) { separator_seen=1; next }
-      if (count != 7) fail("every row must have seven columns")
+      if (count != 7) { fail("every row must have seven columns"); next }
+      if (fields[1] ~ /^:?-+:?$/) {
+        for (i=2; i<=7; i++) if (fields[i] !~ /^:?-+:?$/) { fail("table separator must have seven Markdown separator cells"); next }
+        separator_seen=1
+        next
+      }
       step=fields[1]; location=fields[2]; agent_type=fields[3]; model_source=fields[4]; model=fields[5]
       if (step == "" || step == "-") fail("step is required")
       if (location == "main") {
@@ -98,13 +139,12 @@ validate_manifest_v2() {
         fail("location must be main or agent")
       }
       row_count++
-      data_seen=1
-      next
     }
     END {
       if (!failed && !header_seen) { print "missing v2 table header"; exit 1 }
       if (!failed && !separator_seen) { print "missing table separator"; exit 1 }
       if (!failed && row_count == 0) { print "manifest has no data rows"; exit 1 }
+      if (failed) exit 1
     }
   ')
 }

--- a/plugins/plan-review/scripts/lib/plan-source.sh
+++ b/plugins/plan-review/scripts/lib/plan-source.sh
@@ -101,16 +101,16 @@ resolve_plan_from_transcript() {
 #     plus the caller's PLAN_FILE_PATH, and sets the REASON global directly
 #     (no $(...) subshell — matches resolve_plan_from_transcript's own
 #     global-assignment style so callers just read $REASON afterward).
-# Three-state error message routed by the resolver's RESOLVE_REASON. Every
-# branch names the plan file path under evaluation (RESOLVE_PATH) so the user
-# can act — "write your plan to this exact file" instead of a bare directive.
+# Resolver-reason error message. Every path-aware branch names the plan file
+# under evaluation (RESOLVE_PATH) so the user can act — "write your plan to
+# this exact file" instead of a bare directive.
 plan_source_error_reason() {
   REASON=""
   case "${RESOLVE_REASON:-}" in
     resolved-but-missing)
       REASON="[ERROR] plan 内容未传入。框架在 transcript 中指定了 plan 文件 \"${RESOLVE_PATH}\"，但该文件尚未写入。请用 Write 将 plan 写入该文件后重新调用 ExitPlanMode。" ;;
     outside-whitelist|symlink-rejected|path-traversal)
-      REASON="[ERROR] plan 文件路径 \"${RESOLVE_PATH}\" 非法（${RESOLVE_REASON}），出于安全已拒绝读取。plan 文件必须位于 ~/.claude/plans 下且不能是软链接。" ;;
+      REASON="[ERROR] plan 文件路径 \"${RESOLVE_PATH}\" 非法（${RESOLVE_REASON}），出于安全已拒绝读取。请将 plan 写入框架许可的 plan 目录；路径不得包含 ..，且不能是软链接。" ;;
     *)
       if [ -n "${PLAN_FILE_PATH:-}" ] && [ "${PLAN_FILE_PATH:-}" != "null" ]; then
         REASON="[ERROR] plan 内容未传入。tool_input.plan 为空，planFilePath=\"${PLAN_FILE_PATH}\" 指向的文件不存在。请将 plan 写入该文件后重新调用 ExitPlanMode。"

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -268,6 +268,10 @@ CONV_FILE="$COUNTER_DIR/.conversation-${SESSION_ID}"
 # clearing it (see that branch below) — that is the highest-value moment for
 # cross-round memory, not a cycle end.
 HISTORY_FILE="$COUNTER_DIR/.review-history-${SESSION_ID}"
+# Dispatch state is session-scoped, but stale files are global debris. Clean
+# them for every valid plan-review invocation, including Tier0 plans that have
+# no Manifest and therefore never enter the approval serializer branch.
+find "$COUNTER_DIR" -maxdepth 1 -name '.dispatch-*.json' -mmin +30 -delete 2>/dev/null || true
 
 # --- Read counter (new format ATTEMPT:TOTAL, backward-compat with old single-number) ---
 IFS=: read -r ATTEMPT TOTAL_ROUNDS <<< "$(cat "$COUNTER_FILE" 2>/dev/null || echo "0:0")"
@@ -419,6 +423,23 @@ ${MANIFEST_EXAMPLE}"
   MANIFEST_DENY_JSON=$(printf '%s' "$MANIFEST_MSG" | jq -Rs .)
   cat <<EOF
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":${MANIFEST_DENY_JSON}}}
+EOF
+  exit 0
+fi
+
+if needs_manifest "$PLAN" && ! manifest_has_agent_signature "$PLAN"; then
+  TOTAL_ROUNDS=$((TOTAL_ROUNDS + 1))
+  echo "${ATTEMPT:-0}:${TOTAL_ROUNDS}" > "$COUNTER_FILE"
+  log_decision "decision=deny reason=dispatch-hoarding"
+  HOARDING_MSG="## Red Team Pre-flight — DISPATCH HOARDING
+
+Plan 声明了 Agent/Task 调度意图，但 Manifest v2 没有任何 \`agent\` 行。不得把全部工作囤积在 Main。
+请移除不再需要的调度关键词，或显式声明至少一个 Agent step 后重新调用 ExitPlanMode。
+
+${MANIFEST_EXAMPLE}"
+  HOARDING_JSON=$(printf '%s' "$HOARDING_MSG" | jq -Rs .)
+  cat <<EOF
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":${HOARDING_JSON}}}
 EOF
   exit 0
 fi
@@ -705,7 +726,6 @@ if [ "$VERDICT" = "APPROVE" ]; then
   if has_manifest "$PLAN"; then
     DISPATCH_DIR="${REVIEW_COUNTER_DIR:-/tmp/claude-reviews}"
     mkdir -p "$DISPATCH_DIR" 2>/dev/null || true
-    find "$DISPATCH_DIR" -maxdepth 1 -name '.dispatch-*.json' -mmin +30 -delete 2>/dev/null || true
     DISPATCH_FILE="$DISPATCH_DIR/.dispatch-${SESSION_ID}.json"
     DISPATCH_TEMP=$(mktemp "$DISPATCH_DIR/.dispatch-${SESSION_ID}.XXXXXX" 2>/dev/null || true)
     if [ -n "$DISPATCH_TEMP" ] \

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -385,10 +385,27 @@ EOF
   exit 0
 fi
 
-# --- Pre-flight manifest check (AFTER non-critical valve, not before) ---
+# --- Pre-flight manifest checks (AFTER non-critical valve, not before) ---
 # Format correction, NOT negotiation round: increments TOTAL_ROUNDS only.
 # ATTEMPT stays frozen — pre-flight denies do not count toward MAX_ROUNDS.
 # Global safety valve (TOTAL_ROUNDS >= 20) still protects against infinite loops.
+if has_manifest "$PLAN" && ! validate_manifest_v2 "$PLAN"; then
+  TOTAL_ROUNDS=$((TOTAL_ROUNDS + 1))
+  echo "${ATTEMPT:-0}:${TOTAL_ROUNDS}" > "$COUNTER_FILE"
+  log_decision "decision=deny reason=invalid-manifest detail=${MANIFEST_ERROR:-unknown}"
+  INVALID_MANIFEST_MSG="## Red Team Pre-flight — INVALID DISPATCH MANIFEST
+
+Manifest v2 结构错误：${MANIFEST_ERROR:-unknown}。
+请按以下固定列顺序和行规则修正后重新调用 ExitPlanMode。
+
+${MANIFEST_EXAMPLE}"
+  INVALID_MANIFEST_JSON=$(printf '%s' "$INVALID_MANIFEST_MSG" | jq -Rs .)
+  cat <<EOF
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":${INVALID_MANIFEST_JSON}}}
+EOF
+  exit 0
+fi
+
 if needs_manifest "$PLAN" && ! has_manifest "$PLAN"; then
   TOTAL_ROUNDS=$((TOTAL_ROUNDS + 1))
   echo "${ATTEMPT:-0}:${TOTAL_ROUNDS}" > "$COUNTER_FILE"
@@ -402,26 +419,6 @@ ${MANIFEST_EXAMPLE}"
   MANIFEST_DENY_JSON=$(printf '%s' "$MANIFEST_MSG" | jq -Rs .)
   cat <<EOF
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":${MANIFEST_DENY_JSON}}}
-EOF
-  exit 0
-fi
-
-# --- Pre-flight degenerate manifest check (all agent_type == "-") ---
-# Fires when manifest is present but declares zero real agent steps.
-if needs_manifest "$PLAN" && has_manifest "$PLAN" && ! manifest_has_real_agent "$PLAN"; then
-  TOTAL_ROUNDS=$((TOTAL_ROUNDS + 1))
-  echo "${ATTEMPT:-0}:${TOTAL_ROUNDS}" > "$COUNTER_FILE"
-  log_decision "decision=deny reason=degenerate-manifest"
-  DEGEN_MSG="## Red Team Pre-flight — DEGENERATE DISPATCH MANIFEST
-
-Plan 含 Agent/Task 调度关键词，但 Manifest 所有行 agent_type 均为 \`-\`（全主上下文）。
-- 若任务确实简单（单一关注点、无接口变更）：**首选**移除 plan 中的 dispatch 关键词，改写为直接执行描述。
-- 若任务复杂：在 manifest 中至少声明一个真实 agent 步骤（agent_type 与 model 两列均填实值）。
-
-${MANIFEST_EXAMPLE}"
-  DEGEN_DENY_JSON=$(printf '%s' "$DEGEN_MSG" | jq -Rs .)
-  cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":${DEGEN_DENY_JSON}}}
 EOF
   exit 0
 fi
@@ -710,10 +707,16 @@ if [ "$VERDICT" = "APPROVE" ]; then
     mkdir -p "$DISPATCH_DIR" 2>/dev/null || true
     find "$DISPATCH_DIR" -maxdepth 1 -name '.dispatch-*.json' -mmin +30 -delete 2>/dev/null || true
     DISPATCH_FILE="$DISPATCH_DIR/.dispatch-${SESSION_ID}.json"
-    parse_manifest_to_json "$PLAN" "$(plan_hash "$PLAN")" > "$DISPATCH_FILE" 2>/dev/null || rm -f "$DISPATCH_FILE"
-    if [ -f "$DISPATCH_FILE" ]; then
+    DISPATCH_TEMP=$(mktemp "$DISPATCH_DIR/.dispatch-${SESSION_ID}.XXXXXX" 2>/dev/null || true)
+    if [ -n "$DISPATCH_TEMP" ] \
+       && parse_manifest_to_json "$PLAN" "$(plan_hash "$PLAN")" > "$DISPATCH_TEMP" 2>/dev/null \
+       && dispatch_state_is_valid_v2 "$DISPATCH_TEMP"; then
+      mv -f "$DISPATCH_TEMP" "$DISPATCH_FILE"
       dispatch_bytes=$(wc -c < "$DISPATCH_FILE" | tr -d ' ')
       log_decision "manifest-written file=$DISPATCH_FILE bytes=$dispatch_bytes"
+    else
+      rm -f "${DISPATCH_TEMP:-}" "$DISPATCH_FILE"
+      log_decision "manifest-write-skipped reason=invalid-json"
     fi
   fi
 

--- a/plugins/plan-review/scripts/plan-review.sh
+++ b/plugins/plan-review/scripts/plan-review.sh
@@ -249,6 +249,9 @@ fi
 # --- Attempt counter (tmpfs-backed, system handles cleanup) ---
 COUNTER_DIR="${REVIEW_COUNTER_DIR:-/tmp/claude-reviews}"
 mkdir -p "$COUNTER_DIR"
+# Dispatch state shares the review-state directory for its whole lifecycle:
+# stale cleanup below and APPROVE serialization must not derive it separately.
+DISPATCH_DIR="$COUNTER_DIR"
 COUNTER_FILE="$COUNTER_DIR/.review-count-${SESSION_ID}"
 APPROVE_MARKER="$COUNTER_DIR/.review-approved-${SESSION_ID}"
 # Gemini degraded state file (global, no session suffix — persists across hooks)
@@ -271,7 +274,7 @@ HISTORY_FILE="$COUNTER_DIR/.review-history-${SESSION_ID}"
 # Dispatch state is session-scoped, but stale files are global debris. Clean
 # them for every valid plan-review invocation, including Tier0 plans that have
 # no Manifest and therefore never enter the approval serializer branch.
-find "$COUNTER_DIR" -maxdepth 1 -name '.dispatch-*.json' -mmin +30 -delete 2>/dev/null || true
+find "$DISPATCH_DIR" -maxdepth 1 -name '.dispatch-*.json*' -mmin +30 -delete 2>/dev/null || true
 
 # --- Read counter (new format ATTEMPT:TOTAL, backward-compat with old single-number) ---
 IFS=: read -r ATTEMPT TOTAL_ROUNDS <<< "$(cat "$COUNTER_FILE" 2>/dev/null || echo "0:0")"
@@ -434,7 +437,7 @@ if needs_manifest "$PLAN" && ! manifest_has_agent_signature "$PLAN"; then
   HOARDING_MSG="## Red Team Pre-flight — DISPATCH HOARDING
 
 Plan 声明了 Agent/Task 调度意图，但 Manifest v2 没有任何 \`agent\` 行。不得把全部工作囤积在 Main。
-请移除不再需要的调度关键词，或显式声明至少一个 Agent step 后重新调用 ExitPlanMode。
+Tier0 工作若保留在 Main，必须同时移除 Manifest 与全部调度关键词；否则显式声明至少一个 Agent step 后重新调用 ExitPlanMode。
 
 ${MANIFEST_EXAMPLE}"
   HOARDING_JSON=$(printf '%s' "$HOARDING_MSG" | jq -Rs .)
@@ -724,10 +727,9 @@ if [ "$VERDICT" = "APPROVE" ]; then
 
   # Parse manifest → dispatch JSON for Layer 2 enforcement (fail-silent: Layer 2 self-disables)
   if has_manifest "$PLAN"; then
-    DISPATCH_DIR="${REVIEW_COUNTER_DIR:-/tmp/claude-reviews}"
     mkdir -p "$DISPATCH_DIR" 2>/dev/null || true
     DISPATCH_FILE="$DISPATCH_DIR/.dispatch-${SESSION_ID}.json"
-    DISPATCH_TEMP=$(mktemp "$DISPATCH_DIR/.dispatch-${SESSION_ID}.XXXXXX" 2>/dev/null || true)
+    DISPATCH_TEMP=$(mktemp "$DISPATCH_DIR/.dispatch-${SESSION_ID}.json.XXXXXX" 2>/dev/null || true)
     if [ -n "$DISPATCH_TEMP" ] \
        && parse_manifest_to_json "$PLAN" "$(plan_hash "$PLAN")" > "$DISPATCH_TEMP" 2>/dev/null \
        && dispatch_state_is_valid_v2 "$DISPATCH_TEMP"; then

--- a/plugins/plan-review/scripts/second-opinion.sh
+++ b/plugins/plan-review/scripts/second-opinion.sh
@@ -143,10 +143,11 @@ unset _f
 #     strips ALL trailing newlines from the last file, so a trailing
 #     sentinel byte is appended before capture and stripped back off after —
 #     this preserves the exact byte sequence of the concatenated files
-#     (no separator is inserted between files; "concatenate in order" is
-#     read literally as back-to-back bytes). Each file is piped through
-#     `tr -d '\r'` — same normalization plan-review.sh:493 applies to its own
-#     two prompt assets — so a CRLF-authored rubric file doesn't change the
+#     (no separator is inserted between files; unlike plan-review.sh's fixed
+#     asset seam, this caller-controlled order is literal back-to-back bytes).
+#     Each file is piped through `tr -d '\r'`, matching plan-review.sh's
+#     CRLF normalization for its own prompt assets, so a CRLF-authored rubric
+#     file doesn't change the
 #     bytes actually sent to the engine (and therefore doesn't change the
 #     --session hash, which is derived from these assembled bytes) relative
 #     to an LF-only file with identical content. ---

--- a/plugins/plan-review/tests/dispatch-check.bats
+++ b/plugins/plan-review/tests/dispatch-check.bats
@@ -186,14 +186,28 @@ VALID_V2_DISPATCH='{
   [ -z "$HOOK_STDOUT" ]
 }
 
-@test "dispatch v1: state without schema_version emits migration prompt and skips matching" {
+@test "dispatch v1: state without schema_version emits only a migration systemMessage" {
   create_dispatch_file "test-session" '{"plan_hash":"old","requires_dispatch_check":true,"steps":[]}'
   INPUT=$(build_agent_input subagent_type=wrong model=wrong)
   run_dispatch_check
 
-  assert_approve_json
-  [[ "$(echo "$HOOK_STDOUT" | jq -r '.systemMessage')" == *"Manifest v1"* ]]
-  [[ "$(echo "$HOOK_STDOUT" | jq -r '.systemMessage')" == *"schema_version: 2"* ]]
+  [ "$HOOK_EXIT" -eq 0 ]
+  echo "$HOOK_STDOUT" | jq -e 'keys == ["systemMessage"] and (.systemMessage | contains("Manifest v1")) and (.systemMessage | contains("schema_version: 2"))' >/dev/null
+  ! echo "$HOOK_STDOUT" | jq -e 'has("hookSpecificOutput") or has("permissionDecision")' >/dev/null
+}
+
+@test "dispatch v2: empty allowed_signatures denies without a deceptive declared list" {
+  local main_only_state
+  main_only_state=$(printf '%s' "$VALID_V2_DISPATCH" | jq '.steps = [.steps[0]] | .allowed_signatures = []')
+  create_dispatch_file "test-session" "$main_only_state"
+  INPUT=$(build_agent_input subagent_type=Explore model=haiku)
+  run_dispatch_check
+
+  assert_deny_json
+  local reason
+  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+  [[ "$reason" == *"contains no agent signatures"* ]]
+  [[ "$reason" != *"Declared signatures:"* ]]
 }
 
 @test "dispatch: corrupt state allows silently" {
@@ -226,7 +240,25 @@ VALID_V2_DISPATCH='{
   [ -z "$HOOK_STDOUT" ]
 }
 
-@test "dispatch: stale state allows silently and removes file" {
+@test "dispatch: its own stale cleanup removes published and temporary state only" {
+  local stale_dispatch="${REVIEW_COUNTER_DIR}/.dispatch-abandoned.json"
+  local stale_temp="${REVIEW_COUNTER_DIR}/.dispatch-abandoned.json.temporary"
+  local retained_review="${REVIEW_COUNTER_DIR}/.review-count-abandoned"
+  printf '%s' '{}' > "$stale_dispatch"
+  printf '%s' '{}' > "$stale_temp"
+  printf '%s' '1:1' > "$retained_review"
+  touch -t 200001010000 "$stale_dispatch" "$stale_temp" "$retained_review"
+  INPUT=$(build_agent_input)
+  run_dispatch_check
+
+  [ "$HOOK_EXIT" -eq 0 ]
+  [ -z "$HOOK_STDOUT" ]
+  [ ! -e "$stale_dispatch" ]
+  [ ! -e "$stale_temp" ]
+  [ -e "$retained_review" ]
+}
+
+@test "dispatch: stale current-session state allows silently and removes file" {
   create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
   local dispatch_file="${REVIEW_COUNTER_DIR}/.dispatch-test-session.json"
   touch -t 200001010000 "$dispatch_file"

--- a/plugins/plan-review/tests/dispatch-check.bats
+++ b/plugins/plan-review/tests/dispatch-check.bats
@@ -148,6 +148,44 @@ VALID_V2_DISPATCH='{
   [ -z "$HOOK_STDOUT" ]
 }
 
+@test "dispatch: jq missing allows silently" {
+  INPUT=$(build_agent_input subagent_type=Explore model=sonnet)
+  local restricted_bin="${TEST_TEMP_DIR}/restricted-bin"
+  mkdir -p "$restricted_bin"
+  local command_name command_path
+  for command_name in bash cat mktemp rm; do
+    command_path=$(command -v "$command_name")
+    ln -s "$command_path" "${restricted_bin}/${command_name}"
+  done
+  local original_path="$PATH"
+  export PATH="$restricted_bin"
+  run_dispatch_check
+  export PATH="$original_path"
+
+  [ "$HOOK_EXIT" -eq 0 ]
+  [ -z "$HOOK_STDOUT" ]
+}
+
+@test "dispatch: missing session_id allows silently" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input session_id= subagent_type=Explore model=sonnet)
+  run_dispatch_check
+
+  [ "$HOOK_EXIT" -eq 0 ]
+  [ -z "$HOOK_STDOUT" ]
+}
+
+@test "dispatch: requires_dispatch_check false allows silently" {
+  local disabled_state
+  disabled_state=$(printf '%s' "$VALID_V2_DISPATCH" | jq '.requires_dispatch_check = false')
+  create_dispatch_file "test-session" "$disabled_state"
+  INPUT=$(build_agent_input subagent_type=Explore model=sonnet)
+  run_dispatch_check
+
+  [ "$HOOK_EXIT" -eq 0 ]
+  [ -z "$HOOK_STDOUT" ]
+}
+
 @test "dispatch v1: state without schema_version emits migration prompt and skips matching" {
   create_dispatch_file "test-session" '{"plan_hash":"old","requires_dispatch_check":true,"steps":[]}'
   INPUT=$(build_agent_input subagent_type=wrong model=wrong)
@@ -191,7 +229,7 @@ VALID_V2_DISPATCH='{
 @test "dispatch: stale state allows silently and removes file" {
   create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
   local dispatch_file="${REVIEW_COUNTER_DIR}/.dispatch-test-session.json"
-  python3 -c "import os,time; os.utime('$dispatch_file', (time.time()-2100, time.time()-2100))"
+  touch -t 200001010000 "$dispatch_file"
   INPUT=$(build_agent_input)
   run_dispatch_check
 
@@ -246,14 +284,12 @@ VALID_V2_DISPATCH='{
 
   # Change only the copied comparator. If this mutation stops the deny, the
   # baseline assertion above is attached to the actual production branch.
-  python3 - "$copy" <<'PYTHON'
-from pathlib import Path
-path = Path(__import__('sys').argv[1])
-text = path.read_text()
-needle = '--arg model "$CALL_MODEL"'
-assert text.count(needle) == 1
-path.write_text(text.replace(needle, '--arg model "haiku"', 1))
-PYTHON
+  perl -0pi -e 's/--arg model "\$CALL_MODEL"/--arg model "haiku"/' "$copy"
+  mutated_count=$(grep -cF -- '--arg model "haiku"' "$copy")
+  [ "$mutated_count" -eq 1 ] || {
+    echo "expected one mutated runtime-model comparator, found $mutated_count"
+    return 1
+  }
 
   DISPATCH_SCRIPT="$copy"
   run_dispatch_check

--- a/plugins/plan-review/tests/dispatch-check.bats
+++ b/plugins/plan-review/tests/dispatch-check.bats
@@ -1,15 +1,13 @@
 #!/usr/bin/env bats
-# BDD test suite for dispatch-check.sh (Layer 2 dispatch enforcement hook).
+# BDD tests for Manifest v2 signature-set enforcement in dispatch-check.sh.
 #
-# Verifies: fail-open on all anomaly paths, correct deny on missing params,
-# stale file cleanup, kill switch, task/agent naming compatibility.
-#
-# Dependencies: bats-core, jq
+# Given an approved v2 dispatch state, Agent and Task calls must match a
+# declared preset/runtime signature. Malformed, stale, and v1 state stays
+# fail-open so an unavailable guard cannot block userspace.
 
 setup() {
   load 'test_helper/common-setup'
   common_setup
-  # Minimal defaults for dispatch-check (unset plan-review-specific overrides)
   unset DISPATCH_CHECK_DISABLED
 }
 
@@ -17,15 +15,151 @@ teardown() {
   common_teardown
 }
 
-# Valid dispatch JSON for use across tests
-VALID_DISPATCH='{"plan_hash":"abc123","created_at":1700000000,"requires_dispatch_check":true,"steps":[{"id":"1","agent_type":null,"model":null},{"id":"2","agent_type":"worker","model":"sonnet"}]}'
+VALID_V2_DISPATCH='{
+  "schema_version": 2,
+  "plan_hash": "abc123",
+  "created_at": 1700000000,
+  "requires_dispatch_check": true,
+  "steps": [
+    {"id":"1","location":"main","subagent_type":null,"model_source":null,"model":null,"depends_on":null,"parallel_with":null},
+    {"id":"2","location":"agent","subagent_type":"dev-econ","model_source":"preset","model":null,"depends_on":"1","parallel_with":null},
+    {"id":"3","location":"agent","subagent_type":"Explore","model_source":"runtime","model":"haiku","depends_on":"1","parallel_with":null}
+  ],
+  "allowed_signatures": [
+    {"subagent_type":"dev-econ","model_source":"preset"},
+    {"subagent_type":"Explore","model_source":"runtime","model":"haiku"}
+  ]
+}'
 
 # =============================================================================
-# Fail-Open: No Dispatch File
+# Manifest v2: declared signature acceptance
 # =============================================================================
 
-# 1. 无 dispatch 文件 + Agent 调用 → allow (exit 0, no JSON output)
-@test "dispatch: no dispatch file + Agent call → allow (fail-open)" {
+@test "dispatch v2: preset signature accepts matching type with model omitted" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input subagent_type=dev-econ)
+  run_dispatch_check
+
+  [ "$HOOK_EXIT" -eq 0 ]
+  [ -z "$HOOK_STDOUT" ]
+}
+
+@test "dispatch v2: runtime signature accepts exact type and model" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input subagent_type=Explore model=haiku)
+  run_dispatch_check
+
+  [ "$HOOK_EXIT" -eq 0 ]
+  [ -z "$HOOK_STDOUT" ]
+}
+
+@test "dispatch v2: repeated matching signature remains allowed" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input subagent_type=Explore model=haiku)
+
+  run_dispatch_check
+  [ "$HOOK_EXIT" -eq 0 ]
+  [ -z "$HOOK_STDOUT" ]
+
+  run_dispatch_check
+  [ "$HOOK_EXIT" -eq 0 ]
+  [ -z "$HOOK_STDOUT" ]
+}
+
+# =============================================================================
+# Manifest v2: undeclared or malformed calls deny
+# =============================================================================
+
+@test "dispatch v2: preset call with explicit model denies" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input subagent_type=dev-econ model=haiku)
+  run_dispatch_check
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"omit model"* ]]
+}
+
+@test "dispatch v2: preset call with wrong type denies" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input subagent_type=worker-econ)
+  run_dispatch_check
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"signature"* ]]
+}
+
+@test "dispatch v2: runtime call with wrong model denies" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input subagent_type=Explore model=sonnet)
+  run_dispatch_check
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"signature"* ]]
+}
+
+@test "dispatch v2: runtime call with wrong type denies" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input subagent_type=dev model=haiku)
+  run_dispatch_check
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"signature"* ]]
+}
+
+@test "dispatch v2: runtime call missing model denies" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input subagent_type=Explore)
+  run_dispatch_check
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"signature"* ]]
+}
+
+# =============================================================================
+# Agent / Task compatibility
+# =============================================================================
+
+@test "dispatch v2: Task accepts the same preset signature as Agent" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input tool_name=Task subagent_type=dev-econ)
+  run_dispatch_check
+
+  [ "$HOOK_EXIT" -eq 0 ]
+  [ -z "$HOOK_STDOUT" ]
+}
+
+@test "dispatch v2: Task rejects the same wrong runtime model as Agent" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input tool_name=Task subagent_type=Explore model=sonnet)
+  run_dispatch_check
+
+  assert_deny_json
+}
+
+# =============================================================================
+# Fail-open paths and legacy migration
+# =============================================================================
+
+@test "dispatch: no dispatch file allows silently" {
+  INPUT=$(build_agent_input subagent_type=Explore model=haiku)
+  run_dispatch_check
+
+  [ "$HOOK_EXIT" -eq 0 ]
+  [ -z "$HOOK_STDOUT" ]
+}
+
+@test "dispatch v1: state without schema_version emits migration prompt and skips matching" {
+  create_dispatch_file "test-session" '{"plan_hash":"old","requires_dispatch_check":true,"steps":[]}'
+  INPUT=$(build_agent_input subagent_type=wrong model=wrong)
+  run_dispatch_check
+
+  assert_approve_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.systemMessage')" == *"Manifest v1"* ]]
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.systemMessage')" == *"schema_version: 2"* ]]
+}
+
+@test "dispatch: corrupt state allows silently" {
+  create_dispatch_file "test-session" 'not-valid-json{{{{'
   INPUT=$(build_agent_input)
   run_dispatch_check
 
@@ -33,71 +167,31 @@ VALID_DISPATCH='{"plan_hash":"abc123","created_at":1700000000,"requires_dispatch
   [ -z "$HOOK_STDOUT" ]
 }
 
-# 2. dispatch 文件存在 + 完整 Agent 参数 → allow (silent exit 0)
-@test "dispatch: dispatch file + complete Agent params → allow" {
-  create_dispatch_file "test-session" "$VALID_DISPATCH"
-  INPUT=$(build_agent_input model=sonnet subagent_type=worker)
+@test "dispatch: structurally invalid v2 state allows silently" {
+  create_dispatch_file "test-session" '{"schema_version":2,"requires_dispatch_check":true,"steps":[],"allowed_signatures":[{"subagent_type":"Explore","model_source":"runtime"}]}'
+  INPUT=$(build_agent_input subagent_type=Explore)
   run_dispatch_check
 
   [ "$HOOK_EXIT" -eq 0 ]
   [ -z "$HOOK_STDOUT" ]
 }
 
-# =============================================================================
-# Deny: Missing Params
-# =============================================================================
 
-# 3. dispatch 文件存在 + 缺 model → deny + 提示含 manifest 预览
-@test "dispatch: dispatch file + missing model → deny with manifest preview" {
-  create_dispatch_file "test-session" "$VALID_DISPATCH"
-  INPUT=$(build_agent_input subagent_type=worker)
-  run_dispatch_check
-
-  assert_deny_json
-  local reason
-  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
-  [[ "$reason" == *"model"* ]]
-  [[ "$reason" == *"Manifest"* ]]
-}
-
-# 4. dispatch 文件存在 + 缺 subagent_type → deny
-@test "dispatch: dispatch file + missing subagent_type → deny" {
-  create_dispatch_file "test-session" "$VALID_DISPATCH"
-  INPUT=$(build_agent_input model=sonnet)
-  run_dispatch_check
-
-  assert_deny_json
-  local reason
-  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
-  [[ "$reason" == *"subagent_type"* ]]
-}
-
-# 5. dispatch 文件存在 + 两者都缺 → deny，提示两者
-@test "dispatch: dispatch file + missing both → deny with both listed" {
-  create_dispatch_file "test-session" "$VALID_DISPATCH"
+@test "dispatch: state with signatures not derived from steps allows silently" {
+  local mismatched_state
+  mismatched_state=$(printf '%s' "$VALID_V2_DISPATCH" | jq '.allowed_signatures = [{"subagent_type":"worker","model_source":"runtime","model":"sonnet"}]')
+  create_dispatch_file "test-session" "$mismatched_state"
   INPUT=$(build_agent_input)
   run_dispatch_check
 
-  assert_deny_json
-  local reason
-  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
-  [[ "$reason" == *"subagent_type"* ]]
-  [[ "$reason" == *"model"* ]]
+  [ "$HOOK_EXIT" -eq 0 ]
+  [ -z "$HOOK_STDOUT" ]
 }
 
-# =============================================================================
-# Fail-Open: Stale File
-# =============================================================================
-
-# 6. dispatch 文件 mtime > 30min → allow + 文件自动删除
-@test "dispatch: stale dispatch file (>30min) → allow + file deleted" {
-  create_dispatch_file "test-session" "$VALID_DISPATCH"
+@test "dispatch: stale state allows silently and removes file" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
   local dispatch_file="${REVIEW_COUNTER_DIR}/.dispatch-test-session.json"
-  # Backdate by 35 minutes
-  touch -t "$(date -v -35M +%Y%m%d%H%M 2>/dev/null || date -d '35 minutes ago' +%Y%m%d%H%M 2>/dev/null || date +%Y%m%d%H%M)" \
-    "$dispatch_file" 2>/dev/null || \
-    python3 -c "import os,time; os.utime('$dispatch_file', (time.time()-2100, time.time()-2100))" 2>/dev/null || true
-
+  python3 -c "import os,time; os.utime('$dispatch_file', (time.time()-2100, time.time()-2100))"
   INPUT=$(build_agent_input)
   run_dispatch_check
 
@@ -106,75 +200,18 @@ VALID_DISPATCH='{"plan_hash":"abc123","created_at":1700000000,"requires_dispatch
   [ ! -f "$dispatch_file" ]
 }
 
-# =============================================================================
-# Fail-Open: Corrupt / Missing Fields
-# =============================================================================
-
-# 7. dispatch JSON 损坏 → allow + 无副作用
-@test "dispatch: corrupt dispatch JSON → allow (fail-open)" {
-  create_dispatch_file "test-session" "not-valid-json{{{{"
-  INPUT=$(build_agent_input)
-  run_dispatch_check
-
-  [ "$HOOK_EXIT" -eq 0 ]
-  [ -z "$HOOK_STDOUT" ]
-}
-
-# 8. requires_dispatch_check=false → allow
-@test "dispatch: requires_dispatch_check=false → allow" {
-  create_dispatch_file "test-session" \
-    '{"plan_hash":"abc","created_at":1700000000,"requires_dispatch_check":false,"steps":[]}'
-  INPUT=$(build_agent_input)
-  run_dispatch_check
-
-  [ "$HOOK_EXIT" -eq 0 ]
-  [ -z "$HOOK_STDOUT" ]
-}
-
-# =============================================================================
-# Fail-Open: Kill Switches
-# =============================================================================
-
-# 9. DISPATCH_CHECK_DISABLED=1 → allow 即使 dispatch 文件存在 + 参数缺失
-@test "dispatch: DISPATCH_CHECK_DISABLED=1 → allow regardless of dispatch file" {
+@test "dispatch: disabled kill switch allows silently" {
   export DISPATCH_CHECK_DISABLED=1
-  create_dispatch_file "test-session" "$VALID_DISPATCH"
-  INPUT=$(build_agent_input)  # missing both model and subagent_type
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input subagent_type=Explore model=sonnet)
   run_dispatch_check
 
   [ "$HOOK_EXIT" -eq 0 ]
   [ -z "$HOOK_STDOUT" ]
 }
 
-# 10. jq 缺失 → allow (PATH 临时去除 jq 模拟)
-@test "dispatch: jq missing → allow (fail-open)" {
-  create_dispatch_file "test-session" "$VALID_DISPATCH"
-  INPUT=$(build_agent_input)
-
-  local restricted_bin="${TEST_TEMP_DIR}/restricted_bin_dc"
-  mkdir -p "$restricted_bin"
-  for cmd in bash cat grep head tr printf mkdir rm find stat date python3 mktemp; do
-    local cmd_path
-    cmd_path=$(command -v "$cmd" 2>/dev/null) || continue
-    ln -sf "$cmd_path" "${restricted_bin}/${cmd}"
-  done
-
-  local orig_path="$PATH"
-  export PATH="$restricted_bin"
-  run_dispatch_check
-  export PATH="$orig_path"
-
-  [ "$HOOK_EXIT" -eq 0 ]
-  [ -z "$HOOK_STDOUT" ]
-}
-
-# =============================================================================
-# Fail-Open: Wrong Tool / Missing Session
-# =============================================================================
-
-# 11. tool_name != Agent/Task → allow (e.g. Read)
-@test "dispatch: tool_name=Read → allow (not an Agent call)" {
-  create_dispatch_file "test-session" "$VALID_DISPATCH"
+@test "dispatch: non-Agent/Task tool allows silently" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
   INPUT=$(build_agent_input tool_name=Read)
   run_dispatch_check
 
@@ -182,50 +219,44 @@ VALID_DISPATCH='{"plan_hash":"abc123","created_at":1700000000,"requires_dispatch
   [ -z "$HOOK_STDOUT" ]
 }
 
-# 12. session_id 缺失 → allow
-@test "dispatch: missing session_id → allow (fail-open)" {
-  create_dispatch_file "test-session" "$VALID_DISPATCH"
-  INPUT=$(jq -n '{"tool_name":"Agent","tool_input":{}}')  # no session_id
-  run_dispatch_check
 
+# =============================================================================
+# Mutation guard
+# =============================================================================
+
+@test "mutation: runtime model comparator has one executable hit" {
+  create_dispatch_file "test-session" "$VALID_V2_DISPATCH"
+  INPUT=$(build_agent_input subagent_type=Explore model=sonnet)
+
+  # Baseline: an undeclared runtime model is denied by the production script.
+  run_dispatch_check
+  assert_deny_json
+
+  local copy_dir="${TEST_TEMP_DIR}/dispatch-copy"
+  local copy="${copy_dir}/dispatch-check.sh"
+  mkdir -p "${copy_dir}/lib"
+  cp "$DISPATCH_SCRIPT" "$copy"
+  cp "${BATS_TEST_DIRNAME}/../scripts/lib/manifest.sh" "${copy_dir}/lib/manifest.sh"
+  local mutation_count
+  mutation_count=$(grep -cF -- '--arg model "$CALL_MODEL"' "$copy")
+  [ "$mutation_count" -eq 1 ] || {
+    echo "expected one runtime-model comparator, found $mutation_count"
+    return 1
+  }
+
+  # Change only the copied comparator. If this mutation stops the deny, the
+  # baseline assertion above is attached to the actual production branch.
+  python3 - "$copy" <<'PYTHON'
+from pathlib import Path
+path = Path(__import__('sys').argv[1])
+text = path.read_text()
+needle = '--arg model "$CALL_MODEL"'
+assert text.count(needle) == 1
+path.write_text(text.replace(needle, '--arg model "haiku"', 1))
+PYTHON
+
+  DISPATCH_SCRIPT="$copy"
+  run_dispatch_check
   [ "$HOOK_EXIT" -eq 0 ]
   [ -z "$HOOK_STDOUT" ]
-}
-
-# =============================================================================
-# Task Tool Name Compatibility
-# =============================================================================
-
-# 13. tool_name="Task" → 与 Agent 同等处理（双命名兼容）
-@test "dispatch: tool_name=Task → same enforcement as Agent" {
-  create_dispatch_file "test-session" "$VALID_DISPATCH"
-  INPUT=$(build_agent_input tool_name=Task)  # missing model + subagent_type
-  run_dispatch_check
-
-  assert_deny_json
-}
-
-# =============================================================================
-# Opportunistic Global Cleanup
-# =============================================================================
-
-# 14. Opportunistic 全局清理：预置其它 session 的 stale dispatch 文件，本次调用后被删除
-@test "dispatch: opportunistic global cleanup removes other sessions' stale files" {
-  # Plant stale files for other sessions
-  local stale1="${REVIEW_COUNTER_DIR}/.dispatch-old-session-1.json"
-  local stale2="${REVIEW_COUNTER_DIR}/.dispatch-old-session-2.json"
-  printf '%s' "$VALID_DISPATCH" > "$stale1"
-  printf '%s' "$VALID_DISPATCH" > "$stale2"
-  touch -t "$(date -v -35M +%Y%m%d%H%M 2>/dev/null || date -d '35 minutes ago' +%Y%m%d%H%M 2>/dev/null || date +%Y%m%d%H%M)" \
-    "$stale1" "$stale2" 2>/dev/null || \
-    python3 -c "import os,time; [os.utime(f, (time.time()-2100,)*2) for f in ['$stale1','$stale2']]" 2>/dev/null || true
-
-  # Fresh file for current session (no dispatch file for test-session → allow path)
-  INPUT=$(build_agent_input)
-  run_dispatch_check
-
-  [ "$HOOK_EXIT" -eq 0 ]
-  # Stale files for other sessions must be cleaned up
-  [ ! -f "$stale1" ]
-  [ ! -f "$stale2" ]
 }

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -2130,15 +2130,18 @@ Approved."
   assert_ack_approve_json
 }
 
-@test "manifest v2: Main-only row is structurally valid" {
-  create_mock_engine "agy" "<verdict>APPROVE</verdict>
-Approved."
+@test "manifest v2: Main-only rows deny when dispatch keywords are present" {
   local plan
   plan=$(manifest_v2_plan '| 1 | main | - | - | - | - | - |')
   INPUT=$(build_input "plan=$plan")
   run_hook
 
-  assert_ack_approve_json
+  assert_deny_json
+  local reason
+  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+  [[ "$reason" == *"DISPATCH HOARDING"* ]]
+  [[ "$reason" == *"移除不再需要的调度关键词"* ]]
+  [[ "$reason" == *"显式声明至少一个 Agent step"* ]]
 }
 
 @test "manifest v2: preset-only row is structurally valid" {
@@ -2320,33 +2323,33 @@ Approved."
   ! find "$REVIEW_COUNTER_DIR" -maxdepth 1 -name '.dispatch-test-session.*' -print -quit | grep -q .
 }
 
-@test "mutation: control-separator guard has one executable hit" {
-  local tab=$'\t'
+@test "mutation: shared blank-line boundary has one executable hit" {
   local plan
-  plan=$(manifest_v2_plan "| 1 | agent | Explore${tab}smuggled | runtime | haiku | - | - |")
+  plan=$(manifest_v2_plan '| 1 | main | - | - | - | - | - |
 
-  # The production validator rejects the tab before serializer framing begins.
-  run bash -c '. "$1"; validate_manifest_v2 "$2"' bash "${BATS_TEST_DIRNAME}/../scripts/lib/manifest.sh" "$plan"
+| 2 | agent | Explore | runtime | haiku | - | - |')
+
+  run bash -c '. "$1"; manifest_has_agent_signature "$2"' bash "${BATS_TEST_DIRNAME}/../scripts/lib/manifest.sh" "$plan"
   [ "$status" -ne 0 ]
 
   setup_script_copy
   local copied_manifest="${COPY_SCRIPT_DIR}/lib/manifest.sh"
-  local mutation_count
-  mutation_count=$(grep -cF 'index($0, "\t") || index($0, "\r")' "$copied_manifest")
-  [ "$mutation_count" -eq 1 ] || {
-    echo "expected one control-separator guard, found $mutation_count"
-    return 1
-  }
+  run grep -F 'table_started && line ~ /^[[:space:]]*$/ { exit }' "$copied_manifest"
+  [ "$status" -eq 0 ]
   python3 - "$copied_manifest" <<'PYTHON'
 from pathlib import Path
 path = Path(__import__('sys').argv[1])
 text = path.read_text()
-needle = 'header_seen && (index($0, "\\t") || index($0, "\\r"))'
+needle = 'table_started && line ~ /^[[:space:]]*$/ { exit }'
 assert text.count(needle) == 1
-path.write_text(text.replace(needle, '0', 1))
+path.write_text(text.replace(needle, '0 # MUTATION', 1))
 PYTHON
+  run grep -F '0 # MUTATION' "$copied_manifest"
+  [ "$status" -eq 0 ]
 
-  run bash -c '. "$1"; validate_manifest_v2 "$2"' bash "$copied_manifest" "$plan"
+  # Red proof: without the shared boundary the later agent row satisfies the
+  # exact signature expectation that the production implementation rejects.
+  run bash -c '. "$1"; manifest_has_agent_signature "$2"' bash "$copied_manifest" "$plan"
   [ "$status" -eq 0 ]
 }
 
@@ -2358,6 +2361,19 @@ Approved."
 
   assert_approve_json
   [ ! -f "${REVIEW_COUNTER_DIR}/.dispatch-test-session.json" ]
+}
+
+@test "dispatch cleanup: Tier0 approval removes stale global dispatch state" {
+  local stale_dispatch="${REVIEW_COUNTER_DIR}/.dispatch-abandoned-session.json"
+  printf '%s' '{}' > "$stale_dispatch"
+  touch -t 200001010000 "$stale_dispatch"
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+Approved."
+  INPUT=$(build_input plan="Edit one file and run its test.")
+  run_hook
+
+  assert_ack_approve_json
+  [ ! -e "$stale_dispatch" ]
 }
 
 @test "manifest v2: missing manifest still rejects dispatch keywords" {
@@ -2454,6 +2470,8 @@ Needs work."
   grep -q "registered agent" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
   grep -q "dev-econ" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
   grep -q "worker-econ" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -qF "full hoarding [Critical]" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -qF "partial hoarding [Major]" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
   ! grep -q "Implementation work.*sonnet" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
 }
 
@@ -2477,18 +2495,18 @@ Use Task( for isolation.
   assert_ack_approve_json
 }
 
-@test "manifest v2 parser: multiple blank lines before a Main-only table are tolerated" {
+@test "manifest v2 parser: multiple blank lines before an Agent table are tolerated" {
   create_mock_engine "agy" "<verdict>APPROVE</verdict>
 Approved."
   local plan="## Plan
-Use Task( for isolation.
+Use Task( for isolated work.
 
 ## Dispatch Manifest
 
 
 | step | location | subagent_type | model_source | model | depends_on | parallel_with |
 |------|----------|---------------|--------------|-------|------------|---------------|
-| 1 | main | - | - | - | - | - |"
+| 1 | agent | Explore | runtime | haiku | - | - |"
   INPUT=$(build_input "plan=$plan")
   run_hook
   assert_ack_approve_json
@@ -2509,6 +2527,68 @@ Use Task( for isolation.
   INPUT=$(build_input "plan=$plan")
   run_hook
   assert_ack_approve_json
+}
+
+@test "manifest v2 parser: blank line blocks a later seven-column agent signature" {
+  local plan="## Plan
+Use Task( for isolation.
+
+## Dispatch Manifest
+| step | location | subagent_type | model_source | model | depends_on | parallel_with |
+|------|----------|---------------|--------------|-------|------------|---------------|
+| 1 | main | - | - | - | - | - |
+
+| 2 | agent | Explore | runtime | haiku | - | - |"
+  run bash -c '. "$1"; manifest_has_agent_signature "$2"' bash "${BATS_TEST_DIRNAME}/../scripts/lib/manifest.sh" "$plan"
+  [ "$status" -ne 0 ]
+  run bash -c '. "$1"; parse_manifest_to_json "$2" test-hash' bash "${BATS_TEST_DIRNAME}/../scripts/lib/manifest.sh" "$plan"
+  [ "$status" -eq 0 ]
+  [[ "$(jq -c '.allowed_signatures' <<<"$output")" == '[]' ]]
+  [[ "$(jq -c '.steps' <<<"$output")" == '[{"id":"1","location":"main","subagent_type":null,"model_source":null,"model":null,"depends_on":null,"parallel_with":null}]' ]]
+
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+  assert_deny_json
+  [[ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<<"$HOOK_STDOUT")" == *"DISPATCH HOARDING"* ]]
+  [ ! -e "${REVIEW_COUNTER_DIR}/.dispatch-test-session.json" ]
+}
+
+@test "manifest v2 parser: blank line blocks a later TAB-based agent signature" {
+  local tab=$'\t'
+  local plan="## Plan
+Use Task( for isolation.
+
+## Dispatch Manifest
+| step | location | subagent_type | model_source | model | depends_on | parallel_with |
+|------|----------|---------------|--------------|-------|------------|---------------|
+| 1 | main | - | - | - | - | - |
+
+| 2 | agent | Explore${tab}smuggled | runtime | haiku | - | - |"
+  run bash -c '. "$1"; manifest_has_agent_signature "$2"' bash "${BATS_TEST_DIRNAME}/../scripts/lib/manifest.sh" "$plan"
+  [ "$status" -ne 0 ]
+  run bash -c '. "$1"; parse_manifest_to_json "$2" test-hash' bash "${BATS_TEST_DIRNAME}/../scripts/lib/manifest.sh" "$plan"
+  [ "$status" -eq 0 ]
+  [[ "$(jq -c '.allowed_signatures' <<<"$output")" == '[]' ]]
+
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+  assert_deny_json
+  [[ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<<"$HOOK_STDOUT")" == *"DISPATCH HOARDING"* ]]
+  [ ! -e "${REVIEW_COUNTER_DIR}/.dispatch-test-session.json" ]
+}
+
+@test "manifest v2 parser: terminal CRLF suffix is normalized before table semantics" {
+  local cr=$'\r'
+  local plan="## Plan
+Use Task( for isolation.
+
+## Dispatch Manifest
+| step | location | subagent_type | model_source | model | depends_on | parallel_with |${cr}
+|------|----------|---------------|--------------|-------|------------|---------------|${cr}
+| 1 | agent | Explore | runtime | haiku | - | - |${cr}"
+  run bash -c '. "$1"; parse_manifest_to_json "$2" test-hash' bash "${BATS_TEST_DIRNAME}/../scripts/lib/manifest.sh" "$plan"
+  [ "$status" -eq 0 ]
+  [[ "$(jq -c '.allowed_signatures' <<<"$output")" == '[{"subagent_type":"Explore","model_source":"runtime","model":"haiku"}]' ]]
 }
 
 @test "manifest v2 parser: next section table does not satisfy missing manifest table" {

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -2078,297 +2078,10 @@ LGTM from Gemini."
   assert_log_contains "rest-fallback-triggered"
 }
 
-# =============================================================================
-# Dispatch Manifest — Layer 1 (plan-review.sh)
-# =============================================================================
 
-# 101. plan 含 Task( 关键词 + 无 manifest → deny 不调引擎 + counter 递增
-@test "manifest: plan with Task( keyword + no manifest → pre-flight deny + counter increment" {
-  # No mock engine — pre-flight fires before engine call
-  INPUT=$(build_input plan="Step 1: Use Task( to isolate work. No manifest here.")
-  run_hook
 
-  assert_deny_json
-  local reason
-  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
-  [[ "$reason" == *"MISSING DISPATCH MANIFEST"* ]]
-  # Deny message must embed a self-contained format example (not just "see CLAUDE.md").
-  # Assert tokens that ONLY appear in the embedded example, so the old code can't pass.
-  [[ "$reason" == *"parallel_with"* ]]
-  [[ "$reason" == *"填写规则"* ]]
-  # Counter must be incremented (TOTAL_ROUNDS only, ATTEMPT stays 0)
-  local attempt; attempt=$(get_counter_value)
-  [ "$attempt" -eq 0 ]
-  [ "$(get_total_rounds)" -eq 1 ]
-}
-
-# 102. plan 含 Task( + 完整 manifest → 进入正常引擎审阅路径
-@test "manifest: plan with Task( + Dispatch Manifest → proceeds to engine review" {
-  create_mock_engine "agy" "<verdict>APPROVE</verdict>
-Plan looks good with manifest."
-  local plan_with_manifest="## Plan
-Step 1: Use Task( to run analysis.
-
-## Dispatch Manifest
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | worker    | sonnet| -          | -             |"
-  INPUT=$(build_input "plan=$plan_with_manifest")
-  run_hook
-
-  # Engine was called (ack-deny with APPROVED)
-  assert_ack_approve_json
-}
-
-# 103. plan 不含 Task 关键词 → 不要求 manifest
-@test "manifest: plan without Task/Agent keywords → no manifest required" {
-  create_mock_engine "agy" "<verdict>APPROVE</verdict>
-Simple plan, no dispatch needed."
-  INPUT=$(build_input plan="Simple plan: edit file X, run tests, commit.")
-  run_hook
-
-  # Engine was called normally (no pre-flight block)
-  assert_ack_approve_json
-}
-
-# 104. 大小写变体 "Worker Agent" / "TASK(" → 也触发 needs_manifest
-@test "manifest: case variants 'Worker Agent' and 'TASK(' trigger manifest requirement" {
-  INPUT=$(build_input plan="Use Worker Agent for step 2. Also TASK( for isolation.")
-  run_hook
-
-  assert_deny_json
-  local reason
-  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
-  [[ "$reason" == *"MISSING DISPATCH MANIFEST"* ]]
-}
-
-# 105. APPROVE 路径 + plan 含 manifest → dispatch JSON 写入且 schema 合法
-@test "manifest: APPROVE path + manifest → dispatch JSON written with valid schema" {
-  create_mock_engine "agy" "<verdict>APPROVE</verdict>
-All good."
-  local plan_with_manifest="## Implementation
-Use Task( for isolation.
-
-## Dispatch Manifest
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | -         | -     | -          | -             |
-| 2    | worker    | sonnet| 1          | -             |"
-  INPUT=$(build_input "plan=$plan_with_manifest")
-  run_hook
-
-  assert_ack_approve_json
-  # Dispatch JSON must exist
-  local dispatch_file="${REVIEW_COUNTER_DIR}/.dispatch-test-session.json"
-  [ -f "$dispatch_file" ]
-  # Must be valid JSON with required fields
-  jq -e '.requires_dispatch_check == true' "$dispatch_file" >/dev/null
-  jq -e '.plan_hash | length > 0' "$dispatch_file" >/dev/null
-  jq -e '.steps | length == 2' "$dispatch_file" >/dev/null
-  # Step 2 has agent_type and model
-  jq -e '.steps[1].agent_type == "worker"' "$dispatch_file" >/dev/null
-  jq -e '.steps[1].model == "sonnet"' "$dispatch_file" >/dev/null
-}
-
-# 106. APPROVE 路径 + plan 无 manifest → 不写 dispatch JSON
-@test "manifest: APPROVE path + no manifest → no dispatch JSON written" {
-  create_mock_engine "agy" "<verdict>APPROVE</verdict>
-Simple plan approved."
-  INPUT=$(build_input plan="Simple plan: edit file, run tests.")
-  run_hook_to_completion
-
-  assert_approve_json
-  # Dispatch file must NOT exist
-  [ ! -f "${REVIEW_COUNTER_DIR}/.dispatch-test-session.json" ]
-}
-
-# 107. manifest 行含 stray 引号 → 落地 JSON 仍合法（jq -e 通过）
-@test "manifest: stray quotes in manifest rows → dispatch JSON still valid" {
-  create_mock_engine "agy" "<verdict>APPROVE</verdict>
-LGTM."
-  local plan_with_quoted_manifest='## Task( analysis
-
-## Dispatch Manifest
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | "worker"  | "sonnet" | -       | -             |'
-  INPUT=$(build_input "plan=$plan_with_quoted_manifest")
-  run_hook
-
-  assert_ack_approve_json
-  local dispatch_file="${REVIEW_COUNTER_DIR}/.dispatch-test-session.json"
-  [ -f "$dispatch_file" ]
-  # Must be parseable by jq (no stray quotes in JSON values)
-  jq -e '.' "$dispatch_file" >/dev/null
-  jq -e '.steps[0].agent_type == "worker"' "$dispatch_file" >/dev/null
-  jq -e '.steps[0].model == "sonnet"' "$dispatch_file" >/dev/null
-}
-
-# 108. pre-flight 反复 deny → ATTEMPT 始终 0，不触发非 Critical 安全阀
-@test "manifest: repeated pre-flight denies → ATTEMPT stays 0, only TOTAL increments" {
-  export REVIEW_MAX_ROUNDS=2
-  # No mock engine — pre-flight fires before engine call
-  INPUT=$(build_input plan="Use Task( for analysis.")
-
-  # Round 1: ATTEMPT stays 0, TOTAL→1
-  run_hook
-  assert_deny_json
-  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"MISSING DISPATCH MANIFEST"* ]]
-  [ "$(get_counter_value)" -eq 0 ]
-  [ "$(get_total_rounds)" -eq 1 ]
-
-  # Round 2: ATTEMPT stays 0, TOTAL→2
-  run_hook
-  assert_deny_json
-  [ "$(get_counter_value)" -eq 0 ]
-  [ "$(get_total_rounds)" -eq 2 ]
-
-  # Round 3: ATTEMPT=0 < MAX=2 → valve does NOT fire, pre-flight deny again
-  run_hook
-  assert_deny_json
-  [ "$(get_counter_value)" -eq 0 ]
-  [ "$(get_total_rounds)" -eq 3 ]
-}
-
-# 109. APPROVE 写入 dispatch 前清理 stale 文件
-@test "manifest: APPROVE path cleans up stale dispatch files" {
-  create_mock_engine "agy" "<verdict>APPROVE</verdict>
-Good."
-  local plan_with_manifest="## Task( work
-
-## Dispatch Manifest
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | worker    | haiku | -          | -             |"
-
-  # Pre-plant a stale dispatch file (mtime >30min ago via touch -t)
-  local stale_file="${REVIEW_COUNTER_DIR}/.dispatch-other-session.json"
-  printf '{"stale":true}' > "$stale_file"
-  # Backdate by 35 minutes (2100 seconds)
-  touch -t "$(date -v -35M +%Y%m%d%H%M 2>/dev/null || date -d '35 minutes ago' +%Y%m%d%H%M 2>/dev/null || date +%Y%m%d%H%M)" "$stale_file" 2>/dev/null || \
-    python3 -c "import os,time; os.utime('$stale_file', (time.time()-2100, time.time()-2100))" 2>/dev/null || true
-
-  INPUT=$(build_input "plan=$plan_with_manifest")
-  run_hook
-
-  assert_ack_approve_json
-  # Stale file must be cleaned up
-  [ ! -f "$stale_file" ]
-}
-
-# 110. plan 含 dispatch 关键词 + manifest 全 "-" → degenerate deny + counter increment
-@test "manifest: all-dash manifest → pre-flight degenerate deny + counter increment" {
-  local plan_all_dash="## Plan
-Step 1: Use Task( for analysis.
-
-## Dispatch Manifest
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | -         | -     | -          | -             |
-| 2    | -         | -     | 1          | -             |"
-  INPUT=$(build_input "plan=$plan_all_dash")
-  run_hook
-
-  assert_deny_json
-  local reason
-  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
-  [[ "$reason" == *"DEGENERATE DISPATCH MANIFEST"* ]]
-  # Deny message must embed the self-contained format example.
-  [[ "$reason" == *"parallel_with"* ]]
-  [[ "$reason" == *"填写规则"* ]]
-  local attempt; attempt=$(get_counter_value)
-  [ "$attempt" -eq 0 ]
-  [ "$(get_total_rounds)" -eq 1 ]
-}
-
-# 111. mixed manifest (dash + real agent) → passes pre-flight (non-regression)
-@test "manifest: mixed manifest with real agent_type → passes pre-flight to engine" {
-  create_mock_engine "agy" "<verdict>APPROVE</verdict>
-All good."
-  local plan_mixed="## Plan
-Step 1: Prepare context. Step 2: Use Task( for heavy lifting.
-
-## Dispatch Manifest
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | -         | -     | -          | -             |
-| 2    | worker    | sonnet| 1          | -             |"
-  INPUT=$(build_input "plan=$plan_mixed")
-  run_hook
-
-  assert_ack_approve_json
-}
-
-# 112. all-dash repeated → ATTEMPT stays 0, only TOTAL increments
-@test "manifest: repeated degenerate denies → ATTEMPT stays 0, only TOTAL increments" {
-  export REVIEW_MAX_ROUNDS=2
-  local plan_all_dash="## Plan
-Use Task( for work.
-
-## Dispatch Manifest
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | -         | -     | -          | -             |"
-  INPUT=$(build_input "plan=$plan_all_dash")
-
-  # Round 1: degenerate deny, ATTEMPT stays 0, TOTAL→1
-  run_hook
-  assert_deny_json
-  [ "$(get_counter_value)" -eq 0 ]
-  [ "$(get_total_rounds)" -eq 1 ]
-
-  # Round 2: degenerate deny, ATTEMPT stays 0, TOTAL→2
-  run_hook
-  assert_deny_json
-  [ "$(get_counter_value)" -eq 0 ]
-  [ "$(get_total_rounds)" -eq 2 ]
-
-  # Round 3: ATTEMPT=0 < MAX=2 → valve does NOT fire, degenerate deny again
-  run_hook
-  assert_deny_json
-  [ "$(get_counter_value)" -eq 0 ]
-  [ "$(get_total_rounds)" -eq 3 ]
-}
-
-# 113. empty manifest (header + separator only, 0 data rows) → degenerate deny
-@test "manifest: empty manifest section (no data rows) → degenerate deny" {
-  local plan_empty_manifest="## Plan
-Step 1: Use Task( for isolation.
-
-## Dispatch Manifest
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-
-## Next Section"
-  INPUT=$(build_input "plan=$plan_empty_manifest")
-  run_hook
-
-  assert_deny_json
-  local reason
-  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
-  [[ "$reason" == *"DEGENERATE DISPATCH MANIFEST"* ]]
-}
-
-# 114. agent_type="worker" + model="-" → NOT blocked (only agent_type checked)
-@test "manifest: real agent_type with dash model → passes pre-flight" {
-  create_mock_engine "agy" "<verdict>APPROVE</verdict>
-OK."
-  local plan_agent_no_model="## Plan
-Use Task( for analysis.
-
-## Dispatch Manifest
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | worker    | -     | -          | -             |"
-  INPUT=$(build_input "plan=$plan_agent_no_model")
-  run_hook
-
-  assert_ack_approve_json
-}
-
-# 100. Capacity-fast-break → degrade file already written; REST entry does not overwrite
-#      (double-write is harmless: timestamps differ by <1s, both numeric, TTL still valid)
-@test "degrade: capacity-fast-break + REST success → degrade file refreshed (double-write harmless)" {
+# 100. Capacity-fast-break plus REST success refreshes the degraded state.
+@test "degrade: capacity-fast-break + REST success → degrade file refreshed" {
   create_capacity_exhausted_engine "agy"
   export REVIEW_API_URL="http://localhost:9999"
   export REVIEW_API_KEY="test-key"
@@ -2377,13 +2090,11 @@ Use Task( for analysis.
 
   run_hook
   assert_ack_approve_json
-
-  # Degrade file exists with a valid timestamp (may be written once or twice — both ok)
   assert_degraded_file_written
-  local ts; ts=$(cat "${REVIEW_COUNTER_DIR}/.gemini-degraded")
-  local now; now=$(date +%s)
-  local age=$(( now - ts ))
-  # Timestamp must be recent (within 10s): proves at least one write succeeded
+  local timestamp now age
+  timestamp=$(cat "${REVIEW_COUNTER_DIR}/.gemini-degraded")
+  now=$(date +%s)
+  age=$(( now - timestamp ))
   (( age < 10 )) || { echo "degrade timestamp too old: age=${age}s"; return 1; }
   assert_log_contains "gemini-degrade-write"
 
@@ -2391,18 +2102,319 @@ Use Task( for analysis.
   assert_approve_json
 }
 
-# ---------------------------------------------------------------------------
-# Prompt content integrity
-# ---------------------------------------------------------------------------
-@test "system-instructions: Testability criterion has structured sub-items" {
-  grep -q "Test strategy presence" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
-  grep -q "E2E selector cascade" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
-  grep -q "evidence-gated" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
-  grep -q "Deletion completeness" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
-  grep -q "3000 characters" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+# =============================================================================
+# Dispatch Manifest v2 — Layer 1 (plan-review.sh)
+# =============================================================================
+
+manifest_v2_plan() {
+  local rows="$1"
+  printf '%s\n' "## Plan
+Use Task( for isolated work.
+
+## Dispatch Manifest
+| step | location | subagent_type | model_source | model | depends_on | parallel_with |
+|------|----------|---------------|--------------|-------|------------|---------------|
+${rows}"
 }
 
-@test "system-instructions: Version Identifiers Are Ground Truth has training-cutoff / version-identifier ground-truth directive" {
+@test "manifest v2: Main, preset, and runtime rows pass pre-flight" {
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+Approved."
+  local plan
+  plan=$(manifest_v2_plan '| 1 | main  | -        | -       | -     | - | - |
+| 2 | agent | dev-econ | preset  | -     | 1 | - |
+| 3 | agent | Explore  | runtime | haiku | 1 | 2 |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_ack_approve_json
+}
+
+@test "manifest v2: Main-only row is structurally valid" {
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+Approved."
+  local plan
+  plan=$(manifest_v2_plan '| 1 | main | - | - | - | - | - |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_ack_approve_json
+}
+
+@test "manifest v2: preset-only row is structurally valid" {
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+Approved."
+  local plan
+  plan=$(manifest_v2_plan '| 1 | agent | dev-econ | preset | - | - | - |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_ack_approve_json
+}
+
+@test "manifest v2: runtime-only row is structurally valid" {
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+Approved."
+  local plan
+  plan=$(manifest_v2_plan '| 1 | agent | Explore | runtime | haiku | - | - |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_ack_approve_json
+}
+
+@test "manifest v2: Main row rejects subagent fields" {
+  local plan
+  plan=$(manifest_v2_plan '| 1 | main | dev-econ | - | - | - | - |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"INVALID DISPATCH MANIFEST"* ]]
+}
+
+@test "manifest v2: preset row requires type and forbids model" {
+  local plan
+  plan=$(manifest_v2_plan '| 1 | agent | - | preset | - | - | - |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+  assert_deny_json
+
+  plan=$(manifest_v2_plan '| 1 | agent | dev-econ | preset | haiku | - | - |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+  assert_deny_json
+}
+
+@test "manifest v2: runtime row requires type and model" {
+  local plan
+  plan=$(manifest_v2_plan '| 1 | agent | Explore | runtime | - | - | - |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"INVALID DISPATCH MANIFEST"* ]]
+}
+
+@test "manifest v2: agent row rejects an unknown model_source" {
+  local plan
+  plan=$(manifest_v2_plan '| 1 | agent | Explore | inherited | - | - | - |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"INVALID DISPATCH MANIFEST"* ]]
+}
+
+@test "manifest v2: wrong or missing columns reject before review" {
+  local plan='## Plan
+Use Task( for isolation.
+
+## Dispatch Manifest
+| step | location | subagent_type | model_source | model | depends_on |
+|------|----------|---------------|--------------|-------|------------|
+| 1 | main | - | - | - | - |'
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"INVALID DISPATCH MANIFEST"* ]]
+}
+
+@test "manifest v2: APPROVE writes schema v2 signatures and dependency columns" {
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+Approved."
+  local plan
+  plan=$(manifest_v2_plan '| 1 | main  | -        | -       | -     | - | - |
+| 2 | agent | dev-econ | preset  | -     | 1 | - |
+| 3 | agent | Explore  | runtime | haiku | 1 | 2 |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_ack_approve_json
+  local dispatch_file="${REVIEW_COUNTER_DIR}/.dispatch-test-session.json"
+  [ -f "$dispatch_file" ]
+  jq -e '.schema_version == 2' "$dispatch_file" >/dev/null
+  jq -e '.allowed_signatures == [{"subagent_type":"dev-econ","model_source":"preset"},{"subagent_type":"Explore","model_source":"runtime","model":"haiku"}]' "$dispatch_file" >/dev/null
+  jq -e '.steps[2].depends_on == "1" and .steps[2].parallel_with == "2"' "$dispatch_file" >/dev/null
+}
+
+
+
+@test "manifest v2: quote and backslash cells serialize to valid JSON" {
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+Approved."
+  local plan
+  plan=$(manifest_v2_plan '| 1 | agent | dev"econ\preset | preset | - | - | - |
+| 2 | agent | Explore | runtime | haiku"tier\2 | - | - |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_ack_approve_json
+  local dispatch_file="${REVIEW_COUNTER_DIR}/.dispatch-test-session.json"
+  jq -e . "$dispatch_file" >/dev/null
+  jq -e '.steps[0].subagent_type == "dev\"econ\\preset"' "$dispatch_file" >/dev/null
+  jq -e '.steps[1].model == "haiku\"tier\\2"' "$dispatch_file" >/dev/null
+}
+
+
+
+@test "manifest v2: literal TAB in subagent_type rejects before state creation" {
+  local tab=$'\t'
+  local plan
+  plan=$(manifest_v2_plan "| 1 | agent | Explore${tab}smuggled | runtime | haiku | - | - |")
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"tab or carriage-return"* ]]
+  [ ! -e "${REVIEW_COUNTER_DIR}/.dispatch-test-session.json" ]
+}
+
+@test "manifest v2: literal TAB in model rejects before state creation" {
+  local tab=$'\t'
+  local plan
+  plan=$(manifest_v2_plan "| 1 | agent | Explore | runtime | hai${tab}ku | - | - |")
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"tab or carriage-return"* ]]
+  [ ! -e "${REVIEW_COUNTER_DIR}/.dispatch-test-session.json" ]
+}
+
+
+@test "manifest v2: literal carriage-return in dependency rejects before state creation" {
+  local carriage_return=$'\r'
+  local plan
+  plan=$(manifest_v2_plan "| 1 | agent | Explore | runtime | haiku | dependency${carriage_return}tail | - |")
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"tab or carriage-return"* ]]
+  [ ! -e "${REVIEW_COUNTER_DIR}/.dispatch-test-session.json" ]
+}
+
+@test "manifest v2: failed serializer leaves no temporary or destination state" {
+  setup_script_copy
+  local copied_manifest="${COPY_SCRIPT_DIR}/lib/manifest.sh"
+  python3 - "$copied_manifest" <<'PYTHON'
+from pathlib import Path
+path = Path(__import__('sys').argv[1])
+text = path.read_text()
+needle = '  validate_manifest_v2 "$plan" || return 1\n'
+assert text.count(needle) == 1
+path.write_text(text.replace(needle, '  return 1\n', 1))
+PYTHON
+
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+Approved."
+  local plan
+  plan=$(manifest_v2_plan '| 1 | agent | Explore | runtime | haiku | - | - |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook_copy
+
+  assert_ack_approve_json
+  [ ! -e "${REVIEW_COUNTER_DIR}/.dispatch-test-session.json" ]
+  ! find "$REVIEW_COUNTER_DIR" -maxdepth 1 -name '.dispatch-test-session.*' -print -quit | grep -q .
+}
+
+@test "mutation: control-separator guard has one executable hit" {
+  local tab=$'\t'
+  local plan
+  plan=$(manifest_v2_plan "| 1 | agent | Explore${tab}smuggled | runtime | haiku | - | - |")
+
+  # The production validator rejects the tab before serializer framing begins.
+  run bash -c '. "$1"; validate_manifest_v2 "$2"' bash "${BATS_TEST_DIRNAME}/../scripts/lib/manifest.sh" "$plan"
+  [ "$status" -ne 0 ]
+
+  setup_script_copy
+  local copied_manifest="${COPY_SCRIPT_DIR}/lib/manifest.sh"
+  local mutation_count
+  mutation_count=$(grep -cF 'index($0, "\t") || index($0, "\r")' "$copied_manifest")
+  [ "$mutation_count" -eq 1 ] || {
+    echo "expected one control-separator guard, found $mutation_count"
+    return 1
+  }
+  python3 - "$copied_manifest" <<'PYTHON'
+from pathlib import Path
+path = Path(__import__('sys').argv[1])
+text = path.read_text()
+needle = 'header_seen && (index($0, "\\t") || index($0, "\\r"))'
+assert text.count(needle) == 1
+path.write_text(text.replace(needle, '0', 1))
+PYTHON
+
+  run bash -c '. "$1"; validate_manifest_v2 "$2"' bash "$copied_manifest" "$plan"
+  [ "$status" -eq 0 ]
+}
+
+@test "manifest v2: no manifest remains optional without dispatch keywords" {
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+Approved."
+  INPUT=$(build_input plan="Edit one file and run its test.")
+  run_hook_to_completion
+
+  assert_approve_json
+  [ ! -f "${REVIEW_COUNTER_DIR}/.dispatch-test-session.json" ]
+}
+
+@test "manifest v2: missing manifest still rejects dispatch keywords" {
+  INPUT=$(build_input plan="Use Task( for isolation.")
+  run_hook
+
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"MISSING DISPATCH MANIFEST"* ]]
+}
+
+
+
+# Pre-flight corrections consume only TOTAL_ROUNDS, never the non-Critical
+# ATTEMPT budget. These are control-flow regressions independent of v1 schema.
+@test "manifest v2: repeated pre-flight denies keep ATTEMPT at zero" {
+  export REVIEW_MAX_ROUNDS=2
+  INPUT=$(build_input plan="Use Task( for analysis.")
+
+  run_hook; assert_deny_json; [ "$(get_counter_value)" -eq 0 ]; [ "$(get_total_rounds)" -eq 1 ]
+  run_hook; assert_deny_json; [ "$(get_counter_value)" -eq 0 ]; [ "$(get_total_rounds)" -eq 2 ]
+  run_hook; assert_deny_json; [ "$(get_counter_value)" -eq 0 ]; [ "$(get_total_rounds)" -eq 3 ]
+}
+
+@test "manifest v2: correcting pre-flight error starts engine from prior ATTEMPT" {
+  INPUT=$(build_input plan="Use Task( for analysis.")
+  run_hook
+  assert_deny_json
+  [ "$(get_counter_value)" -eq 0 ]
+  [ "$(get_total_rounds)" -eq 1 ]
+
+  create_mock_engine "agy" "<verdict>CONCERNS</verdict>
+Needs work."
+  local plan
+  plan=$(manifest_v2_plan '| 1 | agent | Explore | runtime | haiku | - | - |')
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_deny_json
+  [ "$(get_counter_value)" -eq 1 ]
+  [ "$(get_total_rounds)" -eq 2 ]
+}
+
+@test "manifest v2: repeated pre-flight denies reach the TOTAL hard stop" {
+  export REVIEW_MAX_TOTAL_ROUNDS=3
+  INPUT=$(build_input plan="Use Task( for analysis.")
+
+  run_hook; assert_deny_json; [ "$(get_total_rounds)" -eq 1 ]
+  run_hook; assert_deny_json; [ "$(get_total_rounds)" -eq 2 ]
+  run_hook; assert_deny_json; [ "$(get_total_rounds)" -eq 3 ]
+  run_hook
+  assert_deny_json
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"HARD STOP"* ]]
+}
+
+# Static contracts in the generic prompt must remain present even though the
+# Manifest v2 criteria live in the plan-specific prompt.
+@test "system-instructions: Version Identifiers Are Ground Truth remains explicit" {
   grep -q "GROUND TRUTH" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
   grep -q "verify against your memory" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
   grep -q "training knowledge has a cutoff" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
@@ -2410,242 +2422,110 @@ Use Task( for analysis.
   grep -q "never Critical" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
 }
 
-# ---------------------------------------------------------------------------
-# Finding Quality Gate (issue #30) — prompt-layer denoising directives.
-# These are static prompt-content assertions: the gate operates inside the
-# review engine (LLM self-check), so it cannot be exercised at runtime here.
-# We assert the four gap-closing directives are present in SYSTEM_INSTRUCTIONS.
-# ---------------------------------------------------------------------------
-@test "system-instructions: Finding Quality Gate section present" {
+@test "system-instructions: Finding Quality Gate contract remains complete" {
   grep -q "Finding Quality Gate" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
-}
-
-@test "quality-gate: gap1 confidence threshold + drop-low-confidence directive" {
   grep -q "Confidence" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
   grep -q "DROP" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
-}
-
-@test "quality-gate: gap1 gradient exit — low-confidence Critical kept as UNVERIFIED, not dropped" {
   grep -q "UNVERIFIED" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
   grep -q "not REJECT" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
-}
-
-@test "quality-gate: gap2 false-positive registry present" {
   grep -q "False-positive registry" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
   grep -qi "never raise" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
-}
-
-@test "quality-gate: gap3 verdict-severity pre-flight self-check (prompt-layer, not body-scan)" {
   grep -q "Verdict↔severity" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
-  # Routing must remain verdict-only: the hook must NOT grep the body for severity tags
+  grep -q "Severity calibration" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
+  grep -q "never Major" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
+  grep -q 'UNVERIFIED.*suspicion.*but no confirmed Critical\|including any .UNVERIFIED' "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
+  grep -q '\[Major\] \[UNVERIFIED\]' "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
   ! grep -qE "grep[^|]*'\[Critical\]'" "${HOOK_SCRIPT:?Missing hook script}"
 }
 
-@test "quality-gate: gap4 severity calibration anti-drift" {
-  grep -q "Severity calibration" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
-  grep -q "never Major" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
-}
-
-@test "quality-gate: UNVERIFIED routes to CONCERNS in verdict rules + output format" {
-  # CONCERNS bucket explicitly includes UNVERIFIED suspicions
-  grep -q "UNVERIFIED.*suspicion.*but no confirmed Critical\|including any .UNVERIFIED" "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
-  # output format documents the [Major] [UNVERIFIED] emission shape
-  grep -q '\[Major\] \[UNVERIFIED\]' "${SYSTEM_PROMPT_COMMON_FILE:?Missing system prompt asset}"
-}
-
 # =============================================================================
-# Dispatch Economy — Criterion 7 regression (v1.0.44 → v1.0.45)
-# Asserts: (1) bash syntax still valid after heredoc refactor,
-#          (2) new Criterion 7 token set is present in SYSTEM_INSTRUCTIONS,
-#          (3) manifest detection path still passes through to engine (non-regression).
+# Dispatch Economy — Criterion 7 regression
 # =============================================================================
 
-# 115. bash syntax check — quoted heredoc must have matching delimiters.
-# Covers the main hook script AND every lib/*.sh it sources (post-split):
-# a syntax error confined to a lib file would otherwise slip past this gate.
-@test "dispatch-economy: bash -n reports no syntax errors after heredoc refactor" {
+@test "dispatch-economy: bash -n reports no syntax errors" {
   while IFS= read -r -d '' f; do
     run bash -n "$f"
     [ "$status" -eq 0 ] || { echo "syntax error in $f: $output"; return 1; }
   done < <(find "${BATS_TEST_DIRNAME}/../scripts" -name '*.sh' -print0)
 }
 
-# 116. Criterion 7 token presence — new prompt content has not been reverted
-@test "dispatch-economy: Criterion 7 tokens present in SYSTEM_INSTRUCTIONS" {
-  grep -q "Dispatch Economy"      "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
-  grep -q "Full hoarding"         "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
-  grep -q "Partial hoarding"      "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
-  grep -q "Retrieval work"        "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
-  grep -q "split-brain"           "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
-  grep -q "Decision work"         "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
-  grep -q "Implementation work"   "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+@test "dispatch-economy: Criterion 7 states ownership and source rules" {
+  grep -q "Decision and review judgment" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "registered agent" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "dev-econ" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  grep -q "worker-econ" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
+  ! grep -q "Implementation work.*sonnet" "${SYSTEM_PROMPT_PLAN_FILE:?Missing system prompt asset}"
 }
 
-# 117. manifest detection survives prompt refactor — Task( + manifest reaches engine
-# Non-regression: same scenario as test 102, re-asserted post-heredoc-refactor.
-@test "dispatch-economy: Task( + Dispatch Manifest still proceeds to engine review after refactor" {
+
+
+# Manifest parser boundaries: blanks before the table are tolerated; a blank
+# after it and a following section are both hard boundaries.
+@test "manifest v2 parser: one blank line before table is tolerated" {
   create_mock_engine "agy" "<verdict>APPROVE</verdict>
-Dispatch Economy verified."
-  local plan_with_manifest="## Plan
-Step 1: Use Task( for isolation.
-
-## Dispatch Manifest
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | worker    | sonnet| -          | -             |"
-  INPUT=$(build_input "plan=$plan_with_manifest")
-  run_hook
-
-  assert_ack_approve_json
-}
-
-# --- Bug #44: blank-line tolerance in manifest parsing ---
-
-# 118. blank line between heading and table → manifest still parsed
-@test "manifest: blank line between heading and table → passes pre-flight" {
-  create_mock_engine "agy" "<verdict>APPROVE</verdict>
-All good."
-  local plan_blank="## Plan
-Step 1: Use Task( for isolation.
-
-## Dispatch Manifest
-
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | worker    | sonnet| -          | -             |"
-  INPUT=$(build_input "plan=$plan_blank")
-  run_hook
-
-  assert_ack_approve_json
-}
-
-# 119. blank line before all-dash table → degenerate deny (not false pass)
-@test "manifest: blank line before all-dash table → degenerate deny" {
-  local plan_blank_dash="## Plan
-Step 1: Use Task( for work.
-
-## Dispatch Manifest
-
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | -         | -     | -          | -             |"
-  INPUT=$(build_input "plan=$plan_blank_dash")
-  run_hook
-
-  assert_deny_json
-  local reason
-  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
-  [[ "$reason" == *"DEGENERATE DISPATCH MANIFEST"* ]]
-}
-
-# 120. multiple blank lines between heading and table → still parsed
-@test "manifest: multiple blank lines between heading and table → passes pre-flight" {
-  create_mock_engine "agy" "<verdict>APPROVE</verdict>
-OK."
-  local plan_multi="## Plan
-Use Task( for work.
-
-## Dispatch Manifest
-
-
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | worker    | haiku | -          | -             |"
-  INPUT=$(build_input "plan=$plan_multi")
-  run_hook
-
-  assert_ack_approve_json
-}
-
-# 121. blank line AFTER table terminates parsing (existing behavior preserved)
-@test "manifest: blank line after table terminates block" {
-  create_mock_engine "agy" "<verdict>APPROVE</verdict>
-Good."
-  local plan_trail="## Plan
+Approved."
+  local plan="## Plan
 Use Task( for isolation.
 
 ## Dispatch Manifest
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | worker    | sonnet| -          | -             |
 
-Some trailing content."
-  INPUT=$(build_input "plan=$plan_trail")
+| step | location | subagent_type | model_source | model | depends_on | parallel_with |
+|------|----------|---------------|--------------|-------|------------|---------------|
+| 1 | agent | Explore | runtime | haiku | - | - |"
+  INPUT=$(build_input "plan=$plan")
   run_hook
-
   assert_ack_approve_json
 }
 
-# 122. manifest heading with no table + next section has table → no bleeding
-@test "manifest: heading with no table + next section has table → chapter boundary stops parsing" {
-  local plan_no_table="## Plan
-Use Task( for analysis.
+@test "manifest v2 parser: multiple blank lines before a Main-only table are tolerated" {
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+Approved."
+  local plan="## Plan
+Use Task( for isolation.
+
+## Dispatch Manifest
+
+
+| step | location | subagent_type | model_source | model | depends_on | parallel_with |
+|------|----------|---------------|--------------|-------|------------|---------------|
+| 1 | main | - | - | - | - | - |"
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+  assert_ack_approve_json
+}
+
+@test "manifest v2 parser: blank line after table terminates parsing" {
+  create_mock_engine "agy" "<verdict>APPROVE</verdict>
+Approved."
+  local plan="## Plan
+Use Task( for isolation.
+
+## Dispatch Manifest
+| step | location | subagent_type | model_source | model | depends_on | parallel_with |
+|------|----------|---------------|--------------|-------|------------|---------------|
+| 1 | agent | Explore | runtime | haiku | - | - |
+
+| this trailing table is not manifest content |"
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+  assert_ack_approve_json
+}
+
+@test "manifest v2 parser: next section table does not satisfy missing manifest table" {
+  local plan="## Plan
+Use Task( for isolation.
 
 ## Dispatch Manifest
 
 ## Other Section
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | worker    | sonnet| -          | -             |"
-  INPUT=$(build_input "plan=$plan_no_table")
+| step | location | subagent_type | model_source | model | depends_on | parallel_with |
+|------|----------|---------------|--------------|-------|------------|---------------|
+| 1 | agent | Explore | runtime | haiku | - | - |"
+  INPUT=$(build_input "plan=$plan")
   run_hook
 
-  # Must deny as MISSING (manifest heading present but no table before next ##)
-  # Actually has_manifest matches heading, manifest_has_real_agent finds nothing → DEGENERATE
   assert_deny_json
-  local reason
-  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
-  [[ "$reason" == *"DEGENERATE DISPATCH MANIFEST"* ]]
-}
-
-# --- Bug #71: pre-flight deny NOT consuming ATTEMPT budget ---
-
-# 123. pre-flight deny then fix → engine review starts ATTEMPT from 0
-@test "manifest: pre-flight deny then fix → engine review starts ATTEMPT from 0" {
-  export REVIEW_MAX_ROUNDS=2
-  INPUT=$(build_input plan="Use Task( for analysis.")
-
-  # Pre-flight deny: ATTEMPT stays 0, TOTAL→1
-  run_hook
-  assert_deny_json
-  [ "$(get_counter_value)" -eq 0 ]
-  [ "$(get_total_rounds)" -eq 1 ]
-
-  # User fixes manifest, engine gives CONCERNS
-  create_mock_engine "agy" "<verdict>CONCERNS</verdict>
-Issues found."
-  local fixed_plan="## Plan
-Use Task( for analysis.
-
-## Dispatch Manifest
-| step | agent_type | model | depends_on | parallel_with |
-|------|-----------|-------|------------|---------------|
-| 1    | worker    | sonnet| -          | -             |"
-  INPUT=$(build_input "plan=$fixed_plan")
-  run_hook
-
-  # Engine CONCERNS: ATTEMPT→1, TOTAL→2
-  assert_deny_json
-  [ "$(get_counter_value)" -eq 1 ]
-  [ "$(get_total_rounds)" -eq 2 ]
-}
-
-# 124. pre-flight denies hit global safety valve at TOTAL_ROUNDS limit
-@test "manifest: pre-flight denies hit global safety valve at TOTAL_ROUNDS limit" {
-  export REVIEW_MAX_TOTAL_ROUNDS=3
-  INPUT=$(build_input plan="Use Task( for analysis.")
-
-  # 3 pre-flight denies → TOTAL reaches 3
-  run_hook; assert_deny_json; [ "$(get_total_rounds)" -eq 1 ]
-  run_hook; assert_deny_json; [ "$(get_total_rounds)" -eq 2 ]
-  run_hook; assert_deny_json; [ "$(get_total_rounds)" -eq 3 ]
-
-  # Next call: TOTAL=3 >= MAX_TOTAL=3 → global safety valve (HARD STOP deny)
-  run_hook
-  assert_deny_json
-  local reason
-  reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
-  [[ "$reason" == *"HARD STOP"* ]]
+  [[ "$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')" == *"INVALID DISPATCH MANIFEST"* ]]
 }
 
 # =============================================================================

--- a/plugins/plan-review/tests/plan-review.bats
+++ b/plugins/plan-review/tests/plan-review.bats
@@ -197,6 +197,7 @@ teardown() {
   local reason
   reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
   [[ "$reason" == *"非法"* ]]
+  [[ "$reason" == *"框架许可的 plan 目录"* ]]
   # Message must name the offending path so the user knows what was rejected.
   [[ "$reason" == *"passwd"* ]]
 }
@@ -2140,7 +2141,7 @@ Approved."
   local reason
   reason=$(echo "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
   [[ "$reason" == *"DISPATCH HOARDING"* ]]
-  [[ "$reason" == *"移除不再需要的调度关键词"* ]]
+  [[ "$reason" == *"必须同时移除 Manifest 与全部调度关键词"* ]]
   [[ "$reason" == *"显式声明至少一个 Agent step"* ]]
 }
 
@@ -2334,17 +2335,19 @@ Approved."
 
   setup_script_copy
   local copied_manifest="${COPY_SCRIPT_DIR}/lib/manifest.sh"
-  run grep -F 'table_started && line ~ /^[[:space:]]*$/ { exit }' "$copied_manifest"
-  [ "$status" -eq 0 ]
   python3 - "$copied_manifest" <<'PYTHON'
 from pathlib import Path
 path = Path(__import__('sys').argv[1])
 text = path.read_text()
-needle = 'table_started && line ~ /^[[:space:]]*$/ { exit }'
-assert text.count(needle) == 1
-path.write_text(text.replace(needle, '0 # MUTATION', 1))
+needle = '''if [ "$table_started" -eq 1 ] && [[ "$line" =~ ^[[:space:]]*$ ]]; then
+      break
+    fi'''
+assert text.count(needle) == 1, text.count(needle)
+path.write_text(text.replace(needle, '''if [ "$table_started" -eq 1 ] && [[ "$line" =~ ^[[:space:]]*$ ]]; then
+      : # MUTATION
+    fi''', 1))
 PYTHON
-  run grep -F '0 # MUTATION' "$copied_manifest"
+  run grep -F ': # MUTATION' "$copied_manifest"
   [ "$status" -eq 0 ]
 
   # Red proof: without the shared boundary the later agent row satisfies the
@@ -2587,6 +2590,54 @@ Use Task( for isolation.
 |------|----------|---------------|--------------|-------|------------|---------------|${cr}
 | 1 | agent | Explore | runtime | haiku | - | - |${cr}"
   run bash -c '. "$1"; parse_manifest_to_json "$2" test-hash' bash "${BATS_TEST_DIRNAME}/../scripts/lib/manifest.sh" "$plan"
+  [ "$status" -eq 0 ]
+  [[ "$(jq -c '.allowed_signatures' <<<"$output")" == '[{"subagent_type":"Explore","model_source":"runtime","model":"haiku"}]' ]]
+}
+
+@test "manifest v2 parser: Markdown alignment separator variants validate" {
+  local plan="## Plan
+Use Task( for isolation.
+
+## Dispatch Manifest
+| step | location | subagent_type | model_source | model | depends_on | parallel_with |
+| :--- | :---: | ---: | :--- | :---: | ---: | :--- |
+| 1 | agent | Explore | runtime | haiku | - | - |"
+  run bash -c '. "$1"; validate_manifest_v2 "$2" && manifest_has_agent_signature "$2" && parse_manifest_to_json "$2" test-hash' bash "${BATS_TEST_DIRNAME}/../scripts/lib/manifest.sh" "$plan"
+
+  [ "$status" -eq 0 ]
+  [[ "$(jq -c '.allowed_signatures' <<<"$output")" == '[{"subagent_type":"Explore","model_source":"runtime","model":"haiku"}]' ]]
+}
+
+@test "manifest v2 parser: malformed later separator cell rejects" {
+  local plan="## Plan
+Use Task( for isolation.
+
+## Dispatch Manifest
+| step | location | subagent_type | model_source | model | depends_on | parallel_with |
+|------|garbage|---------------|--------------|-------|------------|---------------|
+| 1 | agent | Explore | runtime | haiku | - | - |"
+  INPUT=$(build_input "plan=$plan")
+  run_hook
+
+  assert_deny_json
+  [[ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<<"$HOOK_STDOUT")" == *"table separator must have seven Markdown separator cells"* ]]
+}
+
+@test "manifest v2 parser: over-64KB valid plan validates, detects signature, and serializes" {
+  local padding
+  padding=$(head -c 70000 < /dev/zero | tr '\\0' x)
+  local plan="## Plan
+Use Task( for isolation.
+
+## Dispatch Manifest
+| step | location | subagent_type | model_source | model | depends_on | parallel_with |
+|------|----------|---------------|--------------|-------|------------|---------------|
+| 1 | agent | Explore | runtime | haiku | - | - |
+
+## Detail
+${padding}"
+  run bash -c '. "$1"; validate_manifest_v2 "$2" && manifest_has_agent_signature "$2" && parse_manifest_to_json "$2" test-hash' bash "${BATS_TEST_DIRNAME}/../scripts/lib/manifest.sh" "$plan"
+
   [ "$status" -eq 0 ]
   [[ "$(jq -c '.allowed_signatures' <<<"$output")" == '[{"subagent_type":"Explore","model_source":"runtime","model":"haiku"}]' ]]
 }


### PR DESCRIPTION
## Summary

- add a single model-ownership contract: runtime models for built-in agents, frontmatter presets for registered agents
- scope capability Judgment C to runtime-owned agents and close missing/null type bypasses
- upgrade plan-review to Manifest v2 preset/runtime signatures with shared writer/consumer state validation
- preserve preflight counters, degradation handling, prompt quality contracts, and parser boundary coverage

## Verification

- dispatch-contract Bats: 190/190 passed
- plan-review Bats: 282/282 passed
- mutation tests verify ownership, signature matching, and control-separator guards are load-bearing
- three adversarial review rounds converged to APPROVED
- shell syntax, JSON validity, version metadata, and diff whitespace checks passed

Closes #204
